### PR TITLE
fix HttpThreat event timestamp definition and DGA bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Remove `policy` field from `DataSource`.
 
+### Fixed
+
+- Fix the bug writing `invalid event` to syslog for `DGA` event.
+- Fix `time: DateTime<Utc>` to `#[serde(with = "ts_nanoseconds")] time: DateTime<Utc>`
+  of `HttpThreatFields` event fields from REconverge.
+
 ## [0.11.0] - 2023-05-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Remove `policy` field from `DataSource`.
+- Add `confidence` field to `DgaFields` event from Hog.
 
 ### Fixed
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -4,15 +4,13 @@ mod http;
 mod rdp;
 mod tor;
 
-use self::{
-    common::Match,
-    http::{DgaFields, RepeatedHttpSessionsFields},
-    rdp::RdpBruteForceFields,
-};
+use self::{common::Match, http::RepeatedHttpSessionsFields, rdp::RdpBruteForceFields};
 pub use self::{
     common::TriageScore,
     dns::{DnsCovertChannel, DnsEventFields},
-    http::{DomainGenerationAlgorithm, HttpThreat, HttpThreatFields, RepeatedHttpSessions},
+    http::{
+        DgaFields, DomainGenerationAlgorithm, HttpThreat, HttpThreatFields, RepeatedHttpSessions,
+    },
     rdp::RdpBruteForce,
     tor::{TorConnection, TorConnectionFields},
 };
@@ -1385,6 +1383,7 @@ mod tests {
             content_encoding: "encoding type".to_string(),
             content_type: "content type".to_string(),
             cache_control: "no cache".to_string(),
+            confidence: 0.8,
         };
         let msg = EventMessage {
             time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),

--- a/src/event/http.rs
+++ b/src/event/http.rs
@@ -115,6 +115,7 @@ impl Match for RepeatedHttpSessions {
 #[derive(Debug, Deserialize, Serialize)]
 #[allow(clippy::module_name_repetitions)]
 pub struct HttpThreatFields {
+    #[serde(with = "ts_nanoseconds")]
     pub time: DateTime<Utc>,
     pub source: String,
     pub src_addr: IpAddr,

--- a/src/event/http.rs
+++ b/src/event/http.rs
@@ -371,6 +371,27 @@ pub struct DgaFields {
     pub cache_control: String,
 }
 
+impl fmt::Display for DgaFields {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let user_agent = self.user_agent.replace(',', " ");
+        write!(
+            f,
+            "{},{},{},{},{},DGA,3,{},{},{},{},{},{}",
+            self.src_addr,
+            self.src_port,
+            self.dst_addr,
+            self.dst_port,
+            self.proto,
+            self.method,
+            self.host,
+            self.uri,
+            self.referer,
+            self.status_code,
+            user_agent
+        )
+    }
+}
+
 #[derive(Deserialize, Serialize)]
 pub struct DomainGenerationAlgorithm {
     #[serde(with = "ts_nanoseconds")]

--- a/src/event/http.rs
+++ b/src/event/http.rs
@@ -369,6 +369,7 @@ pub struct DgaFields {
     pub content_encoding: String,
     pub content_type: String,
     pub cache_control: String,
+    pub confidence: f32,
 }
 
 impl fmt::Display for DgaFields {
@@ -419,6 +420,7 @@ pub struct DomainGenerationAlgorithm {
     pub content_encoding: String,
     pub content_type: String,
     pub cache_control: String,
+    pub confidence: f32,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -471,6 +473,7 @@ impl DomainGenerationAlgorithm {
             content_encoding: fields.content_encoding,
             content_type: fields.content_type,
             cache_control: fields.cache_control,
+            confidence: fields.confidence,
             triage_scores: None,
         }
     }
@@ -514,7 +517,7 @@ impl Match for DomainGenerationAlgorithm {
     }
 
     fn confidence(&self) -> Option<f32> {
-        None
+        Some(self.confidence)
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {


### PR DESCRIPTION
* Fix HttpThreat timestamp field definition
```rust
 pub struct HttpThreatFields {
+    #[serde(with = "ts_nanoseconds")]
     pub time: DateTime<Utc>,
     pub source: String,

```
* Fix DGA display trait bug: `invalid event` in syslog message for DGA event
```
May 19 16:43:22 manage review[0]: 2019-07-08T07:38:56.979357+00:00,invalid event
May 19 16:43:22 manage review[0]: 2019-07-08T07:38:56.132598+00:00,invalid event
May 19 16:43:24 manage review[0]: 2019-07-08T07:38:57.060577+00:00,DnsCovertChannel,203.254.128.12,59943,106.11.211.66,53,17,DNS covert channel,3,asfnu13u1__asfh98h138tghbasf_qeih02h3gus_13iht0hvubegubouvuon_1.kfv0a.cn
```

* Add `confidence` field to `DgaFields` event from Hog