### PR TITLE
fix migration failure of 0.5.0-alpha.3

### DIFF
--- a/src/migration.rs
+++ b/src/migration.rs
@@ -81,7 +81,7 @@ pub fn migrate_data_dir<P: AsRef<Path>>(data_dir: P, backup_dir: P) -> Result<()
             migrate_0_2_to_0_3,
         ),
         (
-            VersionReq::parse(">=0.3,<0.5.0").expect("valid version requirement"),
+            VersionReq::parse(">=0.3,<0.5.0-alpha.4").expect("valid version requirement"),
             Version::parse("0.5.0").expect("valid version"),
             migrate_0_3_to_0_5,
         ),


### PR DESCRIPTION
* review db `0.5.0-alpha.3` fails to migrate.
* Version string `0.5.0-alpha.3` does not match in requirement `>=0.3,<0.5.0`

```rust
        (
            VersionReq::parse(">=0.3,<0.5.0").expect("valid version requirement"),
            Version::parse("0.5.0").expect("valid version"),
            migrate_0_3_to_0_5,
        ),

```