### PR TITLE
Fix issues in load_model_by_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Use a Rust struct that matches the Postgres table schema when loading a model
+  from the Postgres database.
+
 ## [0.19.0] - 2023-09-25
 
 ### Added
@@ -502,6 +509,7 @@ leading to a more streamlined system.
 
 - An initial version.
 
+[Unreleased]: https://github.com/petabi/review-database/compare/0.19.0...main
 [0.19.0]: https://github.com/petabi/review-database/compare/0.18.0...0.19.0
 [0.18.0]: https://github.com/petabi/review-database/compare/0.17.1...0.18.0
 [0.17.1]: https://github.com/petabi/review-database/compare/0.17.0...0.17.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.19.0"
+version = "0.19.1-alpha.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
There are mismatches in the column/field name (`serialized_classifier ` vs `classifier`) and the data type (`i64` vs `Option<i64>` for `classification_id`) between the Rust `SqlModel` struct and the Postgres table schema `model` which causes errors when loading a model from the Postgres database. 

The Rust struct `SqlModel`:
```
pub struct SqlModel {
    pub id: i32,
    name: String,
    version: i32,
    kind: String,
    serialized_classifier: Vec<u8>,
    max_event_id_num: i32,
    data_source_id: i32,
    classification_id: i64,
}
```

Postgres table schema `Model`
```
                                  Table "public.model"
      Column       |  Type   | Collation | Nullable |              Default              
-------------------+---------+-----------+----------+-----------------------------------
 id                | integer |           | not null | nextval('model_id_seq'::regclass)
 name              | text    |           | not null | 
 kind              | text    |           | not null | 
 max_event_id_num  | integer |           | not null | 
 data_source_id    | integer |           | not null | 
 classifier        | bytea   |           | not null | 
 classification_id | bigint  |           |          | 
 version           | integer |           | not null | 0

```