### PR TITLE
Add argon2id as a password hashing algorithm

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,6 @@
 ---
 MD004:
   style: "consistent"
+
+MD024:
+  siblings_only: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Support for Argon2id as a new and more secure alternative to the existing
+  PBKDF2 password hashing algorithm.
+
 ### Removed
 
 - `initial_account` has been removed since it should be defined by the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.3.0-alpha.2"
+version = "0.3.0-alpha.3"
 edition = "2021"
 
 [dependencies]

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 /// current version. When the database format changes, this requirement must be
 /// updated to match the new version, and the migration code must be added to
 /// the `migrate_data_dir` function.
-const DATABASE_VERSION_REQ: &str = ">0.3.0-alpha.1,<=0.3.0-alpha.2";
+const DATABASE_VERSION_REQ: &str = ">0.3.0-alpha.1,<=0.3.0-alpha.3";
 
 /// Migrates the data directory to the up-to-date format if necessary.
 ///
@@ -185,5 +185,9 @@ mod tests {
         // The current version must match the version requirement.
         let version = Version::parse(env!("CARGO_PKG_VERSION")).expect("valid semver");
         assert!(version_req.matches(&version));
+
+        // An incompatible version must not match the version requirement.
+        let version = Version::parse("0.2.0").expect("valid semver");
+        assert!(!version_req.matches(&version));
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -43,6 +43,7 @@ where
 pub enum PasswordHashAlgorithm {
     #[default]
     Pbkdf2HmacSha512 = 0,
+    Argon2id = 1,
 }
 
 #[derive(Deserialize, Serialize)]


### PR DESCRIPTION
Support for Argon2id as a new and more secure alternative to the existing PBKDF2 password hashing algorithm.