### PR TITLE
Add all fields in DnsCovertChannel and TorConnection event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   method returns an iterator that produces `Account` objects in each iteration.
   This change aims to simplify the usage of iterators and avoid potential
   issues related to the direct handling of serialized data.
+- Add all fields in `DnsCovertChannel` and `TorConnection` event. The added fields
+  are used to perform packet attribute criteria during the adjudication function.
+- Add the ability to migration for `DnsCovertChannel` and `TorConnection`.
 
 ### Deprecated
 
@@ -62,7 +65,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fixed query for selecting column description.
 - Fixed a case where the migration process was not correctly handling existing
-  empty values in the event_ids column.  
+  empty values in the event_ids column.
 
 ## [0.7.0] - 2023-05-02
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.8.0"
+version = "0.9.0-alpha.1"
 edition = "2021"
 
 [dependencies]

--- a/src/event/dns.rs
+++ b/src/event/dns.rs
@@ -1,18 +1,31 @@
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
-use chrono::{DateTime, Local, Utc};
+use chrono::{serde::ts_nanoseconds, DateTime, Local, Utc};
 use serde::{Deserialize, Serialize};
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
 #[derive(Deserialize, Serialize)]
-#[allow(clippy::module_name_repetitions)]
+#[allow(clippy::module_name_repetitions, clippy::struct_excessive_bools)]
 pub struct DnsEventFields {
     pub source: String,
+    #[serde(with = "ts_nanoseconds")]
+    pub session_end_time: DateTime<Utc>,
     pub src_addr: IpAddr,
     pub src_port: u16,
     pub dst_addr: IpAddr,
     pub dst_port: u16,
     pub proto: u8,
     pub query: String,
+    pub answer: Vec<String>,
+    pub trans_id: u16,
+    pub rtt: i64,
+    pub qclass: u16,
+    pub qtype: u16,
+    pub rcode: u16,
+    pub aa_flag: bool,
+    pub tc_flag: bool,
+    pub rd_flag: bool,
+    pub ra_flag: bool,
+    pub ttl: Vec<i32>,
     pub confidence: f32,
 }
 
@@ -26,16 +39,28 @@ impl fmt::Display for DnsEventFields {
     }
 }
 
-#[allow(clippy::module_name_repetitions)]
+#[allow(clippy::module_name_repetitions, clippy::struct_excessive_bools)]
 pub struct DnsCovertChannel {
     pub time: DateTime<Utc>,
     pub source: String,
+    pub session_end_time: DateTime<Utc>,
     pub src_addr: IpAddr,
     pub src_port: u16,
     pub dst_addr: IpAddr,
     pub dst_port: u16,
     pub proto: u8,
     pub query: String,
+    pub answer: Vec<String>,
+    pub trans_id: u16,
+    pub rtt: i64,
+    pub qclass: u16,
+    pub qtype: u16,
+    pub rcode: u16,
+    pub aa_flag: bool,
+    pub tc_flag: bool,
+    pub rd_flag: bool,
+    pub ra_flag: bool,
+    pub ttl: Vec<i32>,
     pub confidence: f32,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
@@ -62,12 +87,24 @@ impl DnsCovertChannel {
         Self {
             time,
             source: fields.source,
+            session_end_time: fields.session_end_time.clone(),
             src_addr: fields.src_addr,
             src_port: fields.src_port,
             dst_addr: fields.dst_addr,
             dst_port: fields.dst_port,
             proto: fields.proto,
             query: fields.query,
+            answer: fields.answer,
+            trans_id: fields.trans_id,
+            rtt: fields.rtt,
+            qclass: fields.qclass,
+            qtype: fields.qtype,
+            rcode: fields.rcode,
+            aa_flag: fields.aa_flag,
+            tc_flag: fields.tc_flag,
+            rd_flag: fields.rd_flag,
+            ra_flag: fields.ra_flag,
+            ttl: fields.ttl,
             confidence: fields.confidence,
             triage_scores: None,
         }

--- a/src/event/tor.rs
+++ b/src/event/tor.rs
@@ -1,16 +1,35 @@
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
-use chrono::{DateTime, Local, Utc};
-use serde::Deserialize;
+use chrono::{serde::ts_nanoseconds, DateTime, Local, Utc};
+use serde::{Deserialize, Serialize};
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
-#[derive(Deserialize)]
-pub(super) struct TorConnectionFields {
+#[derive(Deserialize, Serialize)]
+#[allow(clippy::module_name_repetitions)]
+pub struct TorConnectionFields {
     pub source: String,
+    #[serde(with = "ts_nanoseconds")]
+    pub session_end_time: DateTime<Utc>,
     pub src_addr: IpAddr,
     pub src_port: u16,
     pub dst_addr: IpAddr,
     pub dst_port: u16,
     pub proto: u8,
+    pub method: String,
+    pub host: String,
+    pub uri: String,
+    pub referrer: String,
+    pub version: String,
+    pub user_agent: String,
+    pub request_len: usize,
+    pub response_len: usize,
+    pub status_code: u16,
+    pub status_msg: String,
+    pub username: String,
+    pub password: String,
+    pub cookie: String,
+    pub content_encoding: String,
+    pub content_type: String,
+    pub cache_control: String,
 }
 
 impl fmt::Display for TorConnectionFields {
@@ -27,11 +46,28 @@ impl fmt::Display for TorConnectionFields {
 pub struct TorConnection {
     pub time: DateTime<Utc>,
     pub source: String,
+    pub session_end_time: DateTime<Utc>,
     pub src_addr: IpAddr,
     pub src_port: u16,
     pub dst_addr: IpAddr,
     pub dst_port: u16,
     pub proto: u8,
+    pub method: String,
+    pub host: String,
+    pub uri: String,
+    pub referrer: String,
+    pub version: String,
+    pub user_agent: String,
+    pub request_len: usize,
+    pub response_len: usize,
+    pub status_code: u16,
+    pub status_msg: String,
+    pub username: String,
+    pub password: String,
+    pub cookie: String,
+    pub content_encoding: String,
+    pub content_type: String,
+    pub cache_control: String,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -55,11 +91,28 @@ impl TorConnection {
         TorConnection {
             time,
             source: fields.source.clone(),
+            session_end_time: fields.session_end_time,
             src_addr: fields.src_addr,
             src_port: fields.src_port,
             dst_addr: fields.dst_addr,
             dst_port: fields.dst_port,
             proto: fields.proto,
+            method: fields.method.clone(),
+            host: fields.host.clone(),
+            uri: fields.uri.clone(),
+            referrer: fields.referrer.clone(),
+            version: fields.version.clone(),
+            user_agent: fields.user_agent.clone(),
+            request_len: fields.request_len,
+            response_len: fields.response_len,
+            status_code: fields.status_code,
+            status_msg: fields.status_msg.clone(),
+            username: fields.username.clone(),
+            password: fields.password.clone(),
+            cookie: fields.cookie.clone(),
+            content_encoding: fields.content_encoding.clone(),
+            content_type: fields.content_type.clone(),
+            cache_control: fields.cache_control.clone(),
             triage_scores: None,
         }
     }


### PR DESCRIPTION
- The added fields are used to perform packet attribute criteria during the adjudication function.
- Add the ability to migration for `DnsCovertChannel` and `TorConnection`.

Closes: #48, #49