### PR TITLE
Rename identifiers to conform to the guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Renamed `ExternalDDos` to `ExternalDdos` and `ExternalDDosFields` to
+  `ExternalDdosFields` in line with the Rust API Guidelines. This change
+  improves consistency with the way acronyms are capitalized in UpperCamelCase.
+  According to the guidelines, acronyms and contractions of compound words are
+  to be treated as one word. For example, use `Uuid` instead of `UUID`, `Usize`
+  instead of `USize`, or `Stdin` instead of `StdIn`.
+
+  Please note that this is a breaking change and you will need to update your
+  code if you have been using the old naming convention. We apologise for any
+  inconvenience this may cause, but we believe this change will bring greater
+  consistency and readability to the codebase.
+
 ## [0.15.1] - 2023-06-26
 
 ### Added
@@ -395,6 +411,7 @@ leading to a more streamlined system.
 
 - An initial version.
 
+[Unreleased]: https://github.com/petabi/review-database/compare/0.15.1...main
 [0.15.1]: https://github.com/petabi/review-database/compare/0.15.0...0.15.1
 [0.15.0]: https://github.com/petabi/review-database/compare/0.14.1...0.15.0
 [0.14.1]: https://github.com/petabi/review-database/compare/0.14.0...0.14.1

--- a/src/event.rs
+++ b/src/event.rs
@@ -12,7 +12,7 @@ use self::{common::Match, http::RepeatedHttpSessionsFields, rdp::RdpBruteForceFi
 pub use self::{
     common::TriageScore,
     conn::{
-        ExternalDDos, ExternalDDosFields, MultiHostPortScan, MultiHostPortScanFields, PortScan,
+        ExternalDdos, ExternalDdosFields, MultiHostPortScan, MultiHostPortScanFields, PortScan,
         PortScanFields,
     },
     dns::{DnsCovertChannel, DnsEventFields},
@@ -106,7 +106,7 @@ pub enum Event {
     MultiHostPortScan(MultiHostPortScan),
 
     /// multiple internal host attempt a DDOS attack against a specific external host.
-    ExternalDDos(ExternalDDos),
+    ExternalDdos(ExternalDdos),
 
     /// Non-browser user agent detected in HTTP request message.
     NonBrowser(NonBrowser),
@@ -142,7 +142,7 @@ impl Event {
             Event::FtpPlainText(event) => event.matches(locator, filter),
             Event::PortScan(event) => event.matches(locator, filter),
             Event::MultiHostPortScan(event) => event.matches(locator, filter),
-            Event::ExternalDDos(event) => event.matches(locator, filter),
+            Event::ExternalDdos(event) => event.matches(locator, filter),
             Event::NonBrowser(event) => event.matches(locator, filter),
             Event::LdapBruteForce(event) => event.matches(locator, filter),
             Event::LdapPlainText(event) => event.matches(locator, filter),
@@ -234,7 +234,7 @@ impl Event {
                     *entry += 1;
                 }
             }
-            Event::ExternalDDos(event) => {
+            Event::ExternalDdos(event) => {
                 if event.matches(locator.clone(), filter)?.0 {
                     let dst_country = locator.as_ref().map_or_else(
                         || "ZZ".to_string(),
@@ -341,7 +341,7 @@ impl Event {
                     *entry += 1;
                 }
             }
-            Event::ExternalDDos(event) => {
+            Event::ExternalDdos(event) => {
                 if event.matches(locator, filter)?.0 {
                     let entry = counter.entry(EventCategory::Impact).or_insert(0);
                     *entry += 1;
@@ -433,7 +433,7 @@ impl Event {
                     *entry += 1;
                 }
             }
-            Event::ExternalDDos(event) => {
+            Event::ExternalDdos(event) => {
                 if event.matches(locator, filter)?.0 {
                     let entry = counter.entry(event.dst_addr).or_insert(0);
                     *entry += 1;
@@ -520,7 +520,7 @@ impl Event {
                 }
             }
             Event::MultiHostPortScan(_event) => {}
-            Event::ExternalDDos(_event) => {}
+            Event::ExternalDdos(_event) => {}
             Event::NonBrowser(event) => {
                 if event.matches(locator, filter)?.0 {
                     let entry = counter.entry((event.src_addr, event.dst_addr)).or_insert(0);
@@ -621,7 +621,7 @@ impl Event {
                 }
             }
             Event::MultiHostPortScan(_event) => {}
-            Event::ExternalDDos(_event) => {}
+            Event::ExternalDdos(_event) => {}
             Event::NonBrowser(event) => {
                 if event.matches(locator, filter)?.0 {
                     let entry = counter
@@ -722,7 +722,7 @@ impl Event {
                     *entry += 1;
                 }
             }
-            Event::ExternalDDos(_event) => {}
+            Event::ExternalDdos(_event) => {}
             Event::NonBrowser(event) => {
                 if event.matches(locator, filter)?.0 {
                     let entry = counter.entry(event.src_addr).or_insert(0);
@@ -807,7 +807,7 @@ impl Event {
                 }
             }
             Event::MultiHostPortScan(_event) => {}
-            Event::ExternalDDos(event) => {
+            Event::ExternalDdos(event) => {
                 if event.matches(locator, filter)?.0 {
                     let entry = counter.entry(event.dst_addr).or_insert(0);
                     *entry += 1;
@@ -911,7 +911,7 @@ impl Event {
                     *entry += 1;
                 }
             }
-            Event::ExternalDDos(event) => {
+            Event::ExternalDdos(event) => {
                 if event.matches(locator, filter)?.0 {
                     let entry = counter.entry(EXTERNAL_DDOS.to_string()).or_insert(0);
                     *entry += 1;
@@ -1011,7 +1011,7 @@ impl Event {
                     *entry += 1;
                 }
             }
-            Event::ExternalDDos(event) => {
+            Event::ExternalDdos(event) => {
                 if event.matches(locator, filter)?.0 {
                     let entry = counter.entry(MEDIUM).or_insert(0);
                     *entry += 1;
@@ -1164,7 +1164,7 @@ impl Event {
                     }
                 }
             }
-            Event::ExternalDDos(event) => {
+            Event::ExternalDdos(event) => {
                 if event.matches(locator, filter)?.0 {
                     if let Some(id) = find_network(event.dst_addr, networks) {
                         let entry = counter.entry(id).or_insert(0);
@@ -1245,7 +1245,7 @@ impl Event {
             Event::MultiHostPortScan(event) => {
                 event.triage_scores = Some(triage_scores);
             }
-            Event::ExternalDDos(event) => {
+            Event::ExternalDdos(event) => {
                 event.triage_scores = Some(triage_scores);
             }
             Event::NonBrowser(event) => {
@@ -1287,7 +1287,7 @@ pub enum EventKind {
     NonBrowser,
     LdapBruteForce,
     LdapPlainText,
-    ExternalDDos,
+    ExternalDdos,
 }
 
 /// Machine Learning Method.
@@ -1502,9 +1502,9 @@ impl fmt::Display for EventMessage {
                     write!(f, "invalid event")
                 }
             }
-            EventKind::ExternalDDos => {
-                if let Ok(fields) = bincode::deserialize::<ExternalDDosFields>(&self.fields) {
-                    write!(f, "ExternalDDos,{fields}")
+            EventKind::ExternalDdos => {
+                if let Ok(fields) = bincode::deserialize::<ExternalDdosFields>(&self.fields) {
+                    write!(f, "ExternalDdos,{fields}")
                 } else {
                     write!(f, "invalid event")
                 }
@@ -1786,15 +1786,15 @@ impl<'i> Iterator for EventIterator<'i> {
                     Event::LdapPlainText(LdapPlainText::new(time, fields)),
                 )))
             }
-            EventKind::ExternalDDos => {
+            EventKind::ExternalDdos => {
                 let Ok(fields) =
-                    bincode::deserialize::<ExternalDDosFields>(v.as_ref())
+                    bincode::deserialize::<ExternalDdosFields>(v.as_ref())
                 else {
                     return Some(Err(InvalidEvent::Value(v)));
                 };
                 Some(Ok((
                     key,
-                    Event::ExternalDDos(ExternalDDos::new(time, &fields)),
+                    Event::ExternalDdos(ExternalDdos::new(time, &fields)),
                 )))
             }
             EventKind::Log => None,

--- a/src/event/conn.rs
+++ b/src/event/conn.rs
@@ -226,7 +226,7 @@ impl Match for MultiHostPortScan {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct ExternalDDosFields {
+pub struct ExternalDdosFields {
     pub src_addrs: Vec<IpAddr>,
     pub dst_addr: IpAddr,
     pub proto: u8,
@@ -234,7 +234,7 @@ pub struct ExternalDDosFields {
     pub last_time: DateTime<Utc>,
 }
 
-impl fmt::Display for ExternalDDosFields {
+impl fmt::Display for ExternalDdosFields {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -245,7 +245,7 @@ impl fmt::Display for ExternalDDosFields {
 }
 
 #[allow(clippy::module_name_repetitions)]
-pub struct ExternalDDos {
+pub struct ExternalDdos {
     pub time: DateTime<Utc>,
     pub src_addrs: Vec<IpAddr>,
     pub dst_addr: IpAddr,
@@ -255,7 +255,7 @@ pub struct ExternalDDos {
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
-impl fmt::Display for ExternalDDos {
+impl fmt::Display for ExternalDdos {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -269,9 +269,9 @@ impl fmt::Display for ExternalDDos {
     }
 }
 
-impl ExternalDDos {
-    pub(super) fn new(time: DateTime<Utc>, fields: &ExternalDDosFields) -> Self {
-        ExternalDDos {
+impl ExternalDdos {
+    pub(super) fn new(time: DateTime<Utc>, fields: &ExternalDdosFields) -> Self {
+        ExternalDdos {
             time,
             src_addrs: fields.src_addrs.clone(),
             dst_addr: fields.dst_addr,
@@ -283,7 +283,7 @@ impl ExternalDDos {
     }
 }
 
-impl Match for ExternalDDos {
+impl Match for ExternalDdos {
     fn src_addr(&self) -> IpAddr {
         IpAddr::V4(Ipv4Addr::UNSPECIFIED)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub use self::csv_column_extra::CsvColumnExtraConfig;
 pub use self::event::EventKind;
 pub use self::event::{
     find_ip_country, Direction, DnsCovertChannel, DomainGenerationAlgorithm, Event, EventDb,
-    EventFilter, EventIterator, EventMessage, ExternalDDos, Filter, FilterEndpoint, FlowKind,
+    EventFilter, EventIterator, EventMessage, ExternalDdos, Filter, FilterEndpoint, FlowKind,
     FtpBruteForce, FtpPlainText, HttpThreat, LdapBruteForce, LdapPlainText, LearningMethod,
     MultiHostPortScan, Network, NetworkEntry, NetworkEntryValue, NetworkType, NonBrowser, PortScan,
     RdpBruteForce, RepeatedHttpSessions, TorConnection, TrafficDirection, TriageScore,


### PR DESCRIPTION
Renamed `ExternalDDos` to `ExternalDdos` and `ExternalDDosFields` to `ExternalDdosFields` in line with the Rust API Guidelines. This change improves consistency with the way acronyms are capitalized in UpperCamelCase. According to the guidelines, acronyms and contractions of compound words are to be treated as one word. For example, use `Uuid` instead of `UUID`, `Usize` instead of `USize`, or `Stdin` instead of `StdIn`.
