### PR TITLE
add migration log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Modified the model file naming convention from `{model_name}-{timestamp}` to
   `{model_name}-{timestamp}.tmm`. It is now mandatory to use the .tmm extension
   for model files.
+- Change to write log message `Migrating database to {version}` when migration
+  begins.
 
 ### Removed
 

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -10,6 +10,7 @@ use std::{
     net::IpAddr,
     path::{Path, PathBuf},
 };
+use tracing::info;
 
 /// The range of versions that use the current database format.
 ///
@@ -116,6 +117,7 @@ pub fn migrate_data_dir<P: AsRef<Path>>(data_dir: P, backup_dir: P) -> Result<()
         .iter()
         .find(|(req, _to, _m)| req.matches(&version))
     {
+        info!("Migrating database to {to}");
         m(data_dir, backup_dir)?;
         version = to.clone();
         if compatible.matches(&version) {


### PR DESCRIPTION
Add log message for migration.
In the case of a large DB, the migration process takes too much time, and users may misunderstand that it is malfunctioning.