### PR TITLE
Add all fields in DnsCovertChannel and TorConnection event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   method returns an iterator that produces `Account` objects in each iteration.
   This change aims to simplify the usage of iterators and avoid potential
   issues related to the direct handling of serialized data.
+- Add all fields in `DnsCovertChannel` and `TorConnection` event. The added fields
+  are used to perform packet attribute criteria during the adjudication function.
+- Add the ability to migration for `DnsCovertChannel` and `TorConnection`.
 
 ### Deprecated
 
@@ -62,7 +65,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fixed query for selecting column description.
 - Fixed a case where the migration process was not correctly handling existing
-  empty values in the event_ids column.  
+  empty values in the event_ids column.
 
 ## [0.7.0] - 2023-05-02
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.8.0"
+version = "0.9.0-alpha.1"
 edition = "2021"
 
 [dependencies]

--- a/src/event.rs
+++ b/src/event.rs
@@ -8,14 +8,13 @@ use self::{
     common::Match,
     http::{DgaFields, HttpThreatFields, RepeatedHttpSessionsFields},
     rdp::RdpBruteForceFields,
-    tor::TorConnectionFields,
 };
 pub use self::{
     common::TriageScore,
     dns::{DnsCovertChannel, DnsEventFields},
     http::{DomainGenerationAlgorithm, HttpThreat, RepeatedHttpSessions},
     rdp::RdpBruteForce,
-    tor::TorConnection,
+    tor::{TorConnection, TorConnectionFields},
 };
 use super::{
     types::{Customer, Endpoint, EventCategory, FromKeyValue, HostNetworkGroup, TriagePolicy},
@@ -29,7 +28,7 @@ use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::{FromPrimitive, ToPrimitive};
 use rand::{thread_rng, RngCore};
 pub use rocksdb::Direction;
-use rocksdb::IteratorMode;
+use rocksdb::{DBIteratorWithThreadMode, IteratorMode};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -71,7 +70,7 @@ pub enum Event {
     RepeatedHttpSessions(RepeatedHttpSessions),
 
     /// An HTTP connection to a Tor exit node.
-    TorConnection(TorConnection),
+    TorConnection(Box<TorConnection>),
 
     /// DGA (Domain Generation Algorithm) generated hostname in HTTP request message
     DomainGenerationAlgorithm(Box<DomainGenerationAlgorithm>),
@@ -687,7 +686,7 @@ fn find_network(ip: IpAddr, networks: &[Network]) -> Option<u32> {
     None
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, FromPrimitive, PartialEq, ToPrimitive)]
+#[derive(Serialize, Clone, Copy, Debug, Deserialize, Eq, FromPrimitive, PartialEq, ToPrimitive)]
 #[allow(clippy::module_name_repetitions)]
 pub enum EventKind {
     DnsCovertChannel,
@@ -793,7 +792,7 @@ fn moderate_kinds_by(kinds: &mut Vec<String>, patterns: &[&str], full_name: &str
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 #[allow(clippy::module_name_repetitions)]
 pub struct EventMessage {
     #[serde(with = "ts_nanoseconds")]
@@ -883,6 +882,12 @@ impl<'a> EventDb<'a> {
         EventIterator { inner: iter }
     }
 
+    /// Creates an raw iterator over key-value pairs for the entire events.
+    #[must_use]
+    pub fn raw_iter_forward(&self) -> DBIteratorWithThreadMode<rocksdb::OptimisticTransactionDB> {
+        self.inner.iterator(IteratorMode::Start)
+    }
+
     /// Stores a new event into the database.
     ///
     /// # Errors
@@ -925,6 +930,43 @@ impl<'a> EventDb<'a> {
             }
         }
         Ok(key)
+    }
+
+    /// Updates an old key-value pair to a new one.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the old value does not match the value in the database, the old key does
+    /// not exist, or the database operation fails.
+    pub fn update(&self, old: (&[u8], &[u8]), new: (&[u8], &[u8])) -> Result<()> {
+        loop {
+            let txn = self.inner.transaction();
+            if let Some(old_value) = txn
+                .get_for_update(old.0, super::EXCLUSIVE)
+                .context("cannot read old entry")?
+            {
+                if old.1 != old_value.as_slice() {
+                    bail!("old value mismatch");
+                }
+            } else {
+                bail!("no such entry");
+            };
+
+            txn.put(new.0, new.1).context("failed to write new entry")?;
+            if old.0 != new.0 {
+                txn.delete(old.0).context("failed to delete old entry")?;
+            }
+
+            match txn.commit() {
+                Ok(_) => break,
+                Err(e) => {
+                    if !e.as_ref().starts_with("Resource busy:") {
+                        return Err(e).context("failed to update entry");
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -998,7 +1040,7 @@ impl<'i> Iterator for EventIterator<'i> {
                     };
                 Some(Ok((
                     key,
-                    Event::TorConnection(TorConnection::new(time, &fields)),
+                    Event::TorConnection(Box::new(TorConnection::new(time, &fields))),
                 )))
             }
             EventKind::DomainGenerationAlgorithm => {
@@ -1266,12 +1308,24 @@ mod tests {
         let codec = bincode::DefaultOptions::new();
         let fields = DnsEventFields {
             source: "collector1".to_string(),
+            session_end_time: Utc::now(),
             src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             src_port: 10000,
             dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
             dst_port: 53,
             proto: 17,
             query: "foo.com".to_string(),
+            answer: vec!["1.1.1.1".to_string()],
+            trans_id: 1,
+            rtt: 1,
+            qclass: 0,
+            qtype: 0,
+            rcode: 0,
+            aa_flag: false,
+            tc_flag: false,
+            rd_flag: false,
+            ra_flag: false,
+            ttl: vec![1; 5],
             confidence: 0.8,
         };
         EventMessage {

--- a/src/event/dns.rs
+++ b/src/event/dns.rs
@@ -1,18 +1,31 @@
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
-use chrono::{DateTime, Local, Utc};
+use chrono::{serde::ts_nanoseconds, DateTime, Local, Utc};
 use serde::{Deserialize, Serialize};
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
 #[derive(Deserialize, Serialize)]
-#[allow(clippy::module_name_repetitions)]
+#[allow(clippy::module_name_repetitions, clippy::struct_excessive_bools)]
 pub struct DnsEventFields {
     pub source: String,
+    #[serde(with = "ts_nanoseconds")]
+    pub session_end_time: DateTime<Utc>,
     pub src_addr: IpAddr,
     pub src_port: u16,
     pub dst_addr: IpAddr,
     pub dst_port: u16,
     pub proto: u8,
     pub query: String,
+    pub answer: Vec<String>,
+    pub trans_id: u16,
+    pub rtt: i64,
+    pub qclass: u16,
+    pub qtype: u16,
+    pub rcode: u16,
+    pub aa_flag: bool,
+    pub tc_flag: bool,
+    pub rd_flag: bool,
+    pub ra_flag: bool,
+    pub ttl: Vec<i32>,
     pub confidence: f32,
 }
 
@@ -26,16 +39,28 @@ impl fmt::Display for DnsEventFields {
     }
 }
 
-#[allow(clippy::module_name_repetitions)]
+#[allow(clippy::module_name_repetitions, clippy::struct_excessive_bools)]
 pub struct DnsCovertChannel {
     pub time: DateTime<Utc>,
     pub source: String,
+    pub session_end_time: DateTime<Utc>,
     pub src_addr: IpAddr,
     pub src_port: u16,
     pub dst_addr: IpAddr,
     pub dst_port: u16,
     pub proto: u8,
     pub query: String,
+    pub answer: Vec<String>,
+    pub trans_id: u16,
+    pub rtt: i64,
+    pub qclass: u16,
+    pub qtype: u16,
+    pub rcode: u16,
+    pub aa_flag: bool,
+    pub tc_flag: bool,
+    pub rd_flag: bool,
+    pub ra_flag: bool,
+    pub ttl: Vec<i32>,
     pub confidence: f32,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
@@ -62,12 +87,24 @@ impl DnsCovertChannel {
         Self {
             time,
             source: fields.source,
+            session_end_time: fields.session_end_time,
             src_addr: fields.src_addr,
             src_port: fields.src_port,
             dst_addr: fields.dst_addr,
             dst_port: fields.dst_port,
             proto: fields.proto,
             query: fields.query,
+            answer: fields.answer,
+            trans_id: fields.trans_id,
+            rtt: fields.rtt,
+            qclass: fields.qclass,
+            qtype: fields.qtype,
+            rcode: fields.rcode,
+            aa_flag: fields.aa_flag,
+            tc_flag: fields.tc_flag,
+            rd_flag: fields.rd_flag,
+            ra_flag: fields.ra_flag,
+            ttl: fields.ttl,
             confidence: fields.confidence,
             triage_scores: None,
         }

--- a/src/event/tor.rs
+++ b/src/event/tor.rs
@@ -1,16 +1,35 @@
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
-use chrono::{DateTime, Local, Utc};
-use serde::Deserialize;
+use chrono::{serde::ts_nanoseconds, DateTime, Local, Utc};
+use serde::{Deserialize, Serialize};
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
-#[derive(Deserialize)]
-pub(super) struct TorConnectionFields {
+#[derive(Deserialize, Serialize)]
+#[allow(clippy::module_name_repetitions)]
+pub struct TorConnectionFields {
     pub source: String,
+    #[serde(with = "ts_nanoseconds")]
+    pub session_end_time: DateTime<Utc>,
     pub src_addr: IpAddr,
     pub src_port: u16,
     pub dst_addr: IpAddr,
     pub dst_port: u16,
     pub proto: u8,
+    pub method: String,
+    pub host: String,
+    pub uri: String,
+    pub referrer: String,
+    pub version: String,
+    pub user_agent: String,
+    pub request_len: usize,
+    pub response_len: usize,
+    pub status_code: u16,
+    pub status_msg: String,
+    pub username: String,
+    pub password: String,
+    pub cookie: String,
+    pub content_encoding: String,
+    pub content_type: String,
+    pub cache_control: String,
 }
 
 impl fmt::Display for TorConnectionFields {
@@ -27,11 +46,28 @@ impl fmt::Display for TorConnectionFields {
 pub struct TorConnection {
     pub time: DateTime<Utc>,
     pub source: String,
+    pub session_end_time: DateTime<Utc>,
     pub src_addr: IpAddr,
     pub src_port: u16,
     pub dst_addr: IpAddr,
     pub dst_port: u16,
     pub proto: u8,
+    pub method: String,
+    pub host: String,
+    pub uri: String,
+    pub referrer: String,
+    pub version: String,
+    pub user_agent: String,
+    pub request_len: usize,
+    pub response_len: usize,
+    pub status_code: u16,
+    pub status_msg: String,
+    pub username: String,
+    pub password: String,
+    pub cookie: String,
+    pub content_encoding: String,
+    pub content_type: String,
+    pub cache_control: String,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -55,11 +91,28 @@ impl TorConnection {
         TorConnection {
             time,
             source: fields.source.clone(),
+            session_end_time: fields.session_end_time,
             src_addr: fields.src_addr,
             src_port: fields.src_port,
             dst_addr: fields.dst_addr,
             dst_port: fields.dst_port,
             proto: fields.proto,
+            method: fields.method.clone(),
+            host: fields.host.clone(),
+            uri: fields.uri.clone(),
+            referrer: fields.referrer.clone(),
+            version: fields.version.clone(),
+            user_agent: fields.user_agent.clone(),
+            request_len: fields.request_len,
+            response_len: fields.response_len,
+            status_code: fields.status_code,
+            status_msg: fields.status_msg.clone(),
+            username: fields.username.clone(),
+            password: fields.password.clone(),
+            cookie: fields.cookie.clone(),
+            content_encoding: fields.content_encoding.clone(),
+            content_type: fields.content_type.clone(),
+            cache_control: fields.cache_control.clone(),
             triage_scores: None,
         }
     }

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     fs::{create_dir_all, File},
     io::{Read, Write},
+    net::IpAddr,
     path::{Path, PathBuf},
 };
 
@@ -30,7 +31,7 @@ use std::{
 /// // the database format won't be changed in the future alpha or beta versions.
 /// const COMPATIBLE_VERSION: &str = ">=0.5.0-alpha.2,<=0.5.0-alpha.4";
 /// ```
-const COMPATIBLE_VERSION_REQ: &str = ">=0.7.0,<0.9.0-alpha";
+const COMPATIBLE_VERSION_REQ: &str = ">=0.9.0-alpha.1,<0.10.0-alpha";
 
 /// Migrates the data directory to the up-to-date format if necessary.
 ///
@@ -93,6 +94,11 @@ pub fn migrate_data_dir<P: AsRef<Path>>(data_dir: P, backup_dir: P) -> Result<()
             VersionReq::parse(">=0.6.0,<0.7.0").expect("valid version requirement"),
             Version::parse("0.7.0").expect("valid version"),
             migrate_0_6_to_0_7,
+        ),
+        (
+            VersionReq::parse(">=0.7.0,<0.9.0-alpha1").expect("valid version requirement"),
+            Version::parse("0.9.0-alpha1").expect("valid version"),
+            migrate_0_7_to_0_9_alpha1,
         ),
     ];
 
@@ -175,7 +181,6 @@ pub(crate) fn migrate_0_2_to_0_3<P: AsRef<Path>>(path: P, backup: P) -> Result<(
         IterableMap,
     };
     use chrono::{DateTime, Utc};
-    use std::net::IpAddr;
 
     #[derive(Deserialize, Serialize)]
     struct OldAccount {
@@ -406,6 +411,139 @@ pub(crate) fn migrate_0_6_to_0_7<P: AsRef<Path>>(path: P, backup: P) -> Result<(
     Ok(())
 }
 
+/// Migrates the database from 0.7 to 0.9.0-alpha.1
+///
+/// # Errors
+///
+/// Returns an error if database migration fails.
+#[allow(clippy::too_many_lines)]
+pub(crate) fn migrate_0_7_to_0_9_alpha1<P: AsRef<Path>>(path: P, backup: P) -> Result<()> {
+    use crate::{
+        event::{DnsEventFields, TorConnectionFields},
+        EventKind,
+    };
+    use chrono::{TimeZone, Utc};
+    use num_traits::FromPrimitive;
+
+    #[derive(Deserialize, Serialize)]
+    pub struct OldDnsEventFields {
+        pub source: String,
+        pub src_addr: IpAddr,
+        pub src_port: u16,
+        pub dst_addr: IpAddr,
+        pub dst_port: u16,
+        pub proto: u8,
+        pub query: String,
+        pub confidence: f32,
+    }
+
+    #[derive(Deserialize, Serialize)]
+    pub struct OldTorConnectionFields {
+        pub source: String,
+        pub src_addr: IpAddr,
+        pub src_port: u16,
+        pub dst_addr: IpAddr,
+        pub dst_port: u16,
+        pub proto: u8,
+    }
+
+    impl From<OldDnsEventFields> for DnsEventFields {
+        fn from(input: OldDnsEventFields) -> Self {
+            Self {
+                source: input.source.clone(),
+                session_end_time: Utc.timestamp_nanos(0),
+                src_addr: input.src_addr,
+                src_port: input.src_port,
+                dst_addr: input.dst_addr,
+                dst_port: input.dst_port,
+                proto: input.proto,
+                query: input.query.clone(),
+                answer: Vec::new(),
+                trans_id: 0,
+                rtt: 0,
+                qclass: 1,
+                qtype: 1,
+                rcode: 0,
+                aa_flag: false,
+                tc_flag: false,
+                rd_flag: false,
+                ra_flag: false,
+                ttl: Vec::new(),
+                confidence: input.confidence,
+            }
+        }
+    }
+
+    impl From<OldTorConnectionFields> for TorConnectionFields {
+        fn from(input: OldTorConnectionFields) -> Self {
+            Self {
+                source: input.source.clone(),
+                session_end_time: Utc.timestamp_nanos(0),
+                src_addr: input.src_addr,
+                src_port: input.src_port,
+                dst_addr: input.dst_addr,
+                dst_port: input.dst_port,
+                proto: input.proto,
+                method: String::new(),
+                host: String::new(),
+                uri: String::new(),
+                referrer: String::new(),
+                version: String::new(),
+                user_agent: String::new(),
+                request_len: 0,
+                response_len: 0,
+                status_code: 0,
+                status_msg: String::new(),
+                username: String::new(),
+                password: String::new(),
+                cookie: String::new(),
+                content_encoding: String::new(),
+                content_type: String::new(),
+                cache_control: String::new(),
+            }
+        }
+    }
+
+    let store = super::Store::new(path.as_ref(), backup.as_ref())?;
+    store.backup(1)?;
+
+    let event_db = store.events();
+    for item in event_db.raw_iter_forward() {
+        let (k, v) = item.context("Failed to read events Database")?;
+        let key: [u8; 16] = if let Ok(key) = k.as_ref().try_into() {
+            key
+        } else {
+            return Err(anyhow!("Failed to migrate events: Invalid Event key"));
+        };
+        let key = i128::from_be_bytes(key);
+        let kind_num = (key & 0xffff_ffff_0000_0000) >> 32;
+        let Some(kind) = EventKind::from_i128(kind_num) else {
+            return Err(anyhow!("Failed to migrate events: Invalid Event key"));
+        };
+        match kind {
+            EventKind::DnsCovertChannel => {
+                let Ok(fields) = bincode::deserialize::<OldDnsEventFields>(v.as_ref()) else {
+                    return Err(anyhow!("Failed to migrate events: Invalid Event value"));
+                };
+                let dns_event: DnsEventFields = fields.into();
+                let new = bincode::serialize(&dns_event).unwrap_or_default();
+                event_db.update((&k, &v), (&k, &new))?;
+            }
+            EventKind::TorConnection => {
+                let Ok(fields) = bincode::deserialize::<OldTorConnectionFields>(v.as_ref()) else {
+                    return Err(anyhow!("Failed to migrate events: Invalid Event value"));
+                };
+                let tor_event: TorConnectionFields = fields.into();
+                let new = bincode::serialize(&tor_event).unwrap_or_default();
+                event_db.update((&k, &v), (&k, &new))?;
+            }
+            _ => continue,
+        }
+    }
+    store.purge_old_backups(0)?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use semver::{Version, VersionReq};
@@ -564,5 +702,77 @@ mod tests {
             })
             .collect();
         assert_eq!(reversed, updated);
+    }
+
+    #[test]
+    fn migrate_0_7_to_0_9_alpha1() {
+        use crate::{EventKind, EventMessage};
+        use chrono::{TimeZone, Utc};
+        use serde::{Deserialize, Serialize};
+        use std::net::IpAddr;
+
+        #[derive(Deserialize, Serialize)]
+        pub struct OldDnsEventFields {
+            pub source: String,
+            pub src_addr: IpAddr,
+            pub src_port: u16,
+            pub dst_addr: IpAddr,
+            pub dst_port: u16,
+            pub proto: u8,
+            pub query: String,
+            pub confidence: f32,
+        }
+
+        #[derive(Deserialize, Serialize)]
+        pub struct OldTorConnectionFields {
+            pub source: String,
+            pub src_addr: IpAddr,
+            pub src_port: u16,
+            pub dst_addr: IpAddr,
+            pub dst_port: u16,
+            pub proto: u8,
+        }
+
+        let dsn_kind = EventKind::DnsCovertChannel;
+        let dns_time = Utc.with_ymd_and_hms(2023, 1, 20, 0, 0, 0).unwrap();
+        let dns_value = OldDnsEventFields {
+            source: "reveiw1".to_string(),
+            src_addr: "192.168.4.100".parse::<IpAddr>().unwrap(),
+            src_port: 40000,
+            dst_addr: "31.3.245.100".parse::<IpAddr>().unwrap(),
+            dst_port: 80,
+            proto: 10,
+            query: "Hello Server Hello Server Hello Server".to_string(),
+            confidence: 1.1,
+        };
+        let dns_message = EventMessage {
+            time: dns_time,
+            kind: dsn_kind,
+            fields: bincode::serialize(&dns_value).unwrap_or_default(),
+        };
+
+        let tor_kind = EventKind::TorConnection;
+        let tor_time = Utc.with_ymd_and_hms(2023, 1, 20, 0, 0, 1).unwrap();
+        let tor_value = OldTorConnectionFields {
+            source: "reveiw1".to_string(),
+            src_addr: "192.168.4.200".parse::<IpAddr>().unwrap(),
+            src_port: 50000,
+            dst_addr: "31.3.245.200".parse::<IpAddr>().unwrap(),
+            dst_port: 160,
+            proto: 20,
+        };
+        let tor_message = EventMessage {
+            time: tor_time,
+            kind: tor_kind,
+            fields: bincode::serialize(&tor_value).unwrap_or_default(),
+        };
+
+        let settings = TestSchema::new();
+        let event_db = settings.store.events();
+        event_db.put(&dns_message).unwrap();
+        event_db.put(&tor_message).unwrap();
+        let (db_dir, backup_dir) = settings.close();
+
+        assert!(super::migrate_0_7_to_0_9_alpha1(db_dir.path(), backup_dir.path()).is_ok());
     }
 }


### PR DESCRIPTION
- The added fields are used to perform packet attribute criteria during the adjudication function.
- Add the ability to migration for `DnsCovertChannel` and `TorConnection`.

Closes: #48, #49