### PR TITLE
Add `backup::create`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `backup::create`: This new function creates a new RocksDB backup. In a future
+  release, this function will be enhanced to support creation of PostgreSQL
+  backups as well. This provides a centralized and consistent interface for
+  creating backups across different types of databases.
 - New functions in `Store`:
   - `Store::get_backup_info`: This new function retrieves the details of
     backups stored on filesystem. The returned information is in the form of
@@ -23,9 +27,17 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- The `backup` function has been renamed to `start_periodic_backup` for better
-  clarity and to more accurately represent its functionality of initiating
-  periodic backups. Please update any references in your codebase accordingly.
+- The `backup` function has been renamed to `backup::schedule_periodic` for
+  better clarity and to more accurately represent its functionality of
+  initiating periodic backups. Please update any references in your codebase
+  accordingly.
+
+### Removed
+
+- `Store::backup` has been removed from our API. It is replaced by the
+  `backup::create` function to streamline and centralize backup operations.
+  Please update your codebase to call `backup::create` for creating database
+  backups.
 
 ## [0.12.0] - 2023-05-22
 

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -1,0 +1,55 @@
+//! Database backup utilities.
+
+use std::{sync::Arc, time::Duration};
+
+use anyhow::Result;
+use tokio::sync::Notify;
+use tracing::{info, warn};
+
+use crate::Store;
+
+/// Schedules periodic database backups.
+#[allow(clippy::module_name_repetitions)]
+pub async fn schedule_periodic(
+    store: Arc<Store>,
+    schedule: (Duration, Duration),
+    backups_to_keep: u32,
+    stop: Arc<Notify>,
+) {
+    use tokio::time::{sleep, Instant};
+
+    let (init, duration) = schedule;
+    let sleep = sleep(init);
+    tokio::pin!(sleep);
+
+    loop {
+        tokio::select! {
+            () = &mut sleep => {
+                sleep.as_mut().reset(Instant::now() + duration);
+                let _res = create(&store, backups_to_keep);
+            }
+            _ = stop.notified() => {
+                info!("creating a database backup before shutdown");
+                let _res = create(&store, backups_to_keep);
+                stop.notify_one();
+                return;
+            }
+
+        }
+    }
+}
+
+/// Creates a new database backup, keeping the specified number of backups.
+///
+/// # Errors
+///
+/// Returns an error if backup fails.
+pub fn create(store: &Store, backups_to_keep: u32) -> Result<()> {
+    // TODO: This function should be expanded to support PostgreSQL backups as well.
+    if let Err(e) = store.backup(backups_to_keep) {
+        warn!("database backup failed: {:?}", e);
+        return Err(e);
+    }
+    info!("database backup created");
+    Ok(())
+}


### PR DESCRIPTION
This new function creates a new RocksDB backup. In a future release, this function will be enhanced to support creation of PostgreSQL backups as well. This provides a centralized and consistent interface for creating backups across different types of databases.