### PR TITLE
Add argon2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add all fields in `DnsCovertChannel` and `TorConnection` event. The added fields
   are used to perform packet attribute criteria during the adjudication function.
 - Add the ability to migration for `DnsCovertChannel` and `TorConnection`.
+- Add support for `argon2id` as a password hashing algorithm.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 aho-corasick = "0.7"
 anyhow = "1"
+argon2 = { version = "0.5", features = ["std"] }
 bb8-postgres = { version = "0.8", features = [
   "with-serde_json-1",
   "with-chrono-0_4",


### PR DESCRIPTION
Use the one of the recommended configuration settings in the [OWASP guidelines](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id):

```
the minimum memory size = 19456 
the minimum number of iterations = 2
the degree of parallelism = 1
```

These values are equivalent to `Argon2::default()`.

Closes https://github.com/petabi/review-database/issues/15