### PR TITLE
Add `Table<Account>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,25 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- The return value of `Store::account_map` method has been modified to provide
+  better encapsulation and prevent misuse of account-related functions.
+  Previously, this method returned a `Map` object, which allowed direct access
+  to the underlying data structure. To ensure that account-related functions
+  are only called on relevant objects, we have updated the return value to be
+  `Table<Account>` instead. As part of this change, the `Map::update_account`
+  function has been moved to `Table<Account>`. This helps prevent other Map
+  objects that have nothing to do with Account from mistakenly calling the
+  update_account function. This change aims to promote better practices in
+  accessing and manipulating the account data, as well as providing a more
+  consistent API for developers.
+
 ### Removed
 
 - `Map::new`. It is only used internally and shouldn't be called from another
   crate.
+- `Map::update_account`. This is now under `Table<Account>`.
 
 ## [0.4.0] - 2023-04-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 edition = "2021"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@ mod model;
 mod outlier;
 mod qualifier;
 mod schema;
-mod state;
 mod status;
+mod tables;
 mod ti;
 mod time_series;
 mod top_n;
@@ -45,8 +45,8 @@ pub use self::migration::migrate_data_dir;
 pub use self::model::Model;
 pub use self::outlier::*;
 pub use self::qualifier::Qualifier;
-pub use self::state::StateDb;
 pub use self::status::Status;
+pub use self::tables::{StateDb, Table};
 pub use self::ti::{Tidb, TidbKind, TidbRule};
 pub use self::time_series::*;
 pub use self::time_series::{ColumnTimeSeries, TimeCount, TimeSeriesResult};
@@ -229,151 +229,153 @@ impl Store {
     #[must_use]
     pub fn access_token_map(&self) -> Map {
         self.states
-            .map(state::ACCESS_TOKENS)
+            .map(tables::ACCESS_TOKENS)
             .expect("always available")
     }
 
     #[must_use]
-    pub fn account_map(&self) -> Map {
-        self.states.map(state::ACCOUNTS).expect("always available")
+    pub fn account_map(&self) -> Table<types::Account> {
+        self.states.accounts()
     }
 
     #[must_use]
     pub fn account_policy_map(&self) -> Map {
         self.states
-            .map(state::ACCOUNT_POLICY)
+            .map(tables::ACCOUNT_POLICY)
             .expect("always available")
     }
 
     #[must_use]
     pub fn allow_network_map(&self) -> IndexedMap {
         self.states
-            .indexed_map(state::ALLOW_NETWORKS)
+            .indexed_map(tables::ALLOW_NETWORKS)
             .expect("always available")
     }
 
     #[must_use]
     pub fn block_network_map(&self) -> IndexedMap {
         self.states
-            .indexed_map(state::BLOCK_NETWORKS)
+            .indexed_map(tables::BLOCK_NETWORKS)
             .expect("always available")
     }
 
     #[must_use]
     pub fn customer_map(&self) -> IndexedMap {
         self.states
-            .indexed_map(state::CUSTOMERS)
+            .indexed_map(tables::CUSTOMERS)
             .expect("always available")
     }
 
     #[must_use]
     pub fn data_source_map(&self) -> IndexedMap {
         self.states
-            .indexed_map(state::DATA_SOURCES)
+            .indexed_map(tables::DATA_SOURCES)
             .expect("always available")
     }
 
     #[must_use]
     pub fn event_tag_set(&self) -> IndexedSet {
         self.states
-            .indexed_set(state::EVENT_TAGS)
+            .indexed_set(tables::EVENT_TAGS)
             .expect("always available")
     }
 
     #[must_use]
     pub fn filter_map(&self) -> Map {
-        self.states.map(state::FILTERS).expect("always available")
+        self.states.map(tables::FILTERS).expect("always available")
     }
 
     #[must_use]
     pub fn model_indicator_map(&self) -> Map {
         self.states
-            .map(state::MODEL_INDICATORS)
+            .map(tables::MODEL_INDICATORS)
             .expect("always available")
     }
 
     #[must_use]
     pub fn network_map(&self) -> IndexedMultimap {
         self.states
-            .indexed_multimap(state::NETWORKS)
+            .indexed_multimap(tables::NETWORKS)
             .expect("always available")
     }
 
     #[must_use]
     pub fn network_tag_set(&self) -> IndexedSet {
         self.states
-            .indexed_set(state::NETWORK_TAGS)
+            .indexed_set(tables::NETWORK_TAGS)
             .expect("always available")
     }
 
     #[must_use]
     pub fn node_map(&self) -> IndexedMap {
         self.states
-            .indexed_map(state::NODES)
+            .indexed_map(tables::NODES)
             .expect("always available")
     }
 
     #[must_use]
     pub fn outlier_map(&self) -> Map {
-        self.states.map(state::OUTLIERS).expect("always available")
+        self.states.map(tables::OUTLIERS).expect("always available")
     }
 
     #[must_use]
     pub fn sampling_policy_map(&self) -> IndexedMap {
         self.states
-            .indexed_map(state::SAMPLING_POLICY)
+            .indexed_map(tables::SAMPLING_POLICY)
             .expect("always available")
     }
 
     #[must_use]
     pub fn template_map(&self) -> Map {
-        self.states.map(state::TEMPLATES).expect("always available")
+        self.states
+            .map(tables::TEMPLATES)
+            .expect("always available")
     }
 
     #[must_use]
     pub fn tidb_map(&self) -> Map {
-        self.states.map(state::TIDB).expect("always available")
+        self.states.map(tables::TIDB).expect("always available")
     }
 
     #[must_use]
     pub fn tor_exit_node_map(&self) -> Map {
         self.states
-            .map(state::TOR_EXIT_NODES)
+            .map(tables::TOR_EXIT_NODES)
             .expect("always available")
     }
 
     #[must_use]
     pub fn triage_policy_map(&self) -> IndexedMap {
         self.states
-            .indexed_map(state::TRIAGE_POLICY)
+            .indexed_map(tables::TRIAGE_POLICY)
             .expect("always available")
     }
 
     #[must_use]
     pub fn triage_response_map(&self) -> IndexedMap {
         self.states
-            .indexed_map(state::TRIAGE_RESPONSE)
+            .indexed_map(tables::TRIAGE_RESPONSE)
             .expect("always available")
     }
 
     #[must_use]
     pub fn trusted_dns_server_map(&self) -> Map {
         self.states
-            .map(state::TRUSTED_DNS_SERVERS)
+            .map(tables::TRUSTED_DNS_SERVERS)
             .expect("always available")
     }
 
     #[must_use]
     pub fn traffic_filter_map(&self) -> Map {
         self.states
-            .map(state::TRAFFIC_FILTER_RULES)
+            .map(tables::TRAFFIC_FILTER_RULES)
             .expect("always available")
     }
 
     #[must_use]
     pub fn workflow_tag_set(&self) -> IndexedSet {
         self.states
-            .indexed_set(state::WORKFLOW_TAGS)
+            .indexed_set(tables::WORKFLOW_TAGS)
             .expect("always available")
     }
 

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 /// current version. When the database format changes, this requirement must be
 /// updated to match the new version, and the migration code must be added to
 /// the `migrate_data_dir` function.
-const DATABASE_VERSION_REQ: &str = ">=0.3.0,<0.5.0-alpha.2";
+const DATABASE_VERSION_REQ: &str = ">=0.3.0,<0.5.0-alpha.3";
 
 /// Migrates the data directory to the up-to-date format if necessary.
 ///

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -1,3 +1,7 @@
+mod accounts;
+
+use crate::types::Account;
+
 use super::{event, IndexedMap, IndexedMultimap, IndexedSet, Map};
 use anyhow::Result;
 use std::path::Path;
@@ -69,6 +73,11 @@ impl StateDb {
     }
 
     #[must_use]
+    pub(crate) fn accounts(&self) -> Table<Account> {
+        Table::<Account>::open(&self.inner)
+    }
+
+    #[must_use]
     pub fn events(&self) -> event::EventDb {
         event::EventDb::new(&self.inner)
     }
@@ -120,5 +129,19 @@ impl StateDb {
         let db_env = rocksdb::Env::new()?;
         let mut engine = rocksdb::backup::BackupEngine::open(&opts, &db_env)?;
         Ok(engine.purge_old_backups(num_of_backups_to_keep as usize)?)
+    }
+}
+
+pub struct Table<'d, R> {
+    map: Map<'d>,
+    _phantom: std::marker::PhantomData<R>,
+}
+
+impl<'d, R> Table<'d, R> {
+    fn new(map: Map<'d>) -> Self {
+        Self {
+            map,
+            _phantom: std::marker::PhantomData,
+        }
     }
 }

--- a/src/tables/accounts.rs
+++ b/src/tables/accounts.rs
@@ -1,0 +1,135 @@
+use std::net::IpAddr;
+
+use anyhow::{bail, Context};
+use rocksdb::{Direction, IteratorMode, OptimisticTransactionDB};
+
+use crate::{
+    types::{Account, SaltedPassword},
+    IterableMap, Map, MapIterator, Role, EXCLUSIVE,
+};
+
+impl<'d> super::Table<'d, Account> {
+    /// Opens the accounts table in the database.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the accounts table is not present in the database.
+    pub(super) fn open(db: &'d OptimisticTransactionDB) -> Self {
+        let map = Map::new(db, super::ACCOUNTS).expect("accounts table is present");
+        Self::new(map)
+    }
+
+    pub fn delete(&self, key: &[u8]) -> Result<(), anyhow::Error> {
+        self.map.delete(key)
+    }
+
+    pub fn get(&self, key: &[u8]) -> Result<Option<impl AsRef<[u8]>>, anyhow::Error> {
+        self.map.get(key)
+    }
+
+    pub fn put(&self, key: &[u8], value: &[u8]) -> Result<(), anyhow::Error> {
+        self.map.put(key, value)
+    }
+
+    pub fn insert(&self, key: &[u8], value: &[u8]) -> Result<(), anyhow::Error> {
+        self.map.insert(key, value)
+    }
+
+    pub fn update(&self, old: (&[u8], &[u8]), new: (&[u8], &[u8])) -> Result<(), anyhow::Error> {
+        self.map.update(old, new)
+    }
+
+    /// Updates an entry in account map.
+    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
+    pub fn update_account(
+        &self,
+        username: &[u8],
+        new_password: &Option<String>,
+        role: Option<(Role, Role)>,
+        name: &Option<(String, String)>,
+        department: &Option<(String, String)>,
+        allow_access_from: &Option<(Option<Vec<IpAddr>>, Option<Vec<IpAddr>>)>,
+        max_parallel_sessions: &Option<(Option<u32>, Option<u32>)>,
+    ) -> Result<(), anyhow::Error> {
+        use bincode::Options;
+
+        loop {
+            let txn = self.map.db.transaction();
+            if let Some(old_value) = txn
+                .get_for_update_cf(self.map.cf, username, EXCLUSIVE)
+                .context("cannot read old entry")?
+            {
+                let mut account =
+                    bincode::DefaultOptions::new().deserialize::<Account>(old_value.as_ref())?;
+
+                if let Some(password) = &new_password {
+                    account.password = SaltedPassword::new(password)?;
+                }
+                if let Some((old, new)) = &role {
+                    if account.role != *old {
+                        bail!("old value mismatch");
+                    }
+                    account.role = *new;
+                }
+                if let Some((old, new)) = &name {
+                    if account.name != *old {
+                        bail!("old value mismatch");
+                    }
+                    account.name = new.clone();
+                }
+                if let Some((old, new)) = &department {
+                    if account.department != *old {
+                        bail!("old value mismatch");
+                    }
+                    account.department = new.clone();
+                }
+                if let Some((old, new)) = &allow_access_from {
+                    if account.allow_access_from != *old {
+                        bail!("old value mismatch");
+                    }
+                    account.allow_access_from = new.clone();
+                }
+                if let Some((old, new)) = max_parallel_sessions {
+                    if account.max_parallel_sessions != *old {
+                        bail!("old value mismatch");
+                    }
+                    account.max_parallel_sessions = *new;
+                }
+
+                let value = bincode::DefaultOptions::new().serialize(&account)?;
+                txn.put_cf(self.map.cf, username, value)
+                    .context("failed to write new entry")?;
+            } else {
+                bail!("no such entry");
+            };
+
+            match txn.commit() {
+                Ok(_) => break,
+                Err(e) => {
+                    if !e.as_ref().starts_with("Resource busy:") {
+                        return Err(e).context("failed to update entry");
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn inner_iterator(&self, mode: IteratorMode) -> MapIterator {
+        MapIterator::new(self.map.db.iterator_cf(self.map.cf, mode))
+    }
+}
+
+impl<'i> IterableMap<'i, MapIterator<'i>> for super::Table<'i, Account> {
+    fn iter_from(&self, key: &[u8], direction: Direction) -> Result<MapIterator, anyhow::Error> {
+        Ok(self.inner_iterator(IteratorMode::From(key, direction)))
+    }
+
+    fn iter_forward(&self) -> Result<MapIterator, anyhow::Error> {
+        Ok(self.inner_iterator(IteratorMode::Start))
+    }
+
+    fn iter_backward(&self) -> Result<MapIterator, anyhow::Error> {
+        Ok(self.inner_iterator(IteratorMode::End))
+    }
+}


### PR DESCRIPTION
This is used in a place where `Map` contains `Account` objects. It ensures that `update_account` is called only for `Account` objects.