### PR TITLE
Remove `Database::update_agent_status`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   `{model_name}-{timestamp}.tmm`. It is now mandatory to use the .tmm extension
   for model files.
 
+### Removed
+
+- `Database::update_agent_status`: This function has been removed from the
+review-database. Previously, `Database::update_agent_status` was utilized when
+REview allowed its agents to forward messages from another agent who wasn't
+directly connected to REview. However, in the recent architecture change, every
+agent is now directly connected to REview, rendering this function obsolete. As
+such, `Database::update_agent_status` has been removed in this release,
+simplifying the overall architecture and reducing unnecessary function calls.
+
 ## [0.13.2] - 2023-05-31
 
 ### Added

--- a/src/ti.rs
+++ b/src/ti.rs
@@ -1,4 +1,4 @@
-use super::{Database, Error, IterableMap, Store, Type};
+use super::{IterableMap, Store};
 use anyhow::{bail, Context, Result};
 use bincode::Options;
 use data_encoding::BASE64;
@@ -231,21 +231,4 @@ pub enum TidbKind {
     Url,
     Token,
     Regex,
-}
-
-impl Database {
-    /// Updates the status of the agent.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if an underlying database operation fails.
-    pub async fn update_agent_status(&self, hostname: String, status: bool) -> Result<(), Error> {
-        let conn = self.pool.get().await?;
-        let id = conn
-            .select_one_from::<i32>("node", &["id"], &[("hostname", Type::TEXT)], &[&hostname])
-            .await?;
-        conn.update("node", id, &[("status", Type::BOOL)], &[&status])
-            .await?;
-        Ok(())
-    }
 }


### PR DESCRIPTION
This function has been removed from the review-database. Previously, `Database::update_agent_status` was utilized when REview allowed its agents to forward messages from another agent who wasn't directly connected to REview. However, in the recent architecture change, every agent is now directly connected to REview, rendering this function obsolete.

Closes #84.