### PR TITLE
Rename `backup` to `start_periodic_backup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## Added
+### Added
 
 - New functions in `Store`:
   - `Store::get_backup_info`: This new function retrieves the details of
@@ -20,6 +20,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
     from a specific backup, given a backup ID. The feature adds significant
     utility to the users by enabling them to restore data from the selected
     backup easily and quickly.
+
+### Changed
+
+- The `backup` function has been renamed to `start_periodic_backup` for better
+  clarity and to more accurately represent its functionality of initiating
+  periodic backups. Please update any references in your codebase accordingly.
 
 ## [0.12.0] - 2023-05-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.12.1-alpha.1"
+version = "0.13.0-alpha.1"
 edition = "2021"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ impl Store {
 /// # Errors
 ///
 /// Returns an error if backup fails.
-pub async fn backup(
+pub async fn start_periodic_backup(
     store: Arc<Store>,
     schedule: (Duration, Duration),
     backups_to_keep: u32,

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -31,7 +31,7 @@ use std::{
 /// // the database format won't be changed in the future alpha or beta versions.
 /// const COMPATIBLE_VERSION: &str = ">=0.5.0-alpha.2,<=0.5.0-alpha.4";
 /// ```
-const COMPATIBLE_VERSION_REQ: &str = ">=0.12.0,<0.13.0-alpha";
+const COMPATIBLE_VERSION_REQ: &str = ">=0.12.0,<=0.13.0-alpha.1";
 
 /// Migrates the data directory to the up-to-date format if necessary.
 ///


### PR DESCRIPTION
The `backup` function has been renamed to `start_periodic_backup` for better clarity and to more accurately represent its functionality of initiating periodic backups. Please update any references in your codebase accordingly.