### PR TITLE
Hide the internal implementation of `Table<Account>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `Table<Account>::put` and `Table<Account>::insert` allow adding an Account
+  instance directly to the database, without requiring explicit serialization
+  by the caller.
+- Renamed `Table<Account>::update_account` to `Table<Account>::update`. This
+  change simplifies the method name and provides a more consistent interface
+  for updating `Account` records.
+
+### Removed
+
+- Removed the old `Table<Account>::update` method. This method was exposing the
+  internal format of the database to the public API, which could lead to
+  potential security and compatibility issues. To maintain a secure and
+  reliable interface, we have decided to remove this method. Users should now
+  use the newly renamed `Table<Account>::update` method for updating `Account`
+  records.
+
 ## [0.7.1] - 2023-05-03
 
 ### Fixed
@@ -87,6 +107,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - An initial version.
 
+[Unreleased]: https://github.com/petabi/review-database/compare/0.7.1...main
 [0.7.1]: https://github.com/petabi/review-database/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/petabi/review-database/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/petabi/review-database/compare/0.5.0...0.6.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.7.1"
+version = "0.8.0-alpha.1"
 edition = "2021"
 
 [dependencies]

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -30,7 +30,7 @@ use std::{
 /// // the database format won't be changed in the future alpha or beta versions.
 /// const COMPATIBLE_VERSION: &str = ">=0.5.0-alpha.2,<=0.5.0-alpha.4";
 /// ```
-const COMPATIBLE_VERSION_REQ: &str = ">=0.7.0,<0.8.0-alpha";
+const COMPATIBLE_VERSION_REQ: &str = ">=0.7.0,<=0.8.0-alpha.1";
 
 /// Migrates the data directory to the up-to-date format if necessary.
 ///
@@ -215,7 +215,7 @@ pub(crate) fn migrate_0_2_to_0_3<P: AsRef<Path>>(path: P, backup: P) -> Result<(
         let old: OldAccount = bincode::DefaultOptions::new().deserialize::<OldAccount>(&v)?;
         let account: Account = (&old).into();
         let new = bincode::DefaultOptions::new().serialize(&account)?;
-        account_map.update((&k, &v), (&k, &new))?;
+        account_map.update_raw((&k, &v), (&k, &new))?;
     }
 
     store.purge_old_backups(0)?;

--- a/src/tables/accounts.rs
+++ b/src/tables/accounts.rs
@@ -3,6 +3,7 @@
 use std::net::IpAddr;
 
 use anyhow::{bail, Context};
+use bincode::Options;
 use rocksdb::{Direction, IteratorMode, OptimisticTransactionDB};
 
 use crate::{
@@ -19,6 +20,15 @@ impl<'d> Table<'d, Account> {
         Map::open(db, super::ACCOUNTS).map(Table::new)
     }
 
+    /// Returns `true` if the table contains an account with the given username.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database operation fails.
+    pub fn contains(&self, username: &str) -> Result<bool, anyhow::Error> {
+        self.map.get(username.as_bytes()).map(|v| v.is_some())
+    }
+
     /// Deletes an account with the given username.
     ///
     /// # Errors
@@ -28,31 +38,39 @@ impl<'d> Table<'d, Account> {
         self.map.delete(username.as_bytes())
     }
 
-    /// Gets an account with the given username.
+    /// Returns an account with the given username.
     ///
     /// # Errors
     ///
     /// Returns an error if the account does not exist or the database operation fails.
-    pub fn get(&self, username: &str) -> Result<Option<impl AsRef<[u8]>>, anyhow::Error> {
-        self.map.get(username.as_bytes())
+    pub fn get(&self, username: &str) -> Result<Option<Account>, anyhow::Error> {
+        let Some(value) = self.map.get(username.as_bytes())? else {
+            return Ok(None);
+        };
+        Ok(Some(
+            bincode::DefaultOptions::new().deserialize::<Account>(value.as_ref())?,
+        ))
     }
 
-    /// Puts an account with the given username and content.
+    /// Stores an account into the database.
     ///
     /// # Errors
     ///
-    /// Returns an error if the database operation fails.
-    pub fn put(&self, username: &str, value: &[u8]) -> Result<(), anyhow::Error> {
-        self.map.put(username.as_bytes(), value)
+    /// Returns an error if the serialization of the account fails or the database operation fails.
+    pub fn put(&self, account: &Account) -> Result<(), anyhow::Error> {
+        let value = bincode::DefaultOptions::new().serialize(account)?;
+        self.map.put(account.username.as_bytes(), &value)
     }
 
-    /// Inserts an account with the given username and content.
+    /// Adds an account into the database.
     ///
     /// # Errors
     ///
-    /// Returns an error if the account already exists or the database operation fails.
-    pub fn insert(&self, username: &str, value: &[u8]) -> Result<(), anyhow::Error> {
-        self.map.insert(username.as_bytes(), value)
+    /// Returns an error if the serialization of the account fails, the account with the same
+    /// username exists, or the database operation fails.
+    pub fn insert(&self, account: &Account) -> Result<(), anyhow::Error> {
+        let value = bincode::DefaultOptions::new().serialize(account)?;
+        self.map.insert(account.username.as_bytes(), &value)
     }
 
     /// Replaces an old key-value pair with a new one.
@@ -61,7 +79,11 @@ impl<'d> Table<'d, Account> {
     ///
     /// Returns an error if the old value does not match the value in the database, the old key does
     /// not exist, or the database operation fails.
-    pub fn update(&self, old: (&[u8], &[u8]), new: (&[u8], &[u8])) -> Result<(), anyhow::Error> {
+    pub(crate) fn update_raw(
+        &self,
+        old: (&[u8], &[u8]),
+        new: (&[u8], &[u8]),
+    ) -> Result<(), anyhow::Error> {
         self.map.update(old, new)
     }
 
@@ -76,7 +98,7 @@ impl<'d> Table<'d, Account> {
     /// * The old values do not match the values in the database.
     /// * The underlying database operation fails.
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]
-    pub fn update_account(
+    pub fn update(
         &self,
         username: &[u8],
         new_password: &Option<String>,
@@ -86,8 +108,6 @@ impl<'d> Table<'d, Account> {
         allow_access_from: &Option<(Option<Vec<IpAddr>>, Option<Vec<IpAddr>>)>,
         max_parallel_sessions: &Option<(Option<u32>, Option<u32>)>,
     ) -> Result<(), anyhow::Error> {
-        use bincode::Options;
-
         loop {
             let txn = self.map.db.transaction();
             if let Some(old_value) = txn


### PR DESCRIPTION
### Changed

- `Table<Account>::put` and `Table<Account>::insert` allow adding an Account
  instance directly to the database, without requiring explicit serialization
  by the caller.
- Renamed `Table<Account>::update_account` to `Table<Account>::update`. This
  change simplifies the method name and provides a more consistent interface
  for updating `Account` records.

### Removed

- Removed the old `Table<Account>::update` method. This method was exposing the
  internal format of the database to the public API, which could lead to
  potential security and compatibility issues. To maintain a secure and
  reliable interface, we have decided to remove this method. Users should now
  use the newly renamed `Table<Account>::update` method for updating `Account`
  records.
