### PR TITLE
Cleanup

### DIFF
--- a/src/top_n.rs
+++ b/src/top_n.rs
@@ -237,7 +237,6 @@ fn total_of_top_n(
 fn limited_top_n_of_clusters(
     top_n_of_clusters: HashMap<i32, HashMap<usize, HashMap<String, i64>>>,
     limit_rate: f64,
-    default_number: usize,
 ) -> HashMap<usize, HashMap<String, i64>> {
     let mut top_n_total: HashMap<usize, HashMap<String, i64>> = HashMap::new(); // (usize, (String, BigDecimal)) = (column_index, (Ip Address, size))
     for (_, top_n) in top_n_of_clusters {
@@ -248,7 +247,9 @@ fn limited_top_n_of_clusters(
 
             let size_including_ips =
                 i64::from_f64((total_sizes.to_f64().unwrap_or(0.0) * limit_rate).trunc())
-                    .unwrap_or_else(|| i64::from_usize(default_number).unwrap_or(i64::MAX));
+                    .unwrap_or_else(|| {
+                        i64::from_usize(DEFAULT_NUMBER_OF_COLUMN).unwrap_or(i64::MAX)
+                    });
 
             let mut sum_sizes = 0;
             for (ip, size) in top_n {

--- a/src/top_n/column.rs
+++ b/src/top_n/column.rs
@@ -1,7 +1,7 @@
 use super::{
     filter_by_whitelists, get_limited_cluster_ids, limited_top_n_of_clusters, total_of_top_n,
     TopElementCountsByColumn, TopNOfMultipleCluster, ValueType, DEFAULT_NUMBER_OF_CLUSTER,
-    DEFAULT_NUMBER_OF_COLUMN, DEFAULT_PORTION_OF_CLUSTER, DEFAULT_PORTION_OF_TOP_N,
+    DEFAULT_PORTION_OF_CLUSTER, DEFAULT_PORTION_OF_TOP_N,
 };
 use crate::{
     csv_indicator::get_whitelists,
@@ -273,11 +273,8 @@ impl Database {
         }
 
         let top_n = total_of_top_n(top_n_of_cluster);
-        let top_n = limited_top_n_of_clusters(
-            top_n,
-            portion_of_top_n.unwrap_or(DEFAULT_PORTION_OF_TOP_N),
-            DEFAULT_NUMBER_OF_COLUMN,
-        );
+        let top_n =
+            limited_top_n_of_clusters(top_n, portion_of_top_n.unwrap_or(DEFAULT_PORTION_OF_TOP_N));
         let column_indices: Vec<usize> = top_n.keys().copied().collect();
         let whitelists = get_whitelists(&mut conn, model_id, &column_indices).await?;
         Ok(filter_by_whitelists(top_n, &whitelists, number_of_top_n))

--- a/src/top_n/column.rs
+++ b/src/top_n/column.rs
@@ -72,7 +72,7 @@ macro_rules! get_top_n_of_column {
 pub(super) async fn get_columns_for_top_n(
     conn: &mut AsyncPgConnection,
     model_id: i32,
-) -> Result<Vec<i32>, Error> {
+) -> Result<HashSet<i32>, Error> {
     use csv_column_extra::dsl as column_d;
 
     let Some(Some(columns)) = column_d::csv_column_extra
@@ -81,7 +81,7 @@ pub(super) async fn get_columns_for_top_n(
         .first::<Option<Vec<bool>>>(conn)
         .await
         .optional()? else {
-            return Ok(Vec::new())
+            return Ok(HashSet::new())
     };
 
     Ok(columns
@@ -153,7 +153,6 @@ impl Database {
     ) -> Result<Vec<TopElementCountsByColumn>, Error> {
         let mut conn = self.pool.get_diesel_conn().await?;
         let columns_for_top_n = get_columns_for_top_n(&mut conn, model_id).await?;
-        let columns_for_top_n: HashSet<i32> = columns_for_top_n.into_iter().collect();
         let mut column_types = self.get_column_types_of_model(model_id).await?;
         column_types.retain(|c| columns_for_top_n.get(&c.column_index).is_some());
 

--- a/src/top_n/ipaddr.rs
+++ b/src/top_n/ipaddr.rs
@@ -1,8 +1,7 @@
 use super::{
     filter_by_whitelists, get_cluster_sizes, get_limited_cluster_ids, limited_top_n_of_clusters,
     total_of_top_n, ElementCount, TopElementCountsByColumn, TopNOfCluster, TopNOfMultipleCluster,
-    DEFAULT_NUMBER_OF_CLUSTER, DEFAULT_NUMBER_OF_COLUMN, DEFAULT_PORTION_OF_CLUSTER,
-    DEFAULT_PORTION_OF_TOP_N,
+    DEFAULT_NUMBER_OF_CLUSTER, DEFAULT_PORTION_OF_CLUSTER, DEFAULT_PORTION_OF_TOP_N,
 };
 use crate::{
     self as database,
@@ -135,11 +134,8 @@ impl Database {
 
         let top_n = get_top_n_of_multiple_clusters(&mut conn, &cluster_ids, time).await?;
         let top_n = total_of_top_n(top_n);
-        let top_n = limited_top_n_of_clusters(
-            top_n,
-            portion_of_top_n.unwrap_or(DEFAULT_PORTION_OF_TOP_N),
-            DEFAULT_NUMBER_OF_COLUMN,
-        );
+        let top_n =
+            limited_top_n_of_clusters(top_n, portion_of_top_n.unwrap_or(DEFAULT_PORTION_OF_TOP_N));
         let column_indices: Vec<usize> = top_n.keys().copied().collect();
         let whitelists = get_whitelists(&mut conn, model_id, &column_indices).await?;
         Ok(filter_by_whitelists(top_n, &whitelists, size))


### PR DESCRIPTION
- Change the return type of `get_columns_for_top_n` from `Vec<i32>` to `HashSet<i32>` since the returned value is immediately converted to `HashSet<i32>`
- Directly use `DEFAULT_NUMBER_OF_COLUMN ` in the `limited_top_n_of_clusters ` function