### PR TITLE
Remove blocking pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `StatdDb` and `Map::new`. They are only used internally and shouldn't be
   called from another crate.
 - `Map::update_account`. Use `Table<Account>::update_account` instead.
+- `BlockingPgPool` has been removed as `diesel_async` is used instead.
 
 ## [0.4.0] - 2023-04-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.5.0-alpha.2"
+version = "0.5.0-alpha.3"
 edition = "2021"
 
 [dependencies]
@@ -16,7 +16,6 @@ data-encoding = "2"
 diesel = { version = "2", features = [
   "chrono",
   "postgres",
-  "r2d2",
   "serde_json",
 ] }
 diesel-async =  { version = "0.2.1", features = ["bb8", "postgres"] }
@@ -30,7 +29,6 @@ ipnet = { version = "2", features = ["serde"] }
 num-derive = "0.3"
 num-traits = "0.2"
 postgres-protocol = "0.6"
-r2d2 = "0.8"
 rand = "0.8"
 ring = { version = "0.16", features = ["std"] }
 rocksdb = "0.20.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ diesel = { version = "2", features = [
   "r2d2",
   "serde_json",
 ] }
+diesel-async =  { version = "0.2.1", features = ["bb8", "postgres"] }
 diesel_derives = "2.0"
 diesel_migrations = "2"
 fallible-iterator = "0.2"

--- a/src/column_statistics.rs
+++ b/src/column_statistics.rs
@@ -1,8 +1,8 @@
 mod load;
-pub(super) mod round;
+mod round;
 mod save;
 
-use super::{schema, BlockingPgConn, Error};
-
-pub(crate) use load::{get_column_statistics, Statistics};
+pub(crate) use load::get_column_statistics;
+pub use load::Statistics;
+pub use round::{RoundByCluster, RoundByModel};
 pub use save::statistics::ColumnStatisticsUpdate;

--- a/src/column_statistics.rs
+++ b/src/column_statistics.rs
@@ -2,7 +2,6 @@ mod load;
 mod round;
 mod save;
 
-pub(crate) use load::get_column_statistics;
 pub use load::Statistics;
 pub use round::{RoundByCluster, RoundByModel};
 pub use save::statistics::ColumnStatisticsUpdate;

--- a/src/column_statistics/load.rs
+++ b/src/column_statistics/load.rs
@@ -8,10 +8,12 @@ mod text;
 
 use crate::{
     schema::{self, column_description::dsl as cd_d, event_range::dsl as e_d},
-    BlockingPgConn, Database, Error,
+    Database, Error,
 };
 use chrono::NaiveDateTime;
 use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
+use diesel_async::RunQueryDsl;
+use futures::future::join_all;
 use serde::Serialize;
 use std::collections::HashMap;
 use structured::{ColumnStatistics, Description, ElementCount, NLargestCount};
@@ -45,67 +47,6 @@ trait ToNLargestCount {
     fn to_n_largest_count(self, ec: Vec<ElementCount>) -> NLargestCount;
 }
 
-pub(crate) fn get_column_statistics(
-    conn: &mut BlockingPgConn,
-    cluster: i32,
-    time: Option<NaiveDateTime>,
-    first_event_id: Option<i64>,
-    last_event_id: Option<i64>,
-) -> Result<Vec<Statistics>, Error> {
-    use diesel::RunQueryDsl;
-
-    let mut query = cd_d::column_description
-        .inner_join(e_d::event_range.on(cd_d::event_range_id.eq(e_d::id)))
-        .select((cd_d::id, cd_d::type_id))
-        .into_boxed();
-    if let Some(time) = time {
-        query = query.filter(e_d::cluster_id.eq(cluster).and(e_d::time.eq(time)));
-    } else {
-        query = query.filter(
-            e_d::cluster_id.eq(cluster).and(
-                e_d::first_event_id
-                    .eq(first_event_id.unwrap_or_default())
-                    .and(e_d::last_event_id.eq(last_event_id.unwrap_or_default())),
-            ),
-        );
-    }
-    let column_info = query
-        .order_by(cd_d::column_index.asc())
-        .load::<ColumnDescriptionLoad>(conn)?;
-
-    let mut columns: HashMap<i32, Vec<i32>> = HashMap::new();
-    for c in &column_info {
-        columns.entry(c.type_id).or_insert_with(Vec::new).push(c.id);
-    }
-
-    let mut results = columns
-        .iter()
-        .filter_map(|(type_id, description_ids)| {
-            let statistics = match type_id {
-                1 => int::get_int_statistics(conn, description_ids),
-                2 => r#enum::get_enum_statistics(conn, description_ids),
-                3 => float::get_float_statistics(conn, description_ids),
-                4 => text::get_text_statistics(conn, description_ids),
-                5 => ipaddr::get_ipaddr_statistics(conn, description_ids),
-                6 => datetime::get_datetime_statistics(conn, description_ids),
-                7 => binary::get_binary_statistics(conn, description_ids),
-                _ => {
-                    error!("Unexpected column type id: {}", type_id);
-                    return None;
-                }
-            };
-            if let Err(e) = &statistics {
-                error!("An error occurred while loading column statistics: {:?}", e);
-            }
-            statistics.ok()
-        })
-        .flatten()
-        .collect::<Vec<_>>();
-
-    results.sort_by(|a, b| a.column_index.cmp(&b.column_index));
-    Ok(results)
-}
-
 impl Database {
     pub async fn get_column_statistics(
         &self,
@@ -114,9 +55,6 @@ impl Database {
         first_event_id: Option<i64>,
         last_event_id: Option<i64>,
     ) -> Result<Vec<Statistics>, Error> {
-        use diesel_async::RunQueryDsl;
-        use futures::future::join_all;
-
         let mut conn = self.pool.get_diesel_conn().await?;
         let mut query = cd_d::column_description
             .inner_join(e_d::event_range.on(cd_d::event_range_id.eq(e_d::id)))
@@ -146,13 +84,13 @@ impl Database {
         let mut results = join_all(columns.iter().map(|(type_id, description_ids)| async move {
             let conn = self.pool.get_diesel_conn().await?;
             let statistics = match type_id {
-                1 => int::async_get_int_statistics(conn, description_ids).await,
-                2 => r#enum::async_get_enum_statistics(conn, description_ids).await,
-                3 => float::async_get_float_statistics(conn, description_ids).await,
-                4 => text::async_get_text_statistics(conn, description_ids).await,
-                5 => ipaddr::async_get_ipaddr_statistics(conn, description_ids).await,
-                6 => datetime::async_get_datetime_statistics(conn, description_ids).await,
-                7 => binary::async_get_binary_statistics(conn, description_ids).await,
+                1 => int::get_int_statistics(conn, description_ids).await,
+                2 => r#enum::get_enum_statistics(conn, description_ids).await,
+                3 => float::get_float_statistics(conn, description_ids).await,
+                4 => text::get_text_statistics(conn, description_ids).await,
+                5 => ipaddr::get_ipaddr_statistics(conn, description_ids).await,
+                6 => datetime::get_datetime_statistics(conn, description_ids).await,
+                7 => binary::get_binary_statistics(conn, description_ids).await,
                 _ => {
                     return Err(Error::InvalidInput(format!(
                         "Unexpected column type id: {type_id}"
@@ -166,12 +104,7 @@ impl Database {
         }))
         .await
         .into_iter()
-        .filter_map(|s| {
-            if let Err(e) = &s {
-                error!("{:#}", e);
-            }
-            s.ok()
-        })
+        .filter_map(Result::ok)
         .flatten()
         .collect::<Vec<_>>();
 

--- a/src/column_statistics/load.rs
+++ b/src/column_statistics/load.rs
@@ -6,12 +6,12 @@ mod int;
 mod ipaddr;
 mod text;
 
-use super::{
+use crate::{
     schema::{self, column_description::dsl as cd_d, event_range::dsl as e_d},
-    BlockingPgConn, Error,
+    BlockingPgConn, Database, Error,
 };
 use chrono::NaiveDateTime;
-use diesel::prelude::*;
+use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
 use serde::Serialize;
 use std::collections::HashMap;
 use structured::{ColumnStatistics, Description, ElementCount, NLargestCount};
@@ -52,6 +52,8 @@ pub(crate) fn get_column_statistics(
     first_event_id: Option<i64>,
     last_event_id: Option<i64>,
 ) -> Result<Vec<Statistics>, Error> {
+    use diesel::RunQueryDsl;
+
     let mut query = cd_d::column_description
         .inner_join(e_d::event_range.on(cd_d::event_range_id.eq(e_d::id)))
         .select((cd_d::id, cd_d::type_id))
@@ -102,6 +104,80 @@ pub(crate) fn get_column_statistics(
 
     results.sort_by(|a, b| a.column_index.cmp(&b.column_index));
     Ok(results)
+}
+
+impl Database {
+    pub async fn get_column_statistics(
+        &self,
+        cluster: i32,
+        time: Option<NaiveDateTime>,
+        first_event_id: Option<i64>,
+        last_event_id: Option<i64>,
+    ) -> Result<Vec<Statistics>, Error> {
+        use diesel_async::RunQueryDsl;
+        use futures::future::join_all;
+
+        let mut conn = self.pool.get_diesel_conn().await?;
+        let mut query = cd_d::column_description
+            .inner_join(e_d::event_range.on(cd_d::event_range_id.eq(e_d::id)))
+            .select((cd_d::id, cd_d::type_id))
+            .into_boxed();
+        if let Some(time) = time {
+            query = query.filter(e_d::cluster_id.eq(cluster).and(e_d::time.eq(time)));
+        } else {
+            query = query.filter(
+                e_d::cluster_id.eq(cluster).and(
+                    e_d::first_event_id
+                        .eq(first_event_id.unwrap_or_default())
+                        .and(e_d::last_event_id.eq(last_event_id.unwrap_or_default())),
+                ),
+            );
+        }
+        let column_info = query
+            .order_by(cd_d::column_index.asc())
+            .load::<ColumnDescriptionLoad>(&mut conn)
+            .await?;
+
+        let mut columns: HashMap<i32, Vec<i32>> = HashMap::new();
+        for c in &column_info {
+            columns.entry(c.type_id).or_insert_with(Vec::new).push(c.id);
+        }
+
+        let mut results = join_all(columns.iter().map(|(type_id, description_ids)| async move {
+            let conn = self.pool.get_diesel_conn().await?;
+            let statistics = match type_id {
+                1 => int::async_get_int_statistics(conn, description_ids).await,
+                2 => r#enum::async_get_enum_statistics(conn, description_ids).await,
+                3 => float::async_get_float_statistics(conn, description_ids).await,
+                4 => text::async_get_text_statistics(conn, description_ids).await,
+                5 => ipaddr::async_get_ipaddr_statistics(conn, description_ids).await,
+                6 => datetime::async_get_datetime_statistics(conn, description_ids).await,
+                7 => binary::async_get_binary_statistics(conn, description_ids).await,
+                _ => {
+                    return Err(Error::InvalidInput(format!(
+                        "Unexpected column type id: {type_id}"
+                    )));
+                }
+            };
+            if let Err(e) = &statistics {
+                error!("An error occurred while loading column statistics: {:?}", e);
+            }
+            statistics
+        }))
+        .await
+        .into_iter()
+        .filter_map(|s| {
+            if let Err(e) = &s {
+                error!("{:#}", e);
+            }
+            s.ok()
+        })
+        .flatten()
+        .collect::<Vec<_>>();
+
+        results.sort_by(|a, b| a.column_index.cmp(&b.column_index));
+        Ok(results)
+    }
 }
 
 fn build_column_statistics<T, U>(column_descriptions: Vec<T>, top_n: Vec<U>) -> Vec<Statistics>

--- a/src/column_statistics/load/binary.rs
+++ b/src/column_statistics/load/binary.rs
@@ -4,7 +4,7 @@ use super::{
     },
     BlockingPgConn, ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
 };
-use diesel::prelude::*;
+use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
 use structured::{Description, Element, ElementCount, NLargestCount};
 
 #[derive(Debug, Queryable)]
@@ -77,6 +77,8 @@ fn load(
     conn: &mut BlockingPgConn,
     description_ids: &[i32],
 ) -> Result<(Vec<DescriptionBinary>, Vec<TopNBinary>), diesel::result::Error> {
+    use diesel::RunQueryDsl;
+
     let column_descriptions = desc::description_binary
         .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
         .select((cd::column_index, cd::count, cd::unique_count, desc::mode))
@@ -92,4 +94,29 @@ fn load(
         .load::<TopNBinary>(conn)?;
 
     Ok((column_descriptions, top_n))
+}
+
+pub(super) async fn async_get_binary_statistics(
+    mut conn: diesel_async::pg::AsyncPgConnection,
+    description_ids: &[i32],
+) -> Result<Vec<Statistics>, Error> {
+    use diesel_async::RunQueryDsl;
+
+    let column_descriptions = desc::description_binary
+        .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
+        .select((cd::column_index, cd::count, cd::unique_count, desc::mode))
+        .filter(cd::id.eq_any(description_ids))
+        .order_by((cd::column_index.asc(), cd::count.desc()))
+        .load::<DescriptionBinary>(&mut conn)
+        .await?;
+
+    let top_n = top_n::top_n_binary
+        .inner_join(cd::column_description.on(cd::id.eq(top_n::description_id)))
+        .select((cd::column_index, top_n::value, top_n::count))
+        .filter(cd::id.eq_any(description_ids))
+        .order_by(cd::column_index.asc())
+        .load::<TopNBinary>(&mut conn)
+        .await?;
+
+    Ok(super::build_column_statistics(column_descriptions, top_n))
 }

--- a/src/column_statistics/load/binary.rs
+++ b/src/column_statistics/load/binary.rs
@@ -2,9 +2,10 @@ use super::{
     schema::{
         column_description::dsl as cd, description_binary::dsl as desc, top_n_binary::dsl as top_n,
     },
-    BlockingPgConn, ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
+    ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
 };
 use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
+use diesel_async::{pg::AsyncPgConnection, RunQueryDsl};
 use structured::{Description, Element, ElementCount, NLargestCount};
 
 #[derive(Debug, Queryable)]
@@ -65,43 +66,10 @@ impl ToElementCount for TopNBinary {
     }
 }
 
-pub(super) fn get_binary_statistics(
-    conn: &mut BlockingPgConn,
+pub(super) async fn get_binary_statistics(
+    mut conn: AsyncPgConnection,
     description_ids: &[i32],
 ) -> Result<Vec<Statistics>, Error> {
-    let (column_descriptions, top_n) = load(conn, description_ids)?;
-    Ok(super::build_column_statistics(column_descriptions, top_n))
-}
-
-fn load(
-    conn: &mut BlockingPgConn,
-    description_ids: &[i32],
-) -> Result<(Vec<DescriptionBinary>, Vec<TopNBinary>), diesel::result::Error> {
-    use diesel::RunQueryDsl;
-
-    let column_descriptions = desc::description_binary
-        .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
-        .select((cd::column_index, cd::count, cd::unique_count, desc::mode))
-        .filter(cd::id.eq_any(description_ids))
-        .order_by((cd::column_index.asc(), cd::count.desc()))
-        .load::<DescriptionBinary>(conn)?;
-
-    let top_n = top_n::top_n_binary
-        .inner_join(cd::column_description.on(cd::id.eq(top_n::description_id)))
-        .select((cd::column_index, top_n::value, top_n::count))
-        .filter(cd::id.eq_any(description_ids))
-        .order_by(cd::column_index.asc())
-        .load::<TopNBinary>(conn)?;
-
-    Ok((column_descriptions, top_n))
-}
-
-pub(super) async fn async_get_binary_statistics(
-    mut conn: diesel_async::pg::AsyncPgConnection,
-    description_ids: &[i32],
-) -> Result<Vec<Statistics>, Error> {
-    use diesel_async::RunQueryDsl;
-
     let column_descriptions = desc::description_binary
         .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
         .select((cd::column_index, cd::count, cd::unique_count, desc::mode))

--- a/src/column_statistics/load/datetime.rs
+++ b/src/column_statistics/load/datetime.rs
@@ -6,7 +6,7 @@ use super::{
     BlockingPgConn, ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
 };
 use chrono::NaiveDateTime;
-use diesel::prelude::*;
+use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
 use structured::{Description, Element, ElementCount, NLargestCount};
 
 #[derive(Debug, Queryable)]
@@ -79,6 +79,8 @@ fn load(
     conn: &mut BlockingPgConn,
     description_ids: &[i32],
 ) -> Result<(Vec<DescriptionDateTime>, Vec<TopNDateTime>), diesel::result::Error> {
+    use diesel::RunQueryDsl;
+
     let column_descriptions = desc::description_datetime
         .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
         .select((cd::column_index, cd::count, cd::unique_count, desc::mode))
@@ -94,4 +96,29 @@ fn load(
         .load::<TopNDateTime>(conn)?;
 
     Ok((column_descriptions, top_n))
+}
+
+pub(super) async fn async_get_datetime_statistics(
+    mut conn: diesel_async::pg::AsyncPgConnection,
+    description_ids: &[i32],
+) -> Result<Vec<Statistics>, Error> {
+    use diesel_async::RunQueryDsl;
+
+    let column_descriptions = desc::description_datetime
+        .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
+        .select((cd::column_index, cd::count, cd::unique_count, desc::mode))
+        .filter(cd::id.eq_any(description_ids))
+        .order_by((cd::column_index.asc(), cd::count.desc()))
+        .load::<DescriptionDateTime>(&mut conn)
+        .await?;
+
+    let top_n = top_n::top_n_datetime
+        .inner_join(cd::column_description.on(cd::id.eq(top_n::description_id)))
+        .select((cd::column_index, top_n::value, top_n::count))
+        .filter(cd::id.eq_any(description_ids))
+        .order_by(cd::column_index.asc())
+        .load::<TopNDateTime>(&mut conn)
+        .await?;
+
+    Ok(super::build_column_statistics(column_descriptions, top_n))
 }

--- a/src/column_statistics/load/enum.rs
+++ b/src/column_statistics/load/enum.rs
@@ -2,9 +2,10 @@ use super::{
     schema::{
         column_description::dsl as cd, description_enum::dsl as desc, top_n_enum::dsl as top_n,
     },
-    BlockingPgConn, ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
+    ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
 };
 use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
+use diesel_async::{pg::AsyncPgConnection, RunQueryDsl};
 use structured::{Description, Element, ElementCount, NLargestCount};
 
 #[derive(Debug, Queryable)]
@@ -65,43 +66,10 @@ impl ToElementCount for TopNEnum {
     }
 }
 
-pub(super) fn get_enum_statistics(
-    conn: &mut BlockingPgConn,
+pub(super) async fn get_enum_statistics(
+    mut conn: AsyncPgConnection,
     description_ids: &[i32],
 ) -> Result<Vec<Statistics>, Error> {
-    let (column_descriptions, top_n) = load(conn, description_ids)?;
-    Ok(super::build_column_statistics(column_descriptions, top_n))
-}
-
-fn load(
-    conn: &mut BlockingPgConn,
-    description_ids: &[i32],
-) -> Result<(Vec<DescriptionEnum>, Vec<TopNEnum>), diesel::result::Error> {
-    use diesel::RunQueryDsl;
-
-    let column_descriptions = desc::description_enum
-        .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
-        .select((cd::column_index, cd::count, cd::unique_count, desc::mode))
-        .filter(cd::id.eq_any(description_ids))
-        .order_by((cd::column_index.asc(), cd::count.desc()))
-        .load::<DescriptionEnum>(conn)?;
-
-    let top_n = top_n::top_n_enum
-        .inner_join(cd::column_description.on(cd::id.eq(top_n::description_id)))
-        .select((cd::column_index, top_n::value, top_n::count))
-        .filter(cd::id.eq_any(description_ids))
-        .order_by(cd::column_index.asc())
-        .load::<TopNEnum>(conn)?;
-
-    Ok((column_descriptions, top_n))
-}
-
-pub(super) async fn async_get_enum_statistics(
-    mut conn: diesel_async::pg::AsyncPgConnection,
-    description_ids: &[i32],
-) -> Result<Vec<Statistics>, Error> {
-    use diesel_async::RunQueryDsl;
-
     let column_descriptions = desc::description_enum
         .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
         .select((cd::column_index, cd::count, cd::unique_count, desc::mode))

--- a/src/column_statistics/load/enum.rs
+++ b/src/column_statistics/load/enum.rs
@@ -4,7 +4,7 @@ use super::{
     },
     BlockingPgConn, ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
 };
-use diesel::prelude::*;
+use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
 use structured::{Description, Element, ElementCount, NLargestCount};
 
 #[derive(Debug, Queryable)]
@@ -77,6 +77,8 @@ fn load(
     conn: &mut BlockingPgConn,
     description_ids: &[i32],
 ) -> Result<(Vec<DescriptionEnum>, Vec<TopNEnum>), diesel::result::Error> {
+    use diesel::RunQueryDsl;
+
     let column_descriptions = desc::description_enum
         .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
         .select((cd::column_index, cd::count, cd::unique_count, desc::mode))
@@ -92,4 +94,29 @@ fn load(
         .load::<TopNEnum>(conn)?;
 
     Ok((column_descriptions, top_n))
+}
+
+pub(super) async fn async_get_enum_statistics(
+    mut conn: diesel_async::pg::AsyncPgConnection,
+    description_ids: &[i32],
+) -> Result<Vec<Statistics>, Error> {
+    use diesel_async::RunQueryDsl;
+
+    let column_descriptions = desc::description_enum
+        .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
+        .select((cd::column_index, cd::count, cd::unique_count, desc::mode))
+        .filter(cd::id.eq_any(description_ids))
+        .order_by((cd::column_index.asc(), cd::count.desc()))
+        .load::<DescriptionEnum>(&mut conn)
+        .await?;
+
+    let top_n = top_n::top_n_enum
+        .inner_join(cd::column_description.on(cd::id.eq(top_n::description_id)))
+        .select((cd::column_index, top_n::value, top_n::count))
+        .filter(cd::id.eq_any(description_ids))
+        .order_by(cd::column_index.asc())
+        .load::<TopNEnum>(&mut conn)
+        .await?;
+
+    Ok(super::build_column_statistics(column_descriptions, top_n))
 }

--- a/src/column_statistics/load/float.rs
+++ b/src/column_statistics/load/float.rs
@@ -2,9 +2,10 @@ use super::{
     schema::{
         column_description::dsl as cd, description_float::dsl as desc, top_n_float::dsl as top_n,
     },
-    BlockingPgConn, ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
+    ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
 };
 use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
+use diesel_async::{pg::AsyncPgConnection, RunQueryDsl};
 use structured::{Description, Element, ElementCount, FloatRange, NLargestCount};
 
 #[derive(Debug, Queryable)]
@@ -77,58 +78,10 @@ impl ToElementCount for TopNFloat {
     }
 }
 
-pub(super) fn get_float_statistics(
-    conn: &mut BlockingPgConn,
+pub(super) async fn get_float_statistics(
+    mut conn: AsyncPgConnection,
     description_ids: &[i32],
 ) -> Result<Vec<Statistics>, Error> {
-    let (column_descriptions, top_n) = load(conn, description_ids)?;
-    Ok(super::build_column_statistics(column_descriptions, top_n))
-}
-
-fn load(
-    conn: &mut BlockingPgConn,
-    description_ids: &[i32],
-) -> Result<(Vec<DescriptionFloat>, Vec<TopNFloat>), diesel::result::Error> {
-    use diesel::RunQueryDsl;
-
-    let column_descriptions = desc::description_float
-        .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
-        .select((
-            cd::column_index,
-            cd::count,
-            cd::unique_count,
-            desc::mode_smallest,
-            desc::mode_largest,
-            desc::min,
-            desc::max,
-            desc::mean,
-            desc::s_deviation,
-        ))
-        .filter(cd::id.eq_any(description_ids))
-        .order_by((cd::column_index.asc(), cd::count.desc()))
-        .load::<DescriptionFloat>(conn)?;
-
-    let top_n = top_n::top_n_float
-        .inner_join(cd::column_description.on(cd::id.eq(top_n::description_id)))
-        .select((
-            cd::column_index,
-            top_n::value_smallest,
-            top_n::value_largest,
-            top_n::count,
-        ))
-        .filter(cd::id.eq_any(description_ids))
-        .order_by(cd::column_index.asc())
-        .load::<TopNFloat>(conn)?;
-
-    Ok((column_descriptions, top_n))
-}
-
-pub(super) async fn async_get_float_statistics(
-    mut conn: diesel_async::pg::AsyncPgConnection,
-    description_ids: &[i32],
-) -> Result<Vec<Statistics>, Error> {
-    use diesel_async::RunQueryDsl;
-
     let column_descriptions = desc::description_float
         .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
         .select((

--- a/src/column_statistics/load/float.rs
+++ b/src/column_statistics/load/float.rs
@@ -4,7 +4,7 @@ use super::{
     },
     BlockingPgConn, ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
 };
-use diesel::prelude::*;
+use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
 use structured::{Description, Element, ElementCount, FloatRange, NLargestCount};
 
 #[derive(Debug, Queryable)]
@@ -89,6 +89,8 @@ fn load(
     conn: &mut BlockingPgConn,
     description_ids: &[i32],
 ) -> Result<(Vec<DescriptionFloat>, Vec<TopNFloat>), diesel::result::Error> {
+    use diesel::RunQueryDsl;
+
     let column_descriptions = desc::description_float
         .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
         .select((
@@ -119,4 +121,44 @@ fn load(
         .load::<TopNFloat>(conn)?;
 
     Ok((column_descriptions, top_n))
+}
+
+pub(super) async fn async_get_float_statistics(
+    mut conn: diesel_async::pg::AsyncPgConnection,
+    description_ids: &[i32],
+) -> Result<Vec<Statistics>, Error> {
+    use diesel_async::RunQueryDsl;
+
+    let column_descriptions = desc::description_float
+        .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
+        .select((
+            cd::column_index,
+            cd::count,
+            cd::unique_count,
+            desc::mode_smallest,
+            desc::mode_largest,
+            desc::min,
+            desc::max,
+            desc::mean,
+            desc::s_deviation,
+        ))
+        .filter(cd::id.eq_any(description_ids))
+        .order_by((cd::column_index.asc(), cd::count.desc()))
+        .load::<DescriptionFloat>(&mut conn)
+        .await?;
+
+    let top_n = top_n::top_n_float
+        .inner_join(cd::column_description.on(cd::id.eq(top_n::description_id)))
+        .select((
+            cd::column_index,
+            top_n::value_smallest,
+            top_n::value_largest,
+            top_n::count,
+        ))
+        .filter(cd::id.eq_any(description_ids))
+        .order_by(cd::column_index.asc())
+        .load::<TopNFloat>(&mut conn)
+        .await?;
+
+    Ok(super::build_column_statistics(column_descriptions, top_n))
 }

--- a/src/column_statistics/load/int.rs
+++ b/src/column_statistics/load/int.rs
@@ -2,9 +2,10 @@ use super::{
     schema::{
         column_description::dsl as cd, description_int::dsl as desc, top_n_int::dsl as top_n,
     },
-    BlockingPgConn, ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
+    ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
 };
 use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
+use diesel_async::{pg::AsyncPgConnection, RunQueryDsl};
 use structured::{Description, Element, ElementCount, NLargestCount};
 
 #[derive(Debug, Queryable)]
@@ -69,52 +70,10 @@ impl ToElementCount for TopNInt {
     }
 }
 
-pub(super) fn get_int_statistics(
-    conn: &mut BlockingPgConn,
+pub(super) async fn get_int_statistics(
+    mut conn: AsyncPgConnection,
     description_ids: &[i32],
 ) -> Result<Vec<Statistics>, Error> {
-    let (column_descriptions, top_n) = load(conn, description_ids)?;
-    Ok(super::build_column_statistics(column_descriptions, top_n))
-}
-
-fn load(
-    conn: &mut BlockingPgConn,
-    description_ids: &[i32],
-) -> Result<(Vec<DescriptionInt>, Vec<TopNInt>), diesel::result::Error> {
-    use diesel::RunQueryDsl;
-
-    let column_descriptions = desc::description_int
-        .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
-        .select((
-            cd::column_index,
-            cd::count,
-            cd::unique_count,
-            desc::mode,
-            desc::min,
-            desc::max,
-            desc::mean,
-            desc::s_deviation,
-        ))
-        .filter(cd::id.eq_any(description_ids))
-        .order_by((cd::column_index.asc(), cd::count.desc()))
-        .load::<DescriptionInt>(conn)?;
-
-    let top_n = top_n::top_n_int
-        .inner_join(cd::column_description.on(cd::id.eq(top_n::description_id)))
-        .select((cd::column_index, top_n::value, top_n::count))
-        .filter(cd::id.eq_any(description_ids))
-        .order_by(cd::column_index.asc())
-        .load::<TopNInt>(conn)?;
-
-    Ok((column_descriptions, top_n))
-}
-
-pub(super) async fn async_get_int_statistics(
-    mut conn: diesel_async::pg::AsyncPgConnection,
-    description_ids: &[i32],
-) -> Result<Vec<Statistics>, Error> {
-    use diesel_async::RunQueryDsl;
-
     let column_descriptions = desc::description_int
         .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
         .select((

--- a/src/column_statistics/load/text.rs
+++ b/src/column_statistics/load/text.rs
@@ -4,7 +4,7 @@ use super::{
     },
     BlockingPgConn, ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
 };
-use diesel::prelude::*;
+use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
 use structured::{Description, Element, ElementCount, NLargestCount};
 
 #[derive(Debug, Queryable)]
@@ -77,6 +77,8 @@ fn load(
     conn: &mut BlockingPgConn,
     description_ids: &[i32],
 ) -> Result<(Vec<DescriptionText>, Vec<TopNText>), diesel::result::Error> {
+    use diesel::RunQueryDsl;
+
     let column_descriptions = desc::description_text
         .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
         .select((cd::column_index, cd::count, cd::unique_count, desc::mode))
@@ -92,4 +94,29 @@ fn load(
         .load::<TopNText>(conn)?;
 
     Ok((column_descriptions, top_n))
+}
+
+pub(super) async fn async_get_text_statistics(
+    mut conn: diesel_async::pg::AsyncPgConnection,
+    description_ids: &[i32],
+) -> Result<Vec<Statistics>, Error> {
+    use diesel_async::RunQueryDsl;
+
+    let column_descriptions = desc::description_text
+        .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
+        .select((cd::column_index, cd::count, cd::unique_count, desc::mode))
+        .filter(cd::id.eq_any(description_ids))
+        .order_by((cd::column_index.asc(), cd::count.desc()))
+        .load::<DescriptionText>(&mut conn)
+        .await?;
+
+    let top_n = top_n::top_n_text
+        .inner_join(cd::column_description.on(cd::id.eq(top_n::description_id)))
+        .select((cd::column_index, top_n::value, top_n::count))
+        .filter(cd::id.eq_any(description_ids))
+        .order_by(cd::column_index.asc())
+        .load::<TopNText>(&mut conn)
+        .await?;
+
+    Ok(super::build_column_statistics(column_descriptions, top_n))
 }

--- a/src/column_statistics/load/text.rs
+++ b/src/column_statistics/load/text.rs
@@ -2,9 +2,10 @@ use super::{
     schema::{
         column_description::dsl as cd, description_text::dsl as desc, top_n_text::dsl as top_n,
     },
-    BlockingPgConn, ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
+    ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
 };
 use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
+use diesel_async::{pg::AsyncPgConnection, RunQueryDsl};
 use structured::{Description, Element, ElementCount, NLargestCount};
 
 #[derive(Debug, Queryable)]
@@ -65,43 +66,10 @@ impl ToElementCount for TopNText {
     }
 }
 
-pub(super) fn get_text_statistics(
-    conn: &mut BlockingPgConn,
+pub(super) async fn get_text_statistics(
+    mut conn: AsyncPgConnection,
     description_ids: &[i32],
 ) -> Result<Vec<Statistics>, Error> {
-    let (column_descriptions, top_n) = load(conn, description_ids)?;
-    Ok(super::build_column_statistics(column_descriptions, top_n))
-}
-
-fn load(
-    conn: &mut BlockingPgConn,
-    description_ids: &[i32],
-) -> Result<(Vec<DescriptionText>, Vec<TopNText>), diesel::result::Error> {
-    use diesel::RunQueryDsl;
-
-    let column_descriptions = desc::description_text
-        .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
-        .select((cd::column_index, cd::count, cd::unique_count, desc::mode))
-        .filter(cd::id.eq_any(description_ids))
-        .order_by((cd::column_index.asc(), cd::count.desc()))
-        .load::<DescriptionText>(conn)?;
-
-    let top_n = top_n::top_n_text
-        .inner_join(cd::column_description.on(cd::id.eq(top_n::description_id)))
-        .select((cd::column_index, top_n::value, top_n::count))
-        .filter(cd::id.eq_any(description_ids))
-        .order_by(cd::column_index.asc())
-        .load::<TopNText>(conn)?;
-
-    Ok((column_descriptions, top_n))
-}
-
-pub(super) async fn async_get_text_statistics(
-    mut conn: diesel_async::pg::AsyncPgConnection,
-    description_ids: &[i32],
-) -> Result<Vec<Statistics>, Error> {
-    use diesel_async::RunQueryDsl;
-
     let column_descriptions = desc::description_text
         .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
         .select((cd::column_index, cd::count, cd::unique_count, desc::mode))

--- a/src/csv_indicator.rs
+++ b/src/csv_indicator.rs
@@ -1,69 +1,18 @@
 use crate::{
     schema::{csv_column_list, csv_indicator, csv_whitelist},
-    BlockingPgConn, Error,
+    Error,
 };
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
+use diesel_async::{pg::AsyncPgConnection, RunQueryDsl};
 use std::collections::HashMap;
 
-pub(crate) fn get_whitelists(
-    conn: &mut BlockingPgConn,
-    model_id: i32,
-    column_indices: &[usize],
-) -> HashMap<usize, String> {
-    use csv_column_list::dsl as list_d;
-    use csv_whitelist::dsl as w_d;
-    use diesel::RunQueryDsl;
-
-    let whitelist_names = match list_d::csv_column_list
-        .select(list_d::column_whitelist)
-        .filter(list_d::model_id.eq(model_id))
-        .get_result::<Option<Vec<String>>>(conn)
-    {
-        Ok(names) => names,
-        Err(_) => None,
-    };
-    let whitelists: HashMap<usize, String> = whitelist_names.map_or_else(HashMap::new, |names| {
-        let whitelist_names_indices: HashMap<String, usize> = column_indices
-            .iter()
-            .filter_map(|i| {
-                names.get(*i).and_then(|n| {
-                    if n.is_empty() {
-                        None
-                    } else {
-                        Some((n.clone(), *i))
-                    }
-                })
-            })
-            .collect();
-        let whitelist_names: Vec<String> = whitelist_names_indices
-            .keys()
-            .map(std::clone::Clone::clone)
-            .collect();
-        let whitelists: Vec<(String, String)> = match w_d::csv_whitelist
-            .select((w_d::name, w_d::list))
-            .filter(w_d::name.eq_any(&whitelist_names))
-            .get_results::<(String, String)>(conn)
-        {
-            Ok(lists) => lists,
-            Err(_) => Vec::new(),
-        };
-        whitelists
-            .into_iter()
-            .map(|(name, value)| (*whitelist_names_indices.get(&name).expect(""), value))
-            .collect()
-    });
-
-    whitelists
-}
-
-pub(crate) async fn async_get_whitelists(
-    conn: &mut diesel_async::pg::AsyncPgConnection,
+pub(crate) async fn get_whitelists(
+    conn: &mut AsyncPgConnection,
     model_id: i32,
     column_indices: &[usize],
 ) -> Result<HashMap<usize, String>, Error> {
     use csv_column_list::dsl as list_d;
     use csv_whitelist::dsl as w_d;
-    use diesel_async::RunQueryDsl;
 
     let Some(Some(whitelist_names)) = list_d::csv_column_list
         .select(list_d::column_whitelist)
@@ -103,70 +52,13 @@ pub(crate) async fn async_get_whitelists(
         .collect())
 }
 
-pub(crate) fn get_csv_indicators(
-    conn: &mut BlockingPgConn,
-    model_id: i32,
-    column_indices: &[usize],
-) -> HashMap<usize, String> {
-    use csv_column_list::dsl as list_d;
-    use csv_indicator::dsl as i_d;
-    use diesel::RunQueryDsl;
-
-    let indicator_names = match list_d::csv_column_list
-        .select(list_d::column_indicator)
-        .filter(list_d::model_id.eq(model_id))
-        .get_result::<Option<Vec<String>>>(conn)
-    {
-        Ok(names) => names,
-        Err(_) => None,
-    };
-    let indicators: HashMap<usize, String> = indicator_names.map_or_else(HashMap::new, |names| {
-        let indicator_names_indices: HashMap<String, usize> = column_indices
-            .iter()
-            .filter_map(|i| {
-                names.get(*i).and_then(|n| {
-                    if n.is_empty() {
-                        None
-                    } else {
-                        Some((n.clone(), *i))
-                    }
-                })
-            })
-            .collect();
-        let indicator_names: Vec<String> = indicator_names_indices
-            .keys()
-            .map(std::clone::Clone::clone)
-            .collect();
-        let indicators: Vec<(String, String)> = match i_d::csv_indicator
-            .select((i_d::name, i_d::list))
-            .filter(i_d::name.eq_any(&indicator_names))
-            .get_results::<(String, String)>(conn)
-        {
-            Ok(lists) => lists,
-            Err(_) => Vec::new(),
-        };
-        indicators
-            .into_iter()
-            .map(|(name, value)| {
-                (
-                    *indicator_names_indices.get(&name).expect("already checked"),
-                    value,
-                )
-            })
-            .collect()
-    });
-
-    indicators
-}
-
-pub(crate) async fn async_get_csv_indicators(
-    conn: &mut diesel_async::pg::AsyncPgConnection,
+pub(crate) async fn get_csv_indicators(
+    conn: &mut AsyncPgConnection,
     model_id: i32,
     column_indices: &[usize],
 ) -> Result<HashMap<usize, String>, Error> {
     use csv_column_list::dsl as list_d;
     use csv_indicator::dsl as i_d;
-    use diesel_async::RunQueryDsl;
 
     let Some(Some(indicator_names)) = list_d::csv_column_list
         .select(list_d::column_indicator)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,6 @@ pub use self::collections::{
     Indexable, Indexed, IndexedMap, IndexedMapIterator, IndexedMapUpdate, IndexedMultimap,
     IndexedSet, IterableMap, Map, MapIterator,
 };
-pub use self::column_statistics::round::{RoundByCluster, RoundByModel};
 pub use self::column_statistics::*;
 pub use self::csv_column_extra::CsvColumnExtraConfig;
 pub use self::event::EventKind;

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 /// current version. When the database format changes, this requirement must be
 /// updated to match the new version, and the migration code must be added to
 /// the `migrate_data_dir` function.
-const DATABASE_VERSION_REQ: &str = ">=0.3.0,<0.5.0-alpha.3";
+const DATABASE_VERSION_REQ: &str = ">=0.3.0,<0.5.0-alpha.4";
 
 /// Migrates the data directory to the up-to-date format if necessary.
 ///

--- a/src/top_n/column.rs
+++ b/src/top_n/column.rs
@@ -1,19 +1,19 @@
 use super::{
-    filter_by_whitelists, get_cluster_sizes, get_limited_cluster_ids, limited_top_n_of_clusters,
-    total_of_top_n, TopElementCountsByColumn, TopNOfMultipleCluster, ValueType,
-    DEFAULT_NUMBER_OF_CLUSTER, DEFAULT_NUMBER_OF_COLUMN, DEFAULT_PORTION_OF_CLUSTER,
-    DEFAULT_PORTION_OF_TOP_N,
+    filter_by_whitelists, get_limited_cluster_ids, limited_top_n_of_clusters, total_of_top_n,
+    TopElementCountsByColumn, TopNOfMultipleCluster, ValueType, DEFAULT_NUMBER_OF_CLUSTER,
+    DEFAULT_NUMBER_OF_COLUMN, DEFAULT_PORTION_OF_CLUSTER, DEFAULT_PORTION_OF_TOP_N,
 };
 use crate::{
-    csv_indicator::{async_get_whitelists, get_whitelists},
+    csv_indicator::get_whitelists,
     schema::{
         cluster, column_description, csv_column_extra, event_range, top_n_binary, top_n_datetime,
         top_n_enum, top_n_float, top_n_int, top_n_ipaddr, top_n_text,
     },
-    BlockingPgConn, Database, Error, StructuredColumnType,
+    Database, Error,
 };
 use chrono::NaiveDateTime;
 use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, OptionalExtension, QueryDsl};
+use diesel_async::{pg::AsyncPgConnection, RunQueryDsl};
 use num_traits::ToPrimitive;
 use std::collections::HashSet;
 use structured::{Element, FloatRange};
@@ -24,55 +24,6 @@ use event_range::dsl as e_d;
 
 macro_rules! get_top_n_of_column {
     ($conn:expr, $top_d:ident, $top_table:ident, $value_type:ty, $c:expr, $i:expr, $tc:expr, $time:expr) => {{
-        use diesel::RunQueryDsl;
-
-        let query = c_d::cluster
-            .inner_join(e_d::event_range.on(c_d::id.eq(e_d::cluster_id)))
-            .inner_join(col_d::column_description.on(col_d::event_range_id.eq(e_d::id)))
-            .inner_join($top_d::$top_table.on(top_d::description_id.eq(col_d::id)))
-            .select((
-                e_d::cluster_id,
-                col_d::column_index,
-                col_d::id,
-                top_d::value,
-                top_d::count,
-            ));
-        let top_n = if let Some(time) = $time {
-            query
-                .filter(
-                    c_d::id
-                        .eq_any($c)
-                        .and(e_d::time.eq(time))
-                        .and(col_d::column_index.eq($i)),
-                )
-                .load::<(i32, i32, i32, $value_type, i64)>($conn)?
-        } else {
-            query
-                .filter(c_d::id.eq_any($c).and(col_d::column_index.eq($i)))
-                .load::<(i32, i32, i32, $value_type, i64)>($conn)?
-        };
-
-        let mut top_n: Vec<TopNOfMultipleCluster> = top_n
-            .into_iter()
-            .map(|t| {
-                let value = ValueType::into_string(t.3);
-                TopNOfMultipleCluster {
-                    cluster_id: t.0,
-                    column_index: t.1,
-                    _description_id: t.2,
-                    value,
-                    count: t.4,
-                }
-            })
-            .collect();
-        $tc.append(&mut top_n);
-    }};
-}
-
-macro_rules! async_get_top_n_of_column {
-    ($conn:expr, $top_d:ident, $top_table:ident, $value_type:ty, $c:expr, $i:expr, $tc:expr, $time:expr) => {{
-        use diesel_async::RunQueryDsl;
-
         let query = c_d::cluster
             .inner_join(e_d::event_range.on(c_d::id.eq(e_d::cluster_id)))
             .inner_join(col_d::column_description.on(col_d::event_range_id.eq(e_d::id)))
@@ -118,37 +69,11 @@ macro_rules! async_get_top_n_of_column {
     }};
 }
 
-pub(super) fn get_columns_for_top_n(conn: &mut BlockingPgConn, model_id: i32) -> Vec<i32> {
-    use csv_column_extra::dsl as column_d;
-    use diesel::RunQueryDsl;
-
-    match column_d::csv_column_extra
-        .select(column_d::column_top_n)
-        .filter(column_d::model_id.eq(model_id))
-        .first::<Option<Vec<bool>>>(conn)
-    {
-        Ok(columns) => columns.map_or_else(Vec::new, |c| {
-            c.iter()
-                .enumerate()
-                .filter_map(|(index, is)| {
-                    if *is {
-                        Some(index.to_i32().expect("column index < i32::max"))
-                    } else {
-                        None
-                    }
-                })
-                .collect()
-        }),
-        Err(_) => Vec::new(),
-    }
-}
-
-pub(super) async fn async_get_columns_for_top_n(
-    conn: &mut diesel_async::pg::AsyncPgConnection,
+pub(super) async fn get_columns_for_top_n(
+    conn: &mut AsyncPgConnection,
     model_id: i32,
 ) -> Result<Vec<i32>, Error> {
     use csv_column_extra::dsl as column_d;
-    use diesel_async::RunQueryDsl;
 
     let Some(Some(columns)) = column_d::csv_column_extra
         .select(column_d::column_top_n)
@@ -173,65 +98,12 @@ pub(super) async fn async_get_columns_for_top_n(
 }
 
 #[allow(clippy::type_complexity)]
-fn top_n_of_float(
-    conn: &mut BlockingPgConn,
+async fn top_n_of_float(
+    conn: &mut AsyncPgConnection,
     cluster_ids: &[i32],
     index: i32,
     time: Option<NaiveDateTime>,
 ) -> Result<Vec<(i32, i32, i32, f64, f64, i64)>, diesel::result::Error> {
-    use diesel::RunQueryDsl;
-    use top_n_float::dsl as top_d;
-    time.as_ref().map_or(
-        c_d::cluster
-            .inner_join(e_d::event_range.on(c_d::id.eq(e_d::cluster_id)))
-            .inner_join(col_d::column_description.on(col_d::event_range_id.eq(e_d::id)))
-            .inner_join(top_d::top_n_float.on(top_d::description_id.eq(col_d::id)))
-            .select((
-                e_d::cluster_id,
-                col_d::column_index,
-                col_d::id,
-                top_d::value_smallest,
-                top_d::value_largest,
-                top_d::count,
-            ))
-            .filter(
-                c_d::id
-                    .eq_any(cluster_ids)
-                    .and(col_d::column_index.eq(&index)),
-            )
-            .load::<(i32, i32, i32, f64, f64, i64)>(conn),
-        |time| {
-            c_d::cluster
-                .inner_join(e_d::event_range.on(c_d::id.eq(e_d::cluster_id)))
-                .inner_join(col_d::column_description.on(col_d::event_range_id.eq(e_d::id)))
-                .inner_join(top_d::top_n_float.on(top_d::description_id.eq(col_d::id)))
-                .select((
-                    e_d::cluster_id,
-                    col_d::column_index,
-                    col_d::id,
-                    top_d::value_smallest,
-                    top_d::value_largest,
-                    top_d::count,
-                ))
-                .filter(
-                    c_d::id
-                        .eq_any(cluster_ids)
-                        .and(e_d::time.eq(time))
-                        .and(col_d::column_index.eq(&index)),
-                )
-                .load::<(i32, i32, i32, f64, f64, i64)>(conn)
-        },
-    )
-}
-
-#[allow(clippy::type_complexity)]
-async fn async_top_n_of_float(
-    conn: &mut diesel_async::pg::AsyncPgConnection,
-    cluster_ids: &[i32],
-    index: i32,
-    time: Option<NaiveDateTime>,
-) -> Result<Vec<(i32, i32, i32, f64, f64, i64)>, diesel::result::Error> {
-    use diesel_async::RunQueryDsl;
     use top_n_float::dsl as top_d;
 
     let query = c_d::cluster
@@ -269,146 +141,6 @@ async fn async_top_n_of_float(
     }
 }
 
-#[allow(clippy::too_many_lines)]
-pub(crate) fn get_top_columns_of_model(
-    conn: &mut BlockingPgConn,
-    model_id: i32,
-    number_of_top_n: usize,
-    time: Option<NaiveDateTime>,
-    portion_of_clusters: Option<f64>,
-    portion_of_top_n: Option<f64>,
-    mut column_types: Vec<StructuredColumnType>,
-) -> Result<Vec<TopElementCountsByColumn>, Error> {
-    let columns_for_top_n = get_columns_for_top_n(conn, model_id);
-    let columns_for_top_n: HashSet<i32> = columns_for_top_n.into_iter().collect();
-    column_types.retain(|c| columns_for_top_n.get(&c.column_index).is_some());
-
-    let cluster_sizes = get_cluster_sizes(conn, model_id)?;
-    let cluster_ids = get_limited_cluster_ids(
-        &cluster_sizes,
-        portion_of_clusters.unwrap_or(DEFAULT_PORTION_OF_CLUSTER),
-        DEFAULT_NUMBER_OF_CLUSTER,
-    );
-
-    let mut top_n_of_cluster: Vec<TopNOfMultipleCluster> = Vec::new();
-
-    for c in column_types {
-        let index = c.column_index;
-        match c.data_type.as_str() {
-            "int64" => {
-                use top_n_int::dsl as top_d;
-                get_top_n_of_column!(
-                    conn,
-                    top_d,
-                    top_n_int,
-                    i64,
-                    &cluster_ids,
-                    &index,
-                    top_n_of_cluster,
-                    time
-                );
-            }
-            "enum" => {
-                use top_n_enum::dsl as top_d;
-                get_top_n_of_column!(
-                    conn,
-                    top_d,
-                    top_n_enum,
-                    String,
-                    &cluster_ids,
-                    &index,
-                    top_n_of_cluster,
-                    time
-                );
-            }
-            "float64" => {
-                let top_n = top_n_of_float(conn, &cluster_ids, index, time)?;
-                let mut top_n: Vec<TopNOfMultipleCluster> = top_n
-                    .into_iter()
-                    .map(|t| {
-                        let value = Element::FloatRange(FloatRange {
-                            smallest: t.3,
-                            largest: t.4,
-                        })
-                        .to_string();
-                        TopNOfMultipleCluster {
-                            cluster_id: t.0,
-                            column_index: t.1,
-                            _description_id: t.2,
-                            value,
-                            count: t.5,
-                        }
-                    })
-                    .collect();
-                top_n_of_cluster.append(&mut top_n);
-            }
-            "utf8" => {
-                use top_n_text::dsl as top_d;
-                get_top_n_of_column!(
-                    conn,
-                    top_d,
-                    top_n_text,
-                    String,
-                    &cluster_ids,
-                    &index,
-                    top_n_of_cluster,
-                    time
-                );
-            }
-            "ipaddr" => {
-                use top_n_ipaddr::dsl as top_d;
-                get_top_n_of_column!(
-                    conn,
-                    top_d,
-                    top_n_ipaddr,
-                    String,
-                    &cluster_ids,
-                    &index,
-                    top_n_of_cluster,
-                    time
-                );
-            }
-            "datetime" => {
-                use top_n_datetime::dsl as top_d;
-                get_top_n_of_column!(
-                    conn,
-                    top_d,
-                    top_n_datetime,
-                    NaiveDateTime,
-                    &cluster_ids,
-                    &index,
-                    top_n_of_cluster,
-                    time
-                );
-            }
-            "binary" => {
-                use top_n_binary::dsl as top_d;
-                get_top_n_of_column!(
-                    conn,
-                    top_d,
-                    top_n_binary,
-                    Vec<u8>,
-                    &cluster_ids,
-                    &index,
-                    top_n_of_cluster,
-                    time
-                );
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    let top_n = total_of_top_n(top_n_of_cluster);
-    let top_n = limited_top_n_of_clusters(
-        top_n,
-        portion_of_top_n.unwrap_or(DEFAULT_PORTION_OF_TOP_N),
-        DEFAULT_NUMBER_OF_COLUMN,
-    );
-    let column_indices: Vec<usize> = top_n.keys().copied().collect();
-    let whitelists = get_whitelists(conn, model_id, &column_indices);
-    Ok(filter_by_whitelists(top_n, &whitelists, number_of_top_n))
-}
-
 impl Database {
     #[allow(clippy::too_many_lines)]
     pub async fn get_top_columns_of_model(
@@ -420,12 +152,12 @@ impl Database {
         portion_of_top_n: Option<f64>,
     ) -> Result<Vec<TopElementCountsByColumn>, Error> {
         let mut conn = self.pool.get_diesel_conn().await?;
-        let columns_for_top_n = async_get_columns_for_top_n(&mut conn, model_id).await?;
+        let columns_for_top_n = get_columns_for_top_n(&mut conn, model_id).await?;
         let columns_for_top_n: HashSet<i32> = columns_for_top_n.into_iter().collect();
         let mut column_types = self.get_column_types_of_model(model_id).await?;
         column_types.retain(|c| columns_for_top_n.get(&c.column_index).is_some());
 
-        let cluster_sizes = super::async_get_cluster_sizes(&mut conn, model_id).await?;
+        let cluster_sizes = super::get_cluster_sizes(&mut conn, model_id).await?;
         let cluster_ids = get_limited_cluster_ids(
             &cluster_sizes,
             portion_of_clusters.unwrap_or(DEFAULT_PORTION_OF_CLUSTER),
@@ -439,7 +171,7 @@ impl Database {
             match c.data_type.as_str() {
                 "int64" => {
                     use top_n_int::dsl as top_d;
-                    async_get_top_n_of_column!(
+                    get_top_n_of_column!(
                         &mut conn,
                         top_d,
                         top_n_int,
@@ -452,7 +184,7 @@ impl Database {
                 }
                 "enum" => {
                     use top_n_enum::dsl as top_d;
-                    async_get_top_n_of_column!(
+                    get_top_n_of_column!(
                         &mut conn,
                         top_d,
                         top_n_enum,
@@ -464,7 +196,7 @@ impl Database {
                     );
                 }
                 "float64" => {
-                    let top_n = async_top_n_of_float(&mut conn, &cluster_ids, index, time).await?;
+                    let top_n = top_n_of_float(&mut conn, &cluster_ids, index, time).await?;
                     let mut top_n: Vec<TopNOfMultipleCluster> = top_n
                         .into_iter()
                         .map(|t| {
@@ -486,7 +218,7 @@ impl Database {
                 }
                 "utf8" => {
                     use top_n_text::dsl as top_d;
-                    async_get_top_n_of_column!(
+                    get_top_n_of_column!(
                         &mut conn,
                         top_d,
                         top_n_text,
@@ -499,7 +231,7 @@ impl Database {
                 }
                 "ipaddr" => {
                     use top_n_ipaddr::dsl as top_d;
-                    async_get_top_n_of_column!(
+                    get_top_n_of_column!(
                         &mut conn,
                         top_d,
                         top_n_ipaddr,
@@ -512,7 +244,7 @@ impl Database {
                 }
                 "datetime" => {
                     use top_n_datetime::dsl as top_d;
-                    async_get_top_n_of_column!(
+                    get_top_n_of_column!(
                         &mut conn,
                         top_d,
                         top_n_datetime,
@@ -525,7 +257,7 @@ impl Database {
                 }
                 "binary" => {
                     use top_n_binary::dsl as top_d;
-                    async_get_top_n_of_column!(
+                    get_top_n_of_column!(
                         &mut conn,
                         top_d,
                         top_n_binary,
@@ -547,7 +279,7 @@ impl Database {
             DEFAULT_NUMBER_OF_COLUMN,
         );
         let column_indices: Vec<usize> = top_n.keys().copied().collect();
-        let whitelists = async_get_whitelists(&mut conn, model_id, &column_indices).await?;
+        let whitelists = get_whitelists(&mut conn, model_id, &column_indices).await?;
         Ok(filter_by_whitelists(top_n, &whitelists, number_of_top_n))
     }
 }

--- a/src/top_n/ipaddr.rs
+++ b/src/top_n/ipaddr.rs
@@ -6,12 +6,13 @@ use super::{
 };
 use crate::{
     self as database,
-    csv_indicator::{async_get_whitelists, get_whitelists},
+    csv_indicator::get_whitelists,
     schema::{cluster, column_description, event_range, top_n_ipaddr},
-    BlockingPgConn, Database, Error,
+    Database, Error,
 };
 use chrono::NaiveDateTime;
 use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
+use diesel_async::{pg::AsyncPgConnection, RunQueryDsl};
 use num_traits::ToPrimitive;
 use std::collections::HashMap;
 
@@ -20,133 +21,11 @@ use column_description::dsl as col_d;
 use event_range::dsl as e_d;
 use top_n_ipaddr::dsl as top_d;
 
-pub(crate) fn get_top_ip_addresses_of_cluster(
-    conn: &mut BlockingPgConn,
-    model_id: i32,
-    cluster_id: &str,
-    size: usize,
-) -> Result<Vec<TopElementCountsByColumn>, Error> {
-    use diesel::RunQueryDsl;
-
-    let values = c_d::cluster
-        .inner_join(e_d::event_range.on(c_d::id.eq(e_d::cluster_id)))
-        .inner_join(col_d::column_description.on(col_d::event_range_id.eq(e_d::id)))
-        .inner_join(top_d::top_n_ipaddr.on(top_d::description_id.eq(col_d::id)))
-        .select((col_d::column_index, col_d::id, top_d::value, top_d::count))
-        .filter(
-            c_d::model_id
-                .eq(model_id)
-                .and(c_d::cluster_id.eq(cluster_id)),
-        )
-        .load::<TopNOfCluster>(conn)?;
-
-    let mut top_n: HashMap<usize, HashMap<String, i64>> = HashMap::new(); // String: Ip Address
-    for v in values {
-        if let (Some(column_index), value, count) = (v.column_index.to_usize(), v.value, v.count) {
-            *top_n
-                .entry(column_index)
-                .or_insert_with(HashMap::<String, i64>::new)
-                .entry(value)
-                .or_insert(0) += count;
-        }
-    }
-
-    let mut top_n: Vec<TopElementCountsByColumn> = top_n
-        .into_iter()
-        .map(|t| {
-            let mut top_n: Vec<ElementCount> =
-                t.1.into_iter()
-                    .map(|t| ElementCount {
-                        value: t.0,
-                        count: t.1,
-                    })
-                    .collect();
-            top_n.sort_by(|a, b| b.count.cmp(&a.count));
-            top_n.truncate(size);
-            TopElementCountsByColumn {
-                column_index: t.0,
-                counts: top_n,
-            }
-        })
-        .collect();
-    top_n.sort_by(|a, b| a.column_index.cmp(&b.column_index));
-    Ok(top_n)
-}
-
-pub(crate) fn get_top_ip_addresses_of_model(
-    conn: &mut BlockingPgConn,
-    model_id: i32,
-    size: usize,
-    time: Option<NaiveDateTime>,
-    portion_of_clusters: Option<f64>,
-    portion_of_top_n: Option<f64>,
-) -> Result<Vec<TopElementCountsByColumn>, Error> {
-    let cluster_sizes = get_cluster_sizes(conn, model_id)?;
-    let cluster_ids = get_limited_cluster_ids(
-        &cluster_sizes,
-        portion_of_clusters.unwrap_or(DEFAULT_PORTION_OF_CLUSTER),
-        DEFAULT_NUMBER_OF_CLUSTER,
-    );
-
-    let top_n = get_top_n_of_multiple_clusters(conn, &cluster_ids, time)?;
-    let top_n = total_of_top_n(top_n);
-    let top_n = limited_top_n_of_clusters(
-        top_n,
-        portion_of_top_n.unwrap_or(DEFAULT_PORTION_OF_TOP_N),
-        DEFAULT_NUMBER_OF_COLUMN,
-    );
-    let column_indices: Vec<usize> = top_n.keys().copied().collect();
-    let whitelists = get_whitelists(conn, model_id, &column_indices);
-    Ok(filter_by_whitelists(top_n, &whitelists, size))
-}
-
-fn get_top_n_of_multiple_clusters(
-    conn: &mut BlockingPgConn,
+async fn get_top_n_of_multiple_clusters(
+    conn: &mut AsyncPgConnection,
     cluster_ids: &[i32],
     time: Option<NaiveDateTime>,
 ) -> Result<Vec<TopNOfMultipleCluster>, database::Error> {
-    use diesel::RunQueryDsl;
-
-    let top_n_of_multiple_clusters = if let Some(time) = time {
-        c_d::cluster
-            .inner_join(e_d::event_range.on(c_d::id.eq(e_d::cluster_id)))
-            .inner_join(col_d::column_description.on(col_d::event_range_id.eq(e_d::id)))
-            .inner_join(top_d::top_n_ipaddr.on(top_d::description_id.eq(col_d::id)))
-            .select((
-                c_d::id,
-                col_d::column_index,
-                col_d::id,
-                top_d::value,
-                top_d::count,
-            ))
-            .filter(e_d::time.eq(time).and(c_d::id.eq_any(cluster_ids)))
-            .load::<TopNOfMultipleCluster>(conn)?
-    } else {
-        c_d::cluster
-            .inner_join(e_d::event_range.on(c_d::id.eq(e_d::cluster_id)))
-            .inner_join(col_d::column_description.on(col_d::event_range_id.eq(e_d::id)))
-            .inner_join(top_d::top_n_ipaddr.on(top_d::description_id.eq(col_d::id)))
-            .select((
-                c_d::id,
-                col_d::column_index,
-                col_d::id,
-                top_d::value,
-                top_d::count,
-            ))
-            .filter(c_d::id.eq_any(cluster_ids))
-            .load::<TopNOfMultipleCluster>(conn)?
-    };
-
-    Ok(top_n_of_multiple_clusters)
-}
-
-async fn async_get_top_n_of_multiple_clusters(
-    conn: &mut diesel_async::pg::AsyncPgConnection,
-    cluster_ids: &[i32],
-    time: Option<NaiveDateTime>,
-) -> Result<Vec<TopNOfMultipleCluster>, database::Error> {
-    use diesel_async::RunQueryDsl;
-
     let top_n_of_multiple_clusters = if let Some(time) = time {
         c_d::cluster
             .inner_join(e_d::event_range.on(c_d::id.eq(e_d::cluster_id)))
@@ -189,8 +68,6 @@ impl Database {
         cluster_id: &str,
         size: usize,
     ) -> Result<Vec<TopElementCountsByColumn>, Error> {
-        use diesel_async::RunQueryDsl;
-
         let mut conn = self.pool.get_diesel_conn().await?;
         let values = c_d::cluster
             .inner_join(e_d::event_range.on(c_d::id.eq(e_d::cluster_id)))
@@ -249,14 +126,14 @@ impl Database {
         portion_of_top_n: Option<f64>,
     ) -> Result<Vec<TopElementCountsByColumn>, Error> {
         let mut conn = self.pool.get_diesel_conn().await?;
-        let cluster_sizes = super::async_get_cluster_sizes(&mut conn, model_id).await?;
+        let cluster_sizes = get_cluster_sizes(&mut conn, model_id).await?;
         let cluster_ids = get_limited_cluster_ids(
             &cluster_sizes,
             portion_of_clusters.unwrap_or(DEFAULT_PORTION_OF_CLUSTER),
             DEFAULT_NUMBER_OF_CLUSTER,
         );
 
-        let top_n = async_get_top_n_of_multiple_clusters(&mut conn, &cluster_ids, time).await?;
+        let top_n = get_top_n_of_multiple_clusters(&mut conn, &cluster_ids, time).await?;
         let top_n = total_of_top_n(top_n);
         let top_n = limited_top_n_of_clusters(
             top_n,
@@ -264,7 +141,7 @@ impl Database {
             DEFAULT_NUMBER_OF_COLUMN,
         );
         let column_indices: Vec<usize> = top_n.keys().copied().collect();
-        let whitelists = async_get_whitelists(&mut conn, model_id, &column_indices).await?;
+        let whitelists = get_whitelists(&mut conn, model_id, &column_indices).await?;
         Ok(filter_by_whitelists(top_n, &whitelists, size))
     }
 }

--- a/src/top_n/one_to_n.rs
+++ b/src/top_n/one_to_n.rs
@@ -5,12 +5,15 @@ use crate::{
         cluster, column_description, csv_column_extra, event_range, model, top_n_binary,
         top_n_datetime, top_n_enum, top_n_float, top_n_int, top_n_ipaddr, top_n_text,
     },
-    BlockingPgConn, Database, Error,
+    Database, Error,
 };
 use chrono::NaiveDateTime;
-use diesel::sql_query;
-use diesel::sql_types::{BigInt, Integer, Text};
-use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
+use diesel::{
+    sql_query,
+    sql_types::{BigInt, Integer, Text},
+    BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl,
+};
+use diesel_async::{pg::AsyncPgConnection, RunQueryDsl};
 use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -123,253 +126,8 @@ use csv_column_extra::dsl as column_d;
 use event_range::dsl as e_d;
 use model::dsl as m_d;
 
-#[allow(clippy::too_many_lines)]
-pub(crate) fn get_top_multimaps_of_model(
-    conn: &mut BlockingPgConn,
-    model_id: i32,
-    number_of_top_n: usize,
-    min_top_n_of_1_to_n: usize,
-    time: Option<NaiveDateTime>,
-    column_types: Vec<StructuredColumnType>,
-) -> Result<Vec<TopMultimaps>, Error> {
-    use diesel::RunQueryDsl;
-
-    let column_types: HashMap<usize, String> = column_types
-        .into_iter()
-        .map(|c| (c.column_index.to_usize().expect("safe"), c.data_type))
-        .collect();
-
-    let columns_for_1_to_n = column_d::csv_column_extra
-        .select((column_d::column_1, column_d::column_n))
-        .filter(column_d::model_id.eq(model_id))
-        .first::<(Option<Vec<bool>>, Option<Vec<bool>>)>(conn)?;
-
-    let columns_for_1: Vec<usize> = columns_for_1_to_n.0.map_or_else(Vec::new, |c| {
-        c.iter()
-            .enumerate()
-            .filter_map(|(index, is)| if *is { Some(index) } else { None })
-            .collect()
-    });
-
-    let columns_for_n: Vec<usize> = columns_for_1_to_n.1.map_or_else(Vec::new, |c| {
-        c.iter()
-            .enumerate()
-            .filter_map(|(index, is)| if *is { Some(index) } else { None })
-            .collect()
-    });
-
-    let mut top_n_transfer: Vec<TopMultimaps> = Vec::new();
-    for column_n in &columns_for_n {
-        let column_type: &str = if let Some(column_type) = column_types.get(column_n) {
-            column_type
-        } else {
-            return Ok(Vec::<TopMultimaps>::new());
-        };
-        let top_table = match column_type {
-            "int64" => "top_n_int",
-            "enum" => "top_n_enum",
-            "float64" => "top_n_float",
-            "utf8" => "top_n_text",
-            "ipaddr" => "top_n_ipaddr",
-            "datetime" => "top_n_datetime",
-            "binary" => "top_n_binary",
-            _ => unreachable!(),
-        };
-
-        let q = if let Some(time) = time {
-            format!(
-                r#"SELECT model.id as model_id, col.column_index, cluster.cluster_id, first_event_id, last_event_id, top.description_id, COUNT(top.id) as count
-                    FROM {} AS top
-                    INNER JOIN column_description AS col ON top.description_id = col.id
-                    INNER JOIN event_range AS ev ON ev.id = col.event_range_id
-                    INNER JOIN cluster ON cluster.id = ev.cluster_id
-                    INNER JOIN model ON cluster.model_id = model.id
-                    GROUP BY model.id, cluster.cluster_id, col.column_index, first_event_id, last_event_id, top.description_id, cluster.category_id, ev.time
-                    HAVING COUNT(top.id) > {} AND model.id = {} AND col.column_index = {} AND cluster.category_id != 2 AND ev.time = '{}'
-                    ORDER BY COUNT(top.id) DESC"#,
-                top_table, min_top_n_of_1_to_n, model_id, *column_n, time
-            )
-        } else {
-            format!(
-                r#"SELECT model.id as model_id, col.column_index, cluster.cluster_id, first_event_id, last_event_id, top.description_id, COUNT(top.id) as count
-                    FROM {} AS top
-                    INNER JOIN column_description AS col ON top.description_id = col.id
-                    INNER JOIN event_range AS ev ON ev.id = col.event_range_id
-                    INNER JOIN cluster ON cluster.id = ev.cluster_id
-                    INNER JOIN model ON cluster.model_id = model.id
-                    GROUP BY model.id, cluster.cluster_id, col.column_index, first_event_id, last_event_id, top.description_id, cluster.category_id, ev.time
-                    HAVING COUNT(top.id) > {} AND model.id = {} AND col.column_index = {} AND cluster.category_id != 2
-                    ORDER BY COUNT(top.id) DESC"#,
-                top_table, min_top_n_of_1_to_n, model_id, *column_n
-            )
-        };
-
-        let selected_clusters = sql_query(q).load::<SelectedCluster>(conn)?;
-
-        let mut sorted_clusters: HashMap<String, Vec<(i64, i64, i64)>> = HashMap::new();
-        for cluster in selected_clusters {
-            sorted_clusters
-                .entry(cluster.cluster_id)
-                .or_insert_with(Vec::<(i64, i64, i64)>::new)
-                .push((cluster.first_event_id, cluster.last_event_id, cluster.count));
-        }
-        for top_n in sorted_clusters.values_mut() {
-            top_n.sort_by(|a, b| b.0.cmp(&a.0)); // recent one among rounds is more important. (assuming recent event id is bigger)
-            top_n.sort_by(|a, b| b.2.cmp(&a.2));
-        }
-
-        let mut sorted_clusters: Vec<(String, i64, i64, i64)> = sorted_clusters // cluster_id, first_event_id, last_event_id, count
-            .into_iter()
-            .map(|(cluster_id, top_n)| (cluster_id, top_n[0].0, top_n[0].1, top_n[0].2))
-            .collect();
-        // HIGHLIGHT: take the biggest round only in each cluster
-        sorted_clusters.sort_by(|a, b| a.0.cmp(&b.0)); // first, sort clusters by alphabetical order
-        sorted_clusters.sort_by(|a, b| b.3.cmp(&a.3)); // then, sort by count
-        sorted_clusters.truncate(number_of_top_n);
-
-        let cluster_ids: Vec<String> = sorted_clusters.iter().map(|c| c.0.clone()).collect();
-        let first_event_ids: Vec<i64> = sorted_clusters.iter().map(|c| c.1).collect();
-        let last_event_ids: Vec<i64> = sorted_clusters.iter().map(|c| c.2).collect();
-
-        let mut top_n_of_clusters: HashMap<String, Vec<TopElementCountsByColumn>> = HashMap::new();
-        for column_1 in &columns_for_1 {
-            let column_type: &str = if let Some(column_type) = column_types.get(column_1) {
-                column_type
-            } else {
-                return Ok(Vec::<TopMultimaps>::new());
-            };
-            let column_index: i32 = if let Some(column_index) = column_1.to_i32() {
-                column_index
-            } else {
-                return Ok(Vec::<TopMultimaps>::new());
-            };
-            let top_n = get_top_n(
-                conn,
-                model_id,
-                &cluster_ids,
-                &first_event_ids,
-                &last_event_ids,
-                column_index,
-                column_type,
-            )?;
-            for (cluster_id, top_n) in top_n {
-                top_n_of_clusters
-                    .entry(cluster_id)
-                    .or_insert_with(Vec::<TopElementCountsByColumn>::new)
-                    .push(TopElementCountsByColumn {
-                        column_index: *column_1,
-                        counts: top_n,
-                    });
-            }
-        }
-
-        for column_n in &columns_for_n {
-            let column_type: &str = if let Some(column_type) = column_types.get(column_n) {
-                column_type
-            } else {
-                return Ok(Vec::<TopMultimaps>::new());
-            };
-            let column_index: i32 = if let Some(column_index) = column_n.to_i32() {
-                column_index
-            } else {
-                return Ok(Vec::<TopMultimaps>::new());
-            };
-            let top_n = get_top_n(
-                conn,
-                model_id,
-                &cluster_ids,
-                &first_event_ids,
-                &last_event_ids,
-                column_index,
-                column_type,
-            )?;
-            for (cluster_id, top_n) in top_n {
-                top_n_of_clusters
-                    .entry(cluster_id)
-                    .or_insert_with(Vec::<TopElementCountsByColumn>::new)
-                    .push(TopElementCountsByColumn {
-                        column_index: *column_n,
-                        counts: top_n,
-                    });
-            }
-        }
-
-        let top_n_of_clusters: Vec<TopColumnsOfCluster> = cluster_ids
-            .into_iter()
-            .map(|cluster_id| {
-                let top_n_of_1_or_n = top_n_of_clusters
-                    .get(&cluster_id)
-                    .expect("should exist")
-                    .clone();
-                TopColumnsOfCluster {
-                    cluster_id,
-                    columns: top_n_of_1_or_n,
-                }
-            })
-            .collect();
-
-        top_n_transfer.push(TopMultimaps {
-            n_index: *column_n,
-            selected: top_n_of_clusters,
-        });
-    }
-    Ok(top_n_transfer)
-}
-
 macro_rules! get_top_n_of_column_by_round {
     ($conn:expr, $top_d:ident, $top_table:ident, $load_type:ty, $d:expr, $c:expr, $f_ei:expr, $l_ei:expr, $index:expr, $func:tt, $top_n:expr) => {{
-        use diesel::RunQueryDsl;
-
-        let top_n = $top_d::$top_table
-            .inner_join(cd_d::column_description.on(cd_d::id.eq($top_d::description_id)))
-            .inner_join(e_d::event_range.on(e_d::id.eq(cd_d::event_range_id)))
-            .inner_join(c_d::cluster.on(c_d::id.eq(e_d::cluster_id)))
-            .inner_join(m_d::model.on(m_d::id.eq(c_d::model_id)))
-            .filter(
-                m_d::id
-                    .eq($d)
-                    .and(c_d::cluster_id.eq_any($c))
-                    .and(e_d::first_event_id.eq_any($f_ei))
-                    .and(e_d::last_event_id.eq_any($l_ei))
-                    .and(cd_d::column_index.eq($index)),
-            )
-            .select((
-                c_d::cluster_id,
-                e_d::first_event_id,
-                e_d::last_event_id,
-                $top_d::description_id,
-                $top_d::value,
-                $top_d::count,
-            ))
-            .load::<$load_type>($conn)?;
-
-        let mut top_n_by_cluster: HashMap<String, Vec<ElementCount>> = HashMap::new();
-        for t in &top_n {
-            let value;
-            $func!(value, &t.value);
-
-            top_n_by_cluster
-                .entry(t.cluster_id.clone())
-                .or_insert_with(Vec::<ElementCount>::new)
-                .push(ElementCount {
-                    value,
-                    count: t.count,
-                });
-        }
-
-        for (_, top_n) in top_n_by_cluster.iter_mut() {
-            top_n.sort_by(|a, b| a.value.cmp(&b.value));
-            top_n.sort_by(|a, b| b.count.cmp(&a.count));
-        }
-
-        $top_n = Ok(top_n_by_cluster);
-    }};
-}
-
-macro_rules! async_get_top_n_of_column_by_round {
-    ($conn:expr, $top_d:ident, $top_table:ident, $load_type:ty, $d:expr, $c:expr, $f_ei:expr, $l_ei:expr, $index:expr, $func:tt, $top_n:expr) => {{
-        use diesel_async::RunQueryDsl;
-
         let top_n = $top_d::$top_table
             .inner_join(cd_d::column_description.on(cd_d::id.eq($top_d::description_id)))
             .inner_join(e_d::event_range.on(e_d::id.eq(cd_d::event_range_id)))
@@ -436,8 +194,8 @@ macro_rules! get_value_of_top_n_round_by_utf8 {
 }
 
 #[allow(clippy::too_many_lines)]
-fn get_top_n(
-    conn: &mut BlockingPgConn,
+async fn get_top_n(
+    conn: &mut AsyncPgConnection,
     model_id: i32,
     cluster_ids: &[String],
     first_event_ids: &[i64],
@@ -483,180 +241,7 @@ fn get_top_n(
             top_n
         }
         "float64" => {
-            use diesel::RunQueryDsl;
             use top_n_float::dsl as ti_d;
-            let top_n = ti_d::top_n_float
-                .inner_join(cd_d::column_description.on(cd_d::id.eq(ti_d::description_id)))
-                .inner_join(e_d::event_range.on(e_d::id.eq(cd_d::event_range_id)))
-                .inner_join(c_d::cluster.on(c_d::id.eq(e_d::cluster_id)))
-                .inner_join(m_d::model.on(m_d::id.eq(c_d::model_id)))
-                .filter(
-                    m_d::id
-                        .eq(model_id)
-                        .and(c_d::cluster_id.eq_any(cluster_ids))
-                        .and(e_d::first_event_id.eq_any(first_event_ids))
-                        .and(e_d::last_event_id.eq_any(last_event_ids))
-                        .and(cd_d::column_index.eq(&column_index)),
-                )
-                .select((
-                    c_d::cluster_id,
-                    e_d::first_event_id,
-                    e_d::last_event_id,
-                    ti_d::description_id,
-                    ti_d::value_smallest,
-                    ti_d::value_largest,
-                    ti_d::count,
-                ))
-                .load::<TopNFloatRound>(conn)?;
-
-            let mut top_n_by_cluster: HashMap<String, Vec<ElementCount>> = HashMap::new();
-            for t in &top_n {
-                let smallest = t.value_smallest;
-                let largest = t.value_largest;
-
-                top_n_by_cluster
-                    .entry(t.cluster_id.clone())
-                    .or_insert_with(Vec::<ElementCount>::new)
-                    .push(ElementCount {
-                        value: Element::FloatRange(FloatRange { smallest, largest }).to_string(),
-                        count: t.count,
-                    });
-            }
-
-            for top_n in top_n_by_cluster.values_mut() {
-                top_n.sort_by(|a, b| a.value.cmp(&b.value));
-                top_n.sort_by(|a, b| b.count.cmp(&a.count));
-            }
-
-            Ok(top_n_by_cluster)
-        }
-        "utf8" => {
-            use top_n_text::dsl as ti_d;
-            let top_n;
-            get_top_n_of_column_by_round!(
-                conn,
-                ti_d,
-                top_n_text,
-                TopNTextRound,
-                model_id,
-                cluster_ids,
-                first_event_ids,
-                last_event_ids,
-                &column_index,
-                get_value_of_top_n_round_by_clone,
-                top_n
-            );
-            top_n
-        }
-        "ipaddr" => {
-            use top_n_ipaddr::dsl as ti_d;
-            let top_n;
-            get_top_n_of_column_by_round!(
-                conn,
-                ti_d,
-                top_n_ipaddr,
-                TopNIpAddrRound,
-                model_id,
-                cluster_ids,
-                first_event_ids,
-                last_event_ids,
-                &column_index,
-                get_value_of_top_n_round_by_clone,
-                top_n
-            );
-            top_n
-        }
-        "datetime" => {
-            use top_n_datetime::dsl as ti_d;
-            let top_n;
-            get_top_n_of_column_by_round!(
-                conn,
-                ti_d,
-                top_n_datetime,
-                TopNDateTimeRound,
-                model_id,
-                cluster_ids,
-                first_event_ids,
-                last_event_ids,
-                &column_index,
-                get_value_of_top_n_round_by_to_string,
-                top_n
-            );
-            top_n
-        }
-        "binary" => {
-            use top_n_binary::dsl as ti_d;
-            let top_n;
-            get_top_n_of_column_by_round!(
-                conn,
-                ti_d,
-                top_n_binary,
-                TopNBinaryRound,
-                model_id,
-                cluster_ids,
-                first_event_ids,
-                last_event_ids,
-                &column_index,
-                get_value_of_top_n_round_by_utf8,
-                top_n
-            );
-            top_n
-        }
-        _ => unreachable!(),
-    }
-}
-
-#[allow(clippy::too_many_lines)]
-async fn async_get_top_n(
-    conn: &mut diesel_async::pg::AsyncPgConnection,
-    model_id: i32,
-    cluster_ids: &[String],
-    first_event_ids: &[i64],
-    last_event_ids: &[i64],
-    column_index: i32,
-    column_type: &str,
-) -> Result<HashMap<String, Vec<ElementCount>>, database::Error> {
-    match column_type {
-        "int64" => {
-            use top_n_int::dsl as ti_d;
-            let top_n;
-            async_get_top_n_of_column_by_round!(
-                conn,
-                ti_d,
-                top_n_int,
-                TopNIntRound,
-                model_id,
-                cluster_ids,
-                first_event_ids,
-                last_event_ids,
-                &column_index,
-                get_value_of_top_n_round_by_to_string,
-                top_n
-            );
-            top_n
-        }
-        "enum" => {
-            use top_n_enum::dsl as ti_d;
-            let top_n;
-            async_get_top_n_of_column_by_round!(
-                conn,
-                ti_d,
-                top_n_enum,
-                TopNEnumRound,
-                model_id,
-                cluster_ids,
-                first_event_ids,
-                last_event_ids,
-                &column_index,
-                get_value_of_top_n_round_by_clone,
-                top_n
-            );
-            top_n
-        }
-        "float64" => {
-            use diesel_async::RunQueryDsl;
-            use top_n_float::dsl as ti_d;
-
             let top_n = ti_d::top_n_float
                 .inner_join(cd_d::column_description.on(cd_d::id.eq(ti_d::description_id)))
                 .inner_join(e_d::event_range.on(e_d::id.eq(cd_d::event_range_id)))
@@ -706,7 +291,7 @@ async fn async_get_top_n(
         "utf8" => {
             use top_n_text::dsl as ti_d;
             let top_n;
-            async_get_top_n_of_column_by_round!(
+            get_top_n_of_column_by_round!(
                 conn,
                 ti_d,
                 top_n_text,
@@ -724,7 +309,7 @@ async fn async_get_top_n(
         "ipaddr" => {
             use top_n_ipaddr::dsl as ti_d;
             let top_n;
-            async_get_top_n_of_column_by_round!(
+            get_top_n_of_column_by_round!(
                 conn,
                 ti_d,
                 top_n_ipaddr,
@@ -742,7 +327,7 @@ async fn async_get_top_n(
         "datetime" => {
             use top_n_datetime::dsl as ti_d;
             let top_n;
-            async_get_top_n_of_column_by_round!(
+            get_top_n_of_column_by_round!(
                 conn,
                 ti_d,
                 top_n_datetime,
@@ -760,7 +345,7 @@ async fn async_get_top_n(
         "binary" => {
             use top_n_binary::dsl as ti_d;
             let top_n;
-            async_get_top_n_of_column_by_round!(
+            get_top_n_of_column_by_round!(
                 conn,
                 ti_d,
                 top_n_binary,
@@ -789,8 +374,6 @@ impl Database {
         time: Option<NaiveDateTime>,
         column_types: Vec<StructuredColumnType>,
     ) -> Result<Vec<TopMultimaps>, Error> {
-        use diesel_async::RunQueryDsl;
-
         let mut conn = self.pool.get_diesel_conn().await?;
         let column_types: HashMap<usize, String> = column_types
             .into_iter()
@@ -903,7 +486,7 @@ impl Database {
                 } else {
                     return Ok(Vec::<TopMultimaps>::new());
                 };
-                let top_n = async_get_top_n(
+                let top_n = get_top_n(
                     &mut conn,
                     model_id,
                     &cluster_ids,
@@ -935,7 +518,7 @@ impl Database {
                 } else {
                     return Ok(Vec::<TopMultimaps>::new());
                 };
-                let top_n = async_get_top_n(
+                let top_n = get_top_n(
                     &mut conn,
                     model_id,
                     &cluster_ids,

--- a/src/top_n/one_to_n.rs
+++ b/src/top_n/one_to_n.rs
@@ -5,12 +5,12 @@ use crate::{
         cluster, column_description, csv_column_extra, event_range, model, top_n_binary,
         top_n_datetime, top_n_enum, top_n_float, top_n_int, top_n_ipaddr, top_n_text,
     },
-    BlockingPgConn, Error,
+    BlockingPgConn, Database, Error,
 };
 use chrono::NaiveDateTime;
-use diesel::prelude::*;
 use diesel::sql_query;
 use diesel::sql_types::{BigInt, Integer, Text};
+use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
 use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -132,6 +132,8 @@ pub(crate) fn get_top_multimaps_of_model(
     time: Option<NaiveDateTime>,
     column_types: Vec<StructuredColumnType>,
 ) -> Result<Vec<TopMultimaps>, Error> {
+    use diesel::RunQueryDsl;
+
     let column_types: HashMap<usize, String> = column_types
         .into_iter()
         .map(|c| (c.column_index.to_usize().expect("safe"), c.data_type))
@@ -316,6 +318,8 @@ pub(crate) fn get_top_multimaps_of_model(
 
 macro_rules! get_top_n_of_column_by_round {
     ($conn:expr, $top_d:ident, $top_table:ident, $load_type:ty, $d:expr, $c:expr, $f_ei:expr, $l_ei:expr, $index:expr, $func:tt, $top_n:expr) => {{
+        use diesel::RunQueryDsl;
+
         let top_n = $top_d::$top_table
             .inner_join(cd_d::column_description.on(cd_d::id.eq($top_d::description_id)))
             .inner_join(e_d::event_range.on(e_d::id.eq(cd_d::event_range_id)))
@@ -338,6 +342,57 @@ macro_rules! get_top_n_of_column_by_round {
                 $top_d::count,
             ))
             .load::<$load_type>($conn)?;
+
+        let mut top_n_by_cluster: HashMap<String, Vec<ElementCount>> = HashMap::new();
+        for t in &top_n {
+            let value;
+            $func!(value, &t.value);
+
+            top_n_by_cluster
+                .entry(t.cluster_id.clone())
+                .or_insert_with(Vec::<ElementCount>::new)
+                .push(ElementCount {
+                    value,
+                    count: t.count,
+                });
+        }
+
+        for (_, top_n) in top_n_by_cluster.iter_mut() {
+            top_n.sort_by(|a, b| a.value.cmp(&b.value));
+            top_n.sort_by(|a, b| b.count.cmp(&a.count));
+        }
+
+        $top_n = Ok(top_n_by_cluster);
+    }};
+}
+
+macro_rules! async_get_top_n_of_column_by_round {
+    ($conn:expr, $top_d:ident, $top_table:ident, $load_type:ty, $d:expr, $c:expr, $f_ei:expr, $l_ei:expr, $index:expr, $func:tt, $top_n:expr) => {{
+        use diesel_async::RunQueryDsl;
+
+        let top_n = $top_d::$top_table
+            .inner_join(cd_d::column_description.on(cd_d::id.eq($top_d::description_id)))
+            .inner_join(e_d::event_range.on(e_d::id.eq(cd_d::event_range_id)))
+            .inner_join(c_d::cluster.on(c_d::id.eq(e_d::cluster_id)))
+            .inner_join(m_d::model.on(m_d::id.eq(c_d::model_id)))
+            .filter(
+                m_d::id
+                    .eq($d)
+                    .and(c_d::cluster_id.eq_any($c))
+                    .and(e_d::first_event_id.eq_any($f_ei))
+                    .and(e_d::last_event_id.eq_any($l_ei))
+                    .and(cd_d::column_index.eq($index)),
+            )
+            .select((
+                c_d::cluster_id,
+                e_d::first_event_id,
+                e_d::last_event_id,
+                $top_d::description_id,
+                $top_d::value,
+                $top_d::count,
+            ))
+            .load::<$load_type>($conn)
+            .await?;
 
         let mut top_n_by_cluster: HashMap<String, Vec<ElementCount>> = HashMap::new();
         for t in &top_n {
@@ -428,6 +483,7 @@ fn get_top_n(
             top_n
         }
         "float64" => {
+            use diesel::RunQueryDsl;
             use top_n_float::dsl as ti_d;
             let top_n = ti_d::top_n_float
                 .inner_join(cd_d::column_description.on(cd_d::id.eq(ti_d::description_id)))
@@ -547,5 +603,378 @@ fn get_top_n(
             top_n
         }
         _ => unreachable!(),
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+async fn async_get_top_n(
+    conn: &mut diesel_async::pg::AsyncPgConnection,
+    model_id: i32,
+    cluster_ids: &[String],
+    first_event_ids: &[i64],
+    last_event_ids: &[i64],
+    column_index: i32,
+    column_type: &str,
+) -> Result<HashMap<String, Vec<ElementCount>>, database::Error> {
+    match column_type {
+        "int64" => {
+            use top_n_int::dsl as ti_d;
+            let top_n;
+            async_get_top_n_of_column_by_round!(
+                conn,
+                ti_d,
+                top_n_int,
+                TopNIntRound,
+                model_id,
+                cluster_ids,
+                first_event_ids,
+                last_event_ids,
+                &column_index,
+                get_value_of_top_n_round_by_to_string,
+                top_n
+            );
+            top_n
+        }
+        "enum" => {
+            use top_n_enum::dsl as ti_d;
+            let top_n;
+            async_get_top_n_of_column_by_round!(
+                conn,
+                ti_d,
+                top_n_enum,
+                TopNEnumRound,
+                model_id,
+                cluster_ids,
+                first_event_ids,
+                last_event_ids,
+                &column_index,
+                get_value_of_top_n_round_by_clone,
+                top_n
+            );
+            top_n
+        }
+        "float64" => {
+            use diesel_async::RunQueryDsl;
+            use top_n_float::dsl as ti_d;
+
+            let top_n = ti_d::top_n_float
+                .inner_join(cd_d::column_description.on(cd_d::id.eq(ti_d::description_id)))
+                .inner_join(e_d::event_range.on(e_d::id.eq(cd_d::event_range_id)))
+                .inner_join(c_d::cluster.on(c_d::id.eq(e_d::cluster_id)))
+                .inner_join(m_d::model.on(m_d::id.eq(c_d::model_id)))
+                .filter(
+                    m_d::id
+                        .eq(model_id)
+                        .and(c_d::cluster_id.eq_any(cluster_ids))
+                        .and(e_d::first_event_id.eq_any(first_event_ids))
+                        .and(e_d::last_event_id.eq_any(last_event_ids))
+                        .and(cd_d::column_index.eq(&column_index)),
+                )
+                .select((
+                    c_d::cluster_id,
+                    e_d::first_event_id,
+                    e_d::last_event_id,
+                    ti_d::description_id,
+                    ti_d::value_smallest,
+                    ti_d::value_largest,
+                    ti_d::count,
+                ))
+                .load::<TopNFloatRound>(conn)
+                .await?;
+
+            let mut top_n_by_cluster: HashMap<String, Vec<ElementCount>> = HashMap::new();
+            for t in &top_n {
+                let smallest = t.value_smallest;
+                let largest = t.value_largest;
+
+                top_n_by_cluster
+                    .entry(t.cluster_id.clone())
+                    .or_insert_with(Vec::<ElementCount>::new)
+                    .push(ElementCount {
+                        value: Element::FloatRange(FloatRange { smallest, largest }).to_string(),
+                        count: t.count,
+                    });
+            }
+
+            for top_n in top_n_by_cluster.values_mut() {
+                top_n.sort_by(|a, b| a.value.cmp(&b.value));
+                top_n.sort_by(|a, b| b.count.cmp(&a.count));
+            }
+
+            Ok(top_n_by_cluster)
+        }
+        "utf8" => {
+            use top_n_text::dsl as ti_d;
+            let top_n;
+            async_get_top_n_of_column_by_round!(
+                conn,
+                ti_d,
+                top_n_text,
+                TopNTextRound,
+                model_id,
+                cluster_ids,
+                first_event_ids,
+                last_event_ids,
+                &column_index,
+                get_value_of_top_n_round_by_clone,
+                top_n
+            );
+            top_n
+        }
+        "ipaddr" => {
+            use top_n_ipaddr::dsl as ti_d;
+            let top_n;
+            async_get_top_n_of_column_by_round!(
+                conn,
+                ti_d,
+                top_n_ipaddr,
+                TopNIpAddrRound,
+                model_id,
+                cluster_ids,
+                first_event_ids,
+                last_event_ids,
+                &column_index,
+                get_value_of_top_n_round_by_clone,
+                top_n
+            );
+            top_n
+        }
+        "datetime" => {
+            use top_n_datetime::dsl as ti_d;
+            let top_n;
+            async_get_top_n_of_column_by_round!(
+                conn,
+                ti_d,
+                top_n_datetime,
+                TopNDateTimeRound,
+                model_id,
+                cluster_ids,
+                first_event_ids,
+                last_event_ids,
+                &column_index,
+                get_value_of_top_n_round_by_to_string,
+                top_n
+            );
+            top_n
+        }
+        "binary" => {
+            use top_n_binary::dsl as ti_d;
+            let top_n;
+            async_get_top_n_of_column_by_round!(
+                conn,
+                ti_d,
+                top_n_binary,
+                TopNBinaryRound,
+                model_id,
+                cluster_ids,
+                first_event_ids,
+                last_event_ids,
+                &column_index,
+                get_value_of_top_n_round_by_utf8,
+                top_n
+            );
+            top_n
+        }
+        _ => unreachable!(),
+    }
+}
+
+impl Database {
+    #[allow(clippy::too_many_lines)]
+    pub async fn get_top_multimaps_of_model(
+        &self,
+        model_id: i32,
+        number_of_top_n: usize,
+        min_top_n_of_1_to_n: usize,
+        time: Option<NaiveDateTime>,
+        column_types: Vec<StructuredColumnType>,
+    ) -> Result<Vec<TopMultimaps>, Error> {
+        use diesel_async::RunQueryDsl;
+
+        let mut conn = self.pool.get_diesel_conn().await?;
+        let column_types: HashMap<usize, String> = column_types
+            .into_iter()
+            .map(|c| (c.column_index.to_usize().expect("safe"), c.data_type))
+            .collect();
+
+        let columns_for_1_to_n = column_d::csv_column_extra
+            .select((column_d::column_1, column_d::column_n))
+            .filter(column_d::model_id.eq(model_id))
+            .first::<(Option<Vec<bool>>, Option<Vec<bool>>)>(&mut conn)
+            .await?;
+
+        let columns_for_1: Vec<usize> = columns_for_1_to_n.0.map_or_else(Vec::new, |c| {
+            c.iter()
+                .enumerate()
+                .filter_map(|(index, is)| if *is { Some(index) } else { None })
+                .collect()
+        });
+
+        let columns_for_n: Vec<usize> = columns_for_1_to_n.1.map_or_else(Vec::new, |c| {
+            c.iter()
+                .enumerate()
+                .filter_map(|(index, is)| if *is { Some(index) } else { None })
+                .collect()
+        });
+
+        let mut top_n_transfer: Vec<TopMultimaps> = Vec::new();
+        for column_n in &columns_for_n {
+            let column_type: &str = if let Some(column_type) = column_types.get(column_n) {
+                column_type
+            } else {
+                return Ok(Vec::<TopMultimaps>::new());
+            };
+            let top_table = match column_type {
+                "int64" => "top_n_int",
+                "enum" => "top_n_enum",
+                "float64" => "top_n_float",
+                "utf8" => "top_n_text",
+                "ipaddr" => "top_n_ipaddr",
+                "datetime" => "top_n_datetime",
+                "binary" => "top_n_binary",
+                _ => unreachable!(),
+            };
+
+            let q = if let Some(time) = time {
+                format!(
+                    r#"SELECT model.id as model_id, col.column_index, cluster.cluster_id, first_event_id, last_event_id, top.description_id, COUNT(top.id) as count
+                        FROM {} AS top
+                        INNER JOIN column_description AS col ON top.description_id = col.id
+                        INNER JOIN event_range AS ev ON ev.id = col.event_range_id
+                        INNER JOIN cluster ON cluster.id = ev.cluster_id
+                        INNER JOIN model ON cluster.model_id = model.id
+                        GROUP BY model.id, cluster.cluster_id, col.column_index, first_event_id, last_event_id, top.description_id, cluster.category_id, ev.time
+                        HAVING COUNT(top.id) > {} AND model.id = {} AND col.column_index = {} AND cluster.category_id != 2 AND ev.time = '{}'
+                        ORDER BY COUNT(top.id) DESC"#,
+                    top_table, min_top_n_of_1_to_n, model_id, *column_n, time
+                )
+            } else {
+                format!(
+                    r#"SELECT model.id as model_id, col.column_index, cluster.cluster_id, first_event_id, last_event_id, top.description_id, COUNT(top.id) as count
+                        FROM {} AS top
+                        INNER JOIN column_description AS col ON top.description_id = col.id
+                        INNER JOIN event_range AS ev ON ev.id = col.event_range_id
+                        INNER JOIN cluster ON cluster.id = ev.cluster_id
+                        INNER JOIN model ON cluster.model_id = model.id
+                        GROUP BY model.id, cluster.cluster_id, col.column_index, first_event_id, last_event_id, top.description_id, cluster.category_id, ev.time
+                        HAVING COUNT(top.id) > {} AND model.id = {} AND col.column_index = {} AND cluster.category_id != 2
+                        ORDER BY COUNT(top.id) DESC"#,
+                    top_table, min_top_n_of_1_to_n, model_id, *column_n
+                )
+            };
+
+            let selected_clusters = sql_query(q).load::<SelectedCluster>(&mut conn).await?;
+
+            let mut sorted_clusters: HashMap<String, Vec<(i64, i64, i64)>> = HashMap::new();
+            for cluster in selected_clusters {
+                sorted_clusters
+                    .entry(cluster.cluster_id)
+                    .or_insert_with(Vec::<(i64, i64, i64)>::new)
+                    .push((cluster.first_event_id, cluster.last_event_id, cluster.count));
+            }
+            for top_n in sorted_clusters.values_mut() {
+                top_n.sort_by(|a, b| b.0.cmp(&a.0)); // recent one among rounds is more important. (assuming recent event id is bigger)
+                top_n.sort_by(|a, b| b.2.cmp(&a.2));
+            }
+
+            let mut sorted_clusters: Vec<(String, i64, i64, i64)> = sorted_clusters // cluster_id, first_event_id, last_event_id, count
+                .into_iter()
+                .map(|(cluster_id, top_n)| (cluster_id, top_n[0].0, top_n[0].1, top_n[0].2))
+                .collect();
+            // HIGHLIGHT: take the biggest round only in each cluster
+            sorted_clusters.sort_by(|a, b| a.0.cmp(&b.0)); // first, sort clusters by alphabetical order
+            sorted_clusters.sort_by(|a, b| b.3.cmp(&a.3)); // then, sort by count
+            sorted_clusters.truncate(number_of_top_n);
+
+            let cluster_ids: Vec<String> = sorted_clusters.iter().map(|c| c.0.clone()).collect();
+            let first_event_ids: Vec<i64> = sorted_clusters.iter().map(|c| c.1).collect();
+            let last_event_ids: Vec<i64> = sorted_clusters.iter().map(|c| c.2).collect();
+
+            let mut top_n_of_clusters: HashMap<String, Vec<TopElementCountsByColumn>> =
+                HashMap::new();
+            for column_1 in &columns_for_1 {
+                let column_type: &str = if let Some(column_type) = column_types.get(column_1) {
+                    column_type
+                } else {
+                    return Ok(Vec::<TopMultimaps>::new());
+                };
+                let column_index: i32 = if let Some(column_index) = column_1.to_i32() {
+                    column_index
+                } else {
+                    return Ok(Vec::<TopMultimaps>::new());
+                };
+                let top_n = async_get_top_n(
+                    &mut conn,
+                    model_id,
+                    &cluster_ids,
+                    &first_event_ids,
+                    &last_event_ids,
+                    column_index,
+                    column_type,
+                )
+                .await?;
+                for (cluster_id, top_n) in top_n {
+                    top_n_of_clusters
+                        .entry(cluster_id)
+                        .or_insert_with(Vec::<TopElementCountsByColumn>::new)
+                        .push(TopElementCountsByColumn {
+                            column_index: *column_1,
+                            counts: top_n,
+                        });
+                }
+            }
+
+            for column_n in &columns_for_n {
+                let column_type: &str = if let Some(column_type) = column_types.get(column_n) {
+                    column_type
+                } else {
+                    return Ok(Vec::<TopMultimaps>::new());
+                };
+                let column_index: i32 = if let Some(column_index) = column_n.to_i32() {
+                    column_index
+                } else {
+                    return Ok(Vec::<TopMultimaps>::new());
+                };
+                let top_n = async_get_top_n(
+                    &mut conn,
+                    model_id,
+                    &cluster_ids,
+                    &first_event_ids,
+                    &last_event_ids,
+                    column_index,
+                    column_type,
+                )
+                .await?;
+                for (cluster_id, top_n) in top_n {
+                    top_n_of_clusters
+                        .entry(cluster_id)
+                        .or_insert_with(Vec::<TopElementCountsByColumn>::new)
+                        .push(TopElementCountsByColumn {
+                            column_index: *column_n,
+                            counts: top_n,
+                        });
+                }
+            }
+
+            let top_n_of_clusters: Vec<TopColumnsOfCluster> = cluster_ids
+                .into_iter()
+                .map(|cluster_id| {
+                    let top_n_of_1_or_n = top_n_of_clusters
+                        .get(&cluster_id)
+                        .expect("should exist")
+                        .clone();
+                    TopColumnsOfCluster {
+                        cluster_id,
+                        columns: top_n_of_1_or_n,
+                    }
+                })
+                .collect();
+
+            top_n_transfer.push(TopMultimaps {
+                n_index: *column_n,
+                selected: top_n_of_clusters,
+            });
+        }
+        Ok(top_n_transfer)
     }
 }

--- a/src/top_n/score.rs
+++ b/src/top_n/score.rs
@@ -1,13 +1,13 @@
 use crate::{
-    csv_indicator::get_csv_indicators,
+    csv_indicator::{async_get_csv_indicators, get_csv_indicators},
     schema::{
         cluster, column_description, event_range, model, top_n_binary, top_n_datetime, top_n_enum,
         top_n_int, top_n_ipaddr, top_n_text,
     },
-    BlockingPgConn, Error, StructuredColumnType,
+    BlockingPgConn, Database, Error, StructuredColumnType,
 };
 use chrono::NaiveDateTime;
-use diesel::prelude::*;
+use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
 use num_traits::ToPrimitive;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
@@ -42,6 +42,7 @@ macro_rules! pass_value_ip {
 
 macro_rules! load_top_n {
     ($top_n:ident, $value:ty, $model_id:expr, $time:expr, $conn:expr, $output:expr, $elem:expr, $value_func:tt) => {{
+        use diesel::RunQueryDsl;
         use $top_n::dsl as t_d;
         let top_n: Vec<(i32, String, $value, i64)> = if let Some(time) = $time {
             t_d::$top_n
@@ -61,6 +62,48 @@ macro_rules! load_top_n {
                 .select((c_d::id, c_d::cluster_id, t_d::value, t_d::count))
                 .filter(m_d::id.eq($model_id))
                 .load::<(i32, String, $value, i64)>($conn)?
+        };
+
+        if top_n.is_empty() {
+            continue;
+        }
+
+        for (cluster_id, cluster_name, value, count) in top_n {
+            $output
+                .entry((cluster_id, cluster_name))
+                .or_insert_with(Vec::<ElementCount>::new)
+                .push(ElementCount {
+                    value: $elem($value_func!(value)),
+                    count,
+                })
+        }
+    }};
+}
+
+macro_rules! async_load_top_n {
+    ($top_n:ident, $value:ty, $model_id:expr, $time:expr, $conn:expr, $output:expr, $elem:expr, $value_func:tt) => {{
+        use diesel_async::RunQueryDsl;
+        use $top_n::dsl as t_d;
+        let top_n: Vec<(i32, String, $value, i64)> = if let Some(time) = $time {
+            t_d::$top_n
+                .inner_join(cd_d::column_description.on(t_d::description_id.eq(cd_d::id)))
+                .inner_join(e_d::event_range.on(e_d::id.eq(cd_d::event_range_id)))
+                .inner_join(c_d::cluster.on(e_d::cluster_id.eq(c_d::id)))
+                .inner_join(m_d::model.on(c_d::model_id.eq(m_d::id)))
+                .select((c_d::id, c_d::cluster_id, t_d::value, t_d::count))
+                .filter(m_d::id.eq($model_id).and(e_d::time.eq(time)))
+                .load::<(i32, String, $value, i64)>($conn)
+                .await?
+        } else {
+            t_d::$top_n
+                .inner_join(cd_d::column_description.on(t_d::description_id.eq(cd_d::id)))
+                .inner_join(e_d::event_range.on(e_d::id.eq(cd_d::event_range_id)))
+                .inner_join(c_d::cluster.on(e_d::cluster_id.eq(c_d::id)))
+                .inner_join(m_d::model.on(c_d::model_id.eq(m_d::id)))
+                .select((c_d::id, c_d::cluster_id, t_d::value, t_d::count))
+                .filter(m_d::id.eq($model_id))
+                .load::<(i32, String, $value, i64)>($conn)
+                .await?
         };
 
         if top_n.is_empty() {
@@ -261,4 +304,180 @@ pub(crate) fn get_top_clusters_by_score(
         top_n_sum: scores_sum,
         top_n_rate: scores_rate,
     })
+}
+
+impl Database {
+    #[allow(clippy::too_many_lines)]
+    pub async fn get_top_clusters_by_score(
+        &self,
+        model_id: i32,
+        size: usize,
+        time: Option<NaiveDateTime>,
+        column_types: &[StructuredColumnType],
+    ) -> Result<ClusterScoreSet, Error> {
+        let columns_indices: Vec<usize> = column_types
+            .iter()
+            .map(|c| {
+                c.column_index
+                    .to_usize()
+                    .expect("safe: positive i32 -> usize")
+            })
+            .collect();
+
+        let mut conn = self.pool.get_diesel_conn().await?;
+        let indicators: HashMap<usize, String> =
+            async_get_csv_indicators(&mut conn, model_id, &columns_indices).await?;
+        let mut indicator_indices: Vec<usize> = indicators.keys().copied().collect();
+        indicator_indices.sort_unstable();
+
+        let mut scores_sum: HashMap<(i32, String), f64> = HashMap::new();
+        let mut scores_rate: HashMap<(i32, String), f64> = HashMap::new();
+        for column_index in indicator_indices {
+            let column_type: &str = &column_types[column_index].data_type;
+            let Some(indicator) = indicators
+                .get(&column_index)
+                .and_then(|indi| serde_json::from_str::<HashMap<String, f64>>(indi).ok()) else {
+                continue
+            };
+
+            let mut top_n_by_cluster: HashMap<(i32, String), Vec<ElementCount>> = HashMap::new(); // i32, String = id, cluster_id
+            match column_type {
+                "int64" => {
+                    async_load_top_n!(
+                        top_n_int,
+                        i64,
+                        model_id,
+                        time,
+                        &mut conn,
+                        top_n_by_cluster,
+                        Element::Int,
+                        pass_value
+                    );
+                }
+                "enum" => {
+                    async_load_top_n!(
+                        top_n_enum,
+                        String,
+                        model_id,
+                        time,
+                        &mut conn,
+                        top_n_by_cluster,
+                        Element::Enum,
+                        pass_value
+                    );
+                }
+                "float64" => {
+                    // TODO: implement later or not?
+                    continue;
+                }
+                "utf8" => {
+                    async_load_top_n!(
+                        top_n_text,
+                        String,
+                        model_id,
+                        time,
+                        &mut conn,
+                        top_n_by_cluster,
+                        Element::Text,
+                        pass_value
+                    );
+                }
+                "ipaddr" => {
+                    async_load_top_n!(
+                        top_n_ipaddr,
+                        String,
+                        model_id,
+                        time,
+                        &mut conn,
+                        top_n_by_cluster,
+                        Element::IpAddr,
+                        pass_value_ip
+                    );
+                }
+                "datetime" => {
+                    async_load_top_n!(
+                        top_n_datetime,
+                        NaiveDateTime,
+                        model_id,
+                        time,
+                        &mut conn,
+                        top_n_by_cluster,
+                        Element::DateTime,
+                        pass_value
+                    );
+                }
+                "binary" => {
+                    async_load_top_n!(
+                        top_n_binary,
+                        Vec<u8>,
+                        model_id,
+                        time,
+                        &mut conn,
+                        top_n_by_cluster,
+                        Element::Binary,
+                        pass_value
+                    );
+                }
+                _ => unreachable!(),
+            }
+
+            for ((cluster_id, cluster_name), top_n) in top_n_by_cluster {
+                let mut score: f64 = 0_f64;
+                let mut count_sum: f64 = 0_f64;
+                for e in top_n {
+                    let weight: f64 = indicator.get(&e.value.to_string()).map_or(0_f64, |w| *w);
+                    let count = e.count.to_f64().expect("safe: usize -> f64");
+                    score += count * weight;
+                    count_sum += count;
+                }
+                if score > 0_f64 {
+                    *scores_sum
+                        .entry((cluster_id, cluster_name.clone()))
+                        .or_insert(0_f64) += score;
+                    *scores_rate
+                        .entry((cluster_id, cluster_name))
+                        .or_insert(0_f64) += score / count_sum;
+                }
+            }
+        }
+
+        let mut scores_sum: Vec<ClusterScore> = scores_sum
+            .into_iter()
+            .map(|((cluster_id, cluster_name), score)| ClusterScore {
+                cluster_id,
+                cluster_name,
+                score,
+            })
+            .collect();
+
+        scores_sum.sort_by(|a, b| a.cluster_id.cmp(&b.cluster_id));
+        scores_sum.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        let mut scores_rate: Vec<ClusterScore> = scores_rate
+            .into_iter()
+            .map(|((cluster_id, cluster_name), score)| ClusterScore {
+                cluster_id,
+                cluster_name,
+                score,
+            })
+            .collect();
+
+        scores_rate.sort_by(|a, b| a.cluster_id.cmp(&b.cluster_id));
+        scores_rate.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        scores_sum.truncate(size);
+        scores_rate.truncate(size);
+        Ok(ClusterScoreSet {
+            top_n_sum: scores_sum,
+            top_n_rate: scores_rate,
+        })
+    }
 }

--- a/src/top_n/score.rs
+++ b/src/top_n/score.rs
@@ -1,13 +1,14 @@
 use crate::{
-    csv_indicator::{async_get_csv_indicators, get_csv_indicators},
+    csv_indicator::get_csv_indicators,
     schema::{
         cluster, column_description, event_range, model, top_n_binary, top_n_datetime, top_n_enum,
         top_n_int, top_n_ipaddr, top_n_text,
     },
-    BlockingPgConn, Database, Error, StructuredColumnType,
+    Database, Error, StructuredColumnType,
 };
 use chrono::NaiveDateTime;
 use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
+use diesel_async::RunQueryDsl;
 use num_traits::ToPrimitive;
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
@@ -42,47 +43,6 @@ macro_rules! pass_value_ip {
 
 macro_rules! load_top_n {
     ($top_n:ident, $value:ty, $model_id:expr, $time:expr, $conn:expr, $output:expr, $elem:expr, $value_func:tt) => {{
-        use diesel::RunQueryDsl;
-        use $top_n::dsl as t_d;
-        let top_n: Vec<(i32, String, $value, i64)> = if let Some(time) = $time {
-            t_d::$top_n
-                .inner_join(cd_d::column_description.on(t_d::description_id.eq(cd_d::id)))
-                .inner_join(e_d::event_range.on(e_d::id.eq(cd_d::event_range_id)))
-                .inner_join(c_d::cluster.on(e_d::cluster_id.eq(c_d::id)))
-                .inner_join(m_d::model.on(c_d::model_id.eq(m_d::id)))
-                .select((c_d::id, c_d::cluster_id, t_d::value, t_d::count))
-                .filter(m_d::id.eq($model_id).and(e_d::time.eq(time)))
-                .load::<(i32, String, $value, i64)>($conn)?
-        } else {
-            t_d::$top_n
-                .inner_join(cd_d::column_description.on(t_d::description_id.eq(cd_d::id)))
-                .inner_join(e_d::event_range.on(e_d::id.eq(cd_d::event_range_id)))
-                .inner_join(c_d::cluster.on(e_d::cluster_id.eq(c_d::id)))
-                .inner_join(m_d::model.on(c_d::model_id.eq(m_d::id)))
-                .select((c_d::id, c_d::cluster_id, t_d::value, t_d::count))
-                .filter(m_d::id.eq($model_id))
-                .load::<(i32, String, $value, i64)>($conn)?
-        };
-
-        if top_n.is_empty() {
-            continue;
-        }
-
-        for (cluster_id, cluster_name, value, count) in top_n {
-            $output
-                .entry((cluster_id, cluster_name))
-                .or_insert_with(Vec::<ElementCount>::new)
-                .push(ElementCount {
-                    value: $elem($value_func!(value)),
-                    count,
-                })
-        }
-    }};
-}
-
-macro_rules! async_load_top_n {
-    ($top_n:ident, $value:ty, $model_id:expr, $time:expr, $conn:expr, $output:expr, $elem:expr, $value_func:tt) => {{
-        use diesel_async::RunQueryDsl;
         use $top_n::dsl as t_d;
         let top_n: Vec<(i32, String, $value, i64)> = if let Some(time) = $time {
             t_d::$top_n
@@ -134,178 +94,6 @@ pub struct ClusterScoreSet {
     pub top_n_rate: Vec<ClusterScore>,
 }
 
-#[allow(clippy::too_many_lines)]
-pub(crate) fn get_top_clusters_by_score(
-    conn: &mut BlockingPgConn,
-    model_id: i32,
-    size: usize,
-    time: Option<NaiveDateTime>,
-    column_types: &[StructuredColumnType],
-) -> Result<ClusterScoreSet, Error> {
-    let columns_indices: Vec<usize> = column_types
-        .iter()
-        .map(|c| {
-            c.column_index
-                .to_usize()
-                .expect("safe: positive i32 -> usize")
-        })
-        .collect();
-
-    let indicators: HashMap<usize, String> = get_csv_indicators(conn, model_id, &columns_indices);
-    let mut indicator_indices: Vec<usize> = indicators.keys().copied().collect();
-    indicator_indices.sort_unstable();
-
-    let mut scores_sum: HashMap<(i32, String), f64> = HashMap::new();
-    let mut scores_rate: HashMap<(i32, String), f64> = HashMap::new();
-    for column_index in indicator_indices {
-        let column_type: &str = &column_types[column_index].data_type;
-        let Some(indicator) = indicators
-            .get(&column_index)
-            .and_then(|indi| serde_json::from_str::<HashMap<String, f64>>(indi).ok()) else {
-            continue
-        };
-
-        let mut top_n_by_cluster: HashMap<(i32, String), Vec<ElementCount>> = HashMap::new(); // i32, String = id, cluster_id
-        match column_type {
-            "int64" => {
-                load_top_n!(
-                    top_n_int,
-                    i64,
-                    model_id,
-                    time,
-                    conn,
-                    top_n_by_cluster,
-                    Element::Int,
-                    pass_value
-                );
-            }
-            "enum" => {
-                load_top_n!(
-                    top_n_enum,
-                    String,
-                    model_id,
-                    time,
-                    conn,
-                    top_n_by_cluster,
-                    Element::Enum,
-                    pass_value
-                );
-            }
-            "float64" => {
-                // TODO: implement later or not?
-                continue;
-            }
-            "utf8" => {
-                load_top_n!(
-                    top_n_text,
-                    String,
-                    model_id,
-                    time,
-                    conn,
-                    top_n_by_cluster,
-                    Element::Text,
-                    pass_value
-                );
-            }
-            "ipaddr" => {
-                load_top_n!(
-                    top_n_ipaddr,
-                    String,
-                    model_id,
-                    time,
-                    conn,
-                    top_n_by_cluster,
-                    Element::IpAddr,
-                    pass_value_ip
-                );
-            }
-            "datetime" => {
-                load_top_n!(
-                    top_n_datetime,
-                    NaiveDateTime,
-                    model_id,
-                    time,
-                    conn,
-                    top_n_by_cluster,
-                    Element::DateTime,
-                    pass_value
-                );
-            }
-            "binary" => {
-                load_top_n!(
-                    top_n_binary,
-                    Vec<u8>,
-                    model_id,
-                    time,
-                    conn,
-                    top_n_by_cluster,
-                    Element::Binary,
-                    pass_value
-                );
-            }
-            _ => unreachable!(),
-        }
-
-        for ((cluster_id, cluster_name), top_n) in top_n_by_cluster {
-            let mut score: f64 = 0_f64;
-            let mut count_sum: f64 = 0_f64;
-            for e in top_n {
-                let weight: f64 = indicator.get(&e.value.to_string()).map_or(0_f64, |w| *w);
-                let count = e.count.to_f64().expect("safe: usize -> f64");
-                score += count * weight;
-                count_sum += count;
-            }
-            if score > 0_f64 {
-                *scores_sum
-                    .entry((cluster_id, cluster_name.clone()))
-                    .or_insert(0_f64) += score;
-                *scores_rate
-                    .entry((cluster_id, cluster_name))
-                    .or_insert(0_f64) += score / count_sum;
-            }
-        }
-    }
-
-    let mut scores_sum: Vec<ClusterScore> = scores_sum
-        .into_iter()
-        .map(|((cluster_id, cluster_name), score)| ClusterScore {
-            cluster_id,
-            cluster_name,
-            score,
-        })
-        .collect();
-
-    scores_sum.sort_by(|a, b| a.cluster_id.cmp(&b.cluster_id));
-    scores_sum.sort_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-
-    let mut scores_rate: Vec<ClusterScore> = scores_rate
-        .into_iter()
-        .map(|((cluster_id, cluster_name), score)| ClusterScore {
-            cluster_id,
-            cluster_name,
-            score,
-        })
-        .collect();
-
-    scores_rate.sort_by(|a, b| a.cluster_id.cmp(&b.cluster_id));
-    scores_rate.sort_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-
-    scores_sum.truncate(size);
-    scores_rate.truncate(size);
-    Ok(ClusterScoreSet {
-        top_n_sum: scores_sum,
-        top_n_rate: scores_rate,
-    })
-}
-
 impl Database {
     #[allow(clippy::too_many_lines)]
     pub async fn get_top_clusters_by_score(
@@ -326,7 +114,7 @@ impl Database {
 
         let mut conn = self.pool.get_diesel_conn().await?;
         let indicators: HashMap<usize, String> =
-            async_get_csv_indicators(&mut conn, model_id, &columns_indices).await?;
+            get_csv_indicators(&mut conn, model_id, &columns_indices).await?;
         let mut indicator_indices: Vec<usize> = indicators.keys().copied().collect();
         indicator_indices.sort_unstable();
 
@@ -343,7 +131,7 @@ impl Database {
             let mut top_n_by_cluster: HashMap<(i32, String), Vec<ElementCount>> = HashMap::new(); // i32, String = id, cluster_id
             match column_type {
                 "int64" => {
-                    async_load_top_n!(
+                    load_top_n!(
                         top_n_int,
                         i64,
                         model_id,
@@ -355,7 +143,7 @@ impl Database {
                     );
                 }
                 "enum" => {
-                    async_load_top_n!(
+                    load_top_n!(
                         top_n_enum,
                         String,
                         model_id,
@@ -371,7 +159,7 @@ impl Database {
                     continue;
                 }
                 "utf8" => {
-                    async_load_top_n!(
+                    load_top_n!(
                         top_n_text,
                         String,
                         model_id,
@@ -383,7 +171,7 @@ impl Database {
                     );
                 }
                 "ipaddr" => {
-                    async_load_top_n!(
+                    load_top_n!(
                         top_n_ipaddr,
                         String,
                         model_id,
@@ -395,7 +183,7 @@ impl Database {
                     );
                 }
                 "datetime" => {
-                    async_load_top_n!(
+                    load_top_n!(
                         top_n_datetime,
                         NaiveDateTime,
                         model_id,
@@ -407,7 +195,7 @@ impl Database {
                     );
                 }
                 "binary" => {
-                    async_load_top_n!(
+                    load_top_n!(
                         top_n_binary,
                         Vec<u8>,
                         model_id,

--- a/src/top_n/time_series.rs
+++ b/src/top_n/time_series.rs
@@ -1,11 +1,11 @@
 use crate::{
     self as database,
     schema::{cluster, time_series},
-    BlockingPgConn, Database, Error, TimeCount,
+    Database, Error, TimeCount,
 };
 use chrono::{Duration, NaiveDateTime, Utc};
-use diesel::dsl::max;
-use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
+use diesel::{dsl::max, BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
+use diesel_async::{pg::AsyncPgConnection, RunQueryDsl};
 use num_traits::ToPrimitive;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -48,124 +48,6 @@ pub struct Regression {
 use cluster::dsl as c_d;
 use time_series::dsl as t_d;
 
-fn get_time_series_of_clusters(
-    conn: &mut BlockingPgConn,
-    model_id: i32,
-    time: Option<NaiveDateTime>,
-    start: Option<i64>,
-    end: Option<i64>,
-) -> Result<Vec<TimeSeriesLoadByCluster>, database::Error> {
-    use diesel::RunQueryDsl;
-
-    let series = if let Some(time) = time {
-        c_d::cluster
-            .inner_join(t_d::time_series.on(t_d::cluster_id.eq(c_d::id)))
-            .select((c_d::cluster_id, t_d::count_index, t_d::value, t_d::count))
-            .filter(c_d::model_id.eq(model_id).and(t_d::time.eq(time)))
-            .load::<TimeSeriesLoadByCluster>(conn)?
-    } else {
-        let latest = c_d::cluster
-            .inner_join(t_d::time_series.on(t_d::cluster_id.eq(c_d::id)))
-            .select(max(t_d::value))
-            .filter(c_d::model_id.eq(model_id))
-            .first::<Option<NaiveDateTime>>(conn)?;
-
-        let recent = latest.unwrap_or_else(|| Utc::now().naive_utc());
-        let (start, end) = if let (Some(start), Some(end)) = (start, end) {
-            match (
-                NaiveDateTime::from_timestamp_opt(start, 0),
-                NaiveDateTime::from_timestamp_opt(end, 0),
-            ) {
-                (Some(s), Some(e)) => (s, e),
-                _ => {
-                    return Err(database::Error::InvalidInput(format!(
-                        "illegal time range provided ({start},{end})"
-                    )))
-                }
-            }
-        } else {
-            (recent - Duration::hours(2), recent)
-        };
-
-        c_d::cluster
-            .inner_join(t_d::time_series.on(t_d::cluster_id.eq(c_d::id)))
-            .select((c_d::cluster_id, t_d::count_index, t_d::value, t_d::count))
-            .filter(
-                c_d::model_id
-                    .eq(model_id)
-                    .and(t_d::value.gt(start)) // HIGHLIGHT: first and last items should not be included because they might have insufficient counts.
-                    .and(t_d::value.lt(end)),
-            )
-            .load::<TimeSeriesLoadByCluster>(conn)?
-    };
-
-    Ok(series)
-}
-
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
-pub(crate) fn get_top_cluster_time_series(
-    conn: &mut BlockingPgConn,
-    model_id: i32,
-    time: Option<NaiveDateTime>,
-    start: Option<i64>,
-    end: Option<i64>,
-) -> Result<Vec<TopTrendsByColumn>, Error> {
-    let values = get_time_series_of_clusters(conn, model_id, time, start, end)?;
-
-    let mut series: HashMap<usize, HashMap<String, HashMap<NaiveDateTime, i64>>> = HashMap::new();
-    for v in values {
-        let (count_index, value, count) = (
-            v.count_index
-                .map_or(100_000, |i| i.to_usize().expect("safe: positive")),
-            // 100_000 means counting events themselves, not any other column values.
-            v.value,
-            v.count,
-        );
-        *series
-            .entry(count_index)
-            .or_insert_with(HashMap::<String, HashMap<NaiveDateTime, i64>>::new)
-            .entry(v.cluster_id)
-            .or_insert_with(HashMap::<NaiveDateTime, i64>::new)
-            .entry(value)
-            .or_insert(0) += count;
-    }
-
-    let mut series: Vec<TopTrendsByColumn> = series
-        .into_iter()
-        .map(|(count_index, cluster_series)| TopTrendsByColumn {
-            count_index,
-            trends: cluster_series
-                .into_iter()
-                .filter_map(|(cluster_id, series)| {
-                    if series.is_empty() {
-                        None
-                    } else {
-                        let mut series: Vec<TimeCount> = series
-                            .into_iter()
-                            .map(|(time, count)| TimeCount {
-                                time,
-                                count: count.to_usize().unwrap_or(usize::MAX),
-                            })
-                            .collect();
-                        series.sort_by(|a, b| a.time.cmp(&b.time));
-                        if time.is_some() && series.len() > 2 {
-                            series.pop();
-                            series.remove(0);
-                        }
-
-                        Some(ClusterTrend { cluster_id, series })
-                    }
-                })
-                .collect(),
-        })
-        .collect();
-
-    for s in &mut series {
-        s.trends.sort_by(|a, b| b.series.len().cmp(&a.series.len())); // for fixed order
-    }
-    Ok(series)
-}
-
 impl Database {
     pub async fn get_top_time_series_of_model(
         &self,
@@ -175,8 +57,7 @@ impl Database {
         end: Option<i64>,
     ) -> Result<Vec<TopTrendsByColumn>, Error> {
         let mut conn = self.pool.get_diesel_conn().await?;
-        let values =
-            async_get_time_series_of_clusters(&mut conn, model_id, time, start, end).await?;
+        let values = get_time_series_of_clusters(&mut conn, model_id, time, start, end).await?;
 
         let mut series: HashMap<usize, HashMap<String, HashMap<NaiveDateTime, i64>>> =
             HashMap::new();
@@ -234,15 +115,13 @@ impl Database {
     }
 }
 
-async fn async_get_time_series_of_clusters(
-    conn: &mut diesel_async::pg::AsyncPgConnection,
+async fn get_time_series_of_clusters(
+    conn: &mut AsyncPgConnection,
     model_id: i32,
     time: Option<NaiveDateTime>,
     start: Option<i64>,
     end: Option<i64>,
 ) -> Result<Vec<TimeSeriesLoadByCluster>, database::Error> {
-    use diesel_async::RunQueryDsl;
-
     let series = if let Some(time) = time {
         c_d::cluster
             .inner_join(t_d::time_series.on(t_d::cluster_id.eq(c_d::id)))

--- a/src/top_n/time_series.rs
+++ b/src/top_n/time_series.rs
@@ -1,11 +1,11 @@
 use crate::{
     self as database,
     schema::{cluster, time_series},
-    BlockingPgConn, Error, TimeCount,
+    BlockingPgConn, Database, Error, TimeCount,
 };
 use chrono::{Duration, NaiveDateTime, Utc};
 use diesel::dsl::max;
-use diesel::prelude::*;
+use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
 use num_traits::ToPrimitive;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -55,6 +55,8 @@ fn get_time_series_of_clusters(
     start: Option<i64>,
     end: Option<i64>,
 ) -> Result<Vec<TimeSeriesLoadByCluster>, database::Error> {
+    use diesel::RunQueryDsl;
+
     let series = if let Some(time) = time {
         c_d::cluster
             .inner_join(t_d::time_series.on(t_d::cluster_id.eq(c_d::id)))
@@ -161,5 +163,130 @@ pub(crate) fn get_top_cluster_time_series(
     for s in &mut series {
         s.trends.sort_by(|a, b| b.series.len().cmp(&a.series.len())); // for fixed order
     }
+    Ok(series)
+}
+
+impl Database {
+    pub async fn get_top_time_series_of_model(
+        &self,
+        model_id: i32,
+        time: Option<NaiveDateTime>,
+        start: Option<i64>,
+        end: Option<i64>,
+    ) -> Result<Vec<TopTrendsByColumn>, Error> {
+        let mut conn = self.pool.get_diesel_conn().await?;
+        let values =
+            async_get_time_series_of_clusters(&mut conn, model_id, time, start, end).await?;
+
+        let mut series: HashMap<usize, HashMap<String, HashMap<NaiveDateTime, i64>>> =
+            HashMap::new();
+        for v in values {
+            let (count_index, value, count) = (
+                v.count_index
+                    .map_or(100_000, |i| i.to_usize().expect("safe: positive")),
+                // 100_000 means counting events themselves, not any other column values.
+                v.value,
+                v.count,
+            );
+            *series
+                .entry(count_index)
+                .or_insert_with(HashMap::<String, HashMap<NaiveDateTime, i64>>::new)
+                .entry(v.cluster_id)
+                .or_insert_with(HashMap::<NaiveDateTime, i64>::new)
+                .entry(value)
+                .or_insert(0) += count;
+        }
+
+        let mut series: Vec<TopTrendsByColumn> = series
+            .into_iter()
+            .map(|(count_index, cluster_series)| TopTrendsByColumn {
+                count_index,
+                trends: cluster_series
+                    .into_iter()
+                    .filter_map(|(cluster_id, series)| {
+                        if series.is_empty() {
+                            None
+                        } else {
+                            let mut series: Vec<TimeCount> = series
+                                .into_iter()
+                                .map(|(time, count)| TimeCount {
+                                    time,
+                                    count: count.to_usize().unwrap_or(usize::MAX),
+                                })
+                                .collect();
+                            series.sort_by(|a, b| a.time.cmp(&b.time));
+                            if time.is_some() && series.len() > 2 {
+                                series.pop();
+                                series.remove(0);
+                            }
+
+                            Some(ClusterTrend { cluster_id, series })
+                        }
+                    })
+                    .collect(),
+            })
+            .collect();
+
+        for s in &mut series {
+            s.trends.sort_by(|a, b| b.series.len().cmp(&a.series.len())); // for fixed order
+        }
+        Ok(series)
+    }
+}
+
+async fn async_get_time_series_of_clusters(
+    conn: &mut diesel_async::pg::AsyncPgConnection,
+    model_id: i32,
+    time: Option<NaiveDateTime>,
+    start: Option<i64>,
+    end: Option<i64>,
+) -> Result<Vec<TimeSeriesLoadByCluster>, database::Error> {
+    use diesel_async::RunQueryDsl;
+
+    let series = if let Some(time) = time {
+        c_d::cluster
+            .inner_join(t_d::time_series.on(t_d::cluster_id.eq(c_d::id)))
+            .select((c_d::cluster_id, t_d::count_index, t_d::value, t_d::count))
+            .filter(c_d::model_id.eq(model_id).and(t_d::time.eq(time)))
+            .load::<TimeSeriesLoadByCluster>(conn)
+            .await?
+    } else {
+        let latest = c_d::cluster
+            .inner_join(t_d::time_series.on(t_d::cluster_id.eq(c_d::id)))
+            .select(max(t_d::value))
+            .filter(c_d::model_id.eq(model_id))
+            .first::<Option<NaiveDateTime>>(conn)
+            .await?;
+
+        let recent = latest.unwrap_or_else(|| Utc::now().naive_utc());
+        let (start, end) = if let (Some(start), Some(end)) = (start, end) {
+            match (
+                NaiveDateTime::from_timestamp_opt(start, 0),
+                NaiveDateTime::from_timestamp_opt(end, 0),
+            ) {
+                (Some(s), Some(e)) => (s, e),
+                _ => {
+                    return Err(database::Error::InvalidInput(format!(
+                        "illegal time range provided ({start},{end})"
+                    )))
+                }
+            }
+        } else {
+            (recent - Duration::hours(2), recent)
+        };
+
+        c_d::cluster
+            .inner_join(t_d::time_series.on(t_d::cluster_id.eq(c_d::id)))
+            .select((c_d::cluster_id, t_d::count_index, t_d::value, t_d::count))
+            .filter(
+                c_d::model_id
+                    .eq(model_id)
+                    .and(t_d::value.gt(start)) // HIGHLIGHT: first and last items should not be included because they might have insufficient counts.
+                    .and(t_d::value.lt(end)),
+            )
+            .load::<TimeSeriesLoadByCluster>(conn)
+            .await?
+    };
+
     Ok(series)
 }


### PR DESCRIPTION
- Remove `BlockingPgPool` and use `diesel_async` instead
  - `get_diesel_conn()` is added to get an async diesel connection
- Basically the same diesel query builders are used. The only change is to use `optional` to convert `Err(NotFound)` to `None` instead of using `match` like below:

```
    let indicator_names = match list_d::csv_column_list
        .select(list_d::column_indicator)
        .filter(list_d::model_id.eq(model_id))
        .get_result::<Option<Vec<String>>>(conn)
    {
        Ok(names) => names,
        Err(_) => None,
    };
```

```
    let Some(Some(indicator_names)) = list_d::csv_column_list
        .select(list_d::column_indicator)
        .filter(list_d::model_id.eq(model_id))
        .get_result::<Option<Vec<String>>>(conn)
        .await
        .optional()? else {
            return Ok(HashMap::new());
    };
```