### PR TITLE
Bug fix: event_sources is updated to NULL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,19 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue where the `event_source` column becomes `null` when the value
+  of `max_event_id_num` gets updated.
+
 ## [0.10.0] - 2023-05-16
 
 ### Changed
 
 - Improved security by hiding `SaltedPassword`, `Account::password` field and
   related operations from user access.
-
-### Fixed
-
-- Fixed an issue where the `event_source` column becomes `null` when the value
-  of `max_event_id_num` gets updated.
 
 ## [0.9.0] - 2023-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Improved security by hiding `SaltedPassword`, `Account::password` field and
   related operations from user access.
 
+### Fixed
+
+- Fixed an issue where the `event_source` column becomes `null` when the value
+  of `max_event_id_num` gets updated.
+
 ## [0.9.0] - 2023-05-15
 
 ### Added

--- a/src/backends/postgres/migrations/2023-05-16-202453_update_attempt_event_ids_update/down.sql
+++ b/src/backends/postgres/migrations/2023-05-16-202453_update_attempt_event_ids_update/down.sql
@@ -1,0 +1,1 @@
+-- This file intentionally left blank

--- a/src/backends/postgres/migrations/2023-05-16-202453_update_attempt_event_ids_update/up.sql
+++ b/src/backends/postgres/migrations/2023-05-16-202453_update_attempt_event_ids_update/up.sql
@@ -1,0 +1,58 @@
+CREATE OR REPLACE FUNCTION attempt_event_ids_update()
+RETURNS TRIGGER AS
+$$
+DECLARE
+  _id INTEGER;
+  _event_ids BIGINT[];
+  _event_sources TEXT[];
+  _event_ids_update BIGINT[];
+  _event_sources_update TEXT[];
+BEGIN
+  FOR _id, _event_ids, _event_sources IN
+    SELECT cluster.id, cluster.event_ids, cluster.event_sources
+    FROM cluster
+    WHERE array_length(cluster.event_ids, 1) > NEW.max_event_id_num
+      AND cluster.model_id = OLD.id
+  LOOP
+    LOOP
+      SELECT ARRAY_AGG(t.id), ARRAY_AGG(t.src)
+        INTO _event_ids_update, _event_sources_update
+        FROM (
+          SELECT _event_ids[i] AS id, _event_sources[i] AS src
+          FROM generate_series(1, array_length(_event_ids, 1)) i
+          WHERE _event_ids[i] <> (SELECT MIN(j) FROM unnest(_event_ids) j)
+        ) t;
+      _event_ids := _event_ids_update;
+      _event_sources := _event_sources_update;
+      IF (array_length(_event_ids, 1) > NEW.max_event_id_num) IS NOT TRUE THEN
+        EXIT;
+      END IF;
+    END LOOP;
+    UPDATE cluster SET event_ids = _event_ids, event_sources = _event_sources WHERE cluster.id = _id;
+  END LOOP;
+
+  FOR _id, _event_ids, _event_sources IN
+    SELECT outlier.id, outlier.event_ids, outlier.event_sources
+    FROM outlier
+    WHERE array_length(outlier.event_ids, 1) > NEW.max_event_id_num
+      AND outlier.model_id = OLD.id
+  LOOP
+    LOOP
+      SELECT ARRAY_AGG(t.id), ARRAY_AGG(t.src)
+        INTO _event_ids_update, _event_sources_update
+        FROM (
+          SELECT _event_ids[i] AS id, _event_sources[i] AS src
+          FROM generate_series(1, array_length(_event_ids, 1)) i
+          WHERE _event_ids[i] <> (SELECT MIN(j) FROM unnest(_event_ids) j)
+        ) t;
+      _event_ids := _event_ids_update;
+      _event_sources := _event_sources_update;
+      IF (array_length(_event_ids, 1) > NEW.max_event_id_num) IS NOT TRUE THEN
+        EXIT;
+      END IF;
+    END LOOP;
+    UPDATE outlier SET event_ids = _event_ids, event_sources = _event_sources WHERE outlier.id = _id;
+  END LOOP;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
When the value of `max_event_id_num` has changed, the `attempt_event_ids_update` function is fired to update `event_ids` and `event_sources`. The problem is that the result of the SELECT statement in the below code. The values of `cluster.id` and `cluster.event_ids` are assigned to `_id` and `_event_ids` variables respectively but no variable for `cluster.event_sources`.

```
  FOR _id, _event_ids IN
    SELECT cluster.id, cluster.event_ids, cluster.event_sources, cluster.model_id
    FROM cluster
    WHERE array_length(cluster.event_ids, 1) > NEW.max_event_id_num
      AND cluster.model_id = OLD.id
```

This causes the `event_sources` column to be updated to `NULL`.

```
     id  | size  |                      event_sources                       
------+-------+----------------------------------------------------------
    1 |     2 | {httpprefix,httpprefix}
    2 |    15 | {NULL,NULL,NULL,NULL,NULL}
    3 |    82 | {NULL,NULL,NULL,NULL,NULL}
    4 |    15 | {NULL,NULL,NULL,NULL,NULL}
    5 |     2 | {httpprefix,httpprefix}
    6 |     6 | {NULL,NULL,NULL,NULL,NULL}
    7 |     4 | {httpprefix,httpprefix,httpprefix,httpprefix}
    8 |    12 | {NULL,NULL,NULL,NULL,NULL}
    9 |     7 | {NULL,NULL,NULL,NULL,NULL}
   10 |     7 | {httpprefix,httpprefix,httpprefix,httpprefix,httpprefix}
   11 |     4 | {httpprefix,httpprefix,httpprefix,httpprefix}
   12 |     6 | {NULL,NULL,NULL,NULL,NULL}
   13 |     8 | {NULL,NULL,NULL,NULL,NULL}
   14 |    18 | {NULL,NULL,NULL,NULL,NULL}
   15 |     5 | {httpprefix,httpprefix,httpprefix,httpprefix,httpprefix}

```

The fix is simply adding `_event_sources` in the first line:

```
  FOR _id, _event_ids, _event_sources IN    
    SELECT cluster.id, cluster.event_ids, cluster.event_sources
    FROM cluster
    WHERE array_length(cluster.event_ids, 1) > NEW.max_event_id_num
      AND cluster.model_id = OLD.id
```