### PR TITLE
Batch info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Removed `batch_info` and `scores` arguments from `Model::from_storage` function.
+  These arguments were previously used for custom initialization of the
+  `batch_info` and `scores` fields within the model. This change means that when
+  you create a model using `Model::from_storage`, the  `batch_info` and `scores`
+  fields will now be initialized with their default values. If you previously
+  relied on custom values for these fields, you will need to update your code accordingly.
+
 ## [0.20.0] - 2023-10-06
 
 ### Added
@@ -517,6 +528,7 @@ leading to a more streamlined system.
 
 - An initial version.
 
+[Unreleased]: https://github.com/petabi/review-database/compare/0.20.0...main
 [0.20.0]: https://github.com/petabi/review-database/compare/0.19.0...0.20.0
 [0.19.0]: https://github.com/petabi/review-database/compare/0.18.0...0.19.0
 [0.18.0]: https://github.com/petabi/review-database/compare/0.17.1...0.18.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.20.0"
+version = "0.21.0-alpha.1"
 edition = "2021"
 
 [dependencies]

--- a/src/backends/postgres/migrations/2023-10-25-192729_deprecate_event_range/down.sql
+++ b/src/backends/postgres/migrations/2023-10-25-192729_deprecate_event_range/down.sql
@@ -1,0 +1,11 @@
+ALTER TABLE IF EXISTS column_description
+    ADD COLUMN IF NOT EXISTS event_range_ids INTEGER[] DEFAULT '{}'::integer[] NOT NULL;
+
+UPDATE column_description AS c
+    SET event_range_ids = ARRAY[e.id]
+    FROM event_range AS e
+    WHERE c.cluster_id = e.id AND c.batch_ts = e.time;
+
+ALTER TABLE IF EXISTS column_description
+    DROP COLUMN cluster_id,
+    DROP COLUMN batch_ts;

--- a/src/backends/postgres/migrations/2023-10-25-192729_deprecate_event_range/up.sql
+++ b/src/backends/postgres/migrations/2023-10-25-192729_deprecate_event_range/up.sql
@@ -1,0 +1,15 @@
+ALTER TABLE IF EXISTS column_description
+    DROP COLUMN IF EXISTS cluster_id,
+    DROP COLUMN IF EXISTS batch_ts,
+    ADD COLUMN cluster_id INTEGER default 0,
+    ADD COLUMN batch_ts TIMESTAMP default 'EPOCH'::TIMESTAMP;
+
+UPDATE column_description
+    SET cluster_id = e.cluster_id, batch_ts = e.time
+    FROM event_range AS e
+    WHERE column_description.event_range_ids[1] = e.id;
+
+ALTER TABLE IF EXISTS column_description
+    ALTER COLUMN cluster_id SET NOT NULL,
+    ALTER COLUMN batch_ts SET NOT NULL,
+    DROP COLUMN event_range_ids;

--- a/src/column_statistics.rs
+++ b/src/column_statistics.rs
@@ -5,4 +5,4 @@ mod save;
 pub use load::Statistics;
 pub use round::{RoundByCluster, RoundByModel};
 #[allow(clippy::module_name_repetitions)]
-pub use save::statistics::{ColumnStatisticsUpdate, EventRange};
+pub use save::statistics::ColumnStatisticsUpdate;

--- a/src/column_statistics/load/binary.rs
+++ b/src/column_statistics/load/binary.rs
@@ -2,7 +2,8 @@ use super::{
     schema::{
         column_description::dsl as cd, description_binary::dsl as desc, top_n_binary::dsl as top_n,
     },
-    ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
+    ColumnIndex, DescriptionIndex, Error, Statistics, ToDescription, ToElementCount,
+    ToNLargestCount,
 };
 use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
 use diesel_async::{pg::AsyncPgConnection, RunQueryDsl};
@@ -10,6 +11,7 @@ use structured::{Description, Element, ElementCount, NLargestCount};
 
 #[derive(Debug, Queryable)]
 struct DescriptionBinary {
+    id: i32,
     column_index: i32,
     count: i64,
     unique_count: i64,
@@ -19,6 +21,12 @@ struct DescriptionBinary {
 impl ColumnIndex for DescriptionBinary {
     fn column_index(&self) -> i32 {
         self.column_index
+    }
+}
+
+impl DescriptionIndex for DescriptionBinary {
+    fn description_index(&self) -> i32 {
+        self.id
     }
 }
 
@@ -46,14 +54,14 @@ impl ToNLargestCount for DescriptionBinary {
 
 #[derive(Debug, Queryable)]
 struct TopNBinary {
-    column_index: i32,
+    description_id: i32,
     value: Vec<u8>,
     count: i64,
 }
 
-impl ColumnIndex for TopNBinary {
-    fn column_index(&self) -> i32 {
-        self.column_index
+impl DescriptionIndex for TopNBinary {
+    fn description_index(&self) -> i32 {
+        self.description_id
     }
 }
 
@@ -72,17 +80,22 @@ pub(super) async fn get_binary_statistics(
 ) -> Result<Vec<Statistics>, Error> {
     let column_descriptions = desc::description_binary
         .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
-        .select((cd::column_index, cd::count, cd::unique_count, desc::mode))
+        .select((
+            cd::id,
+            cd::column_index,
+            cd::count,
+            cd::unique_count,
+            desc::mode,
+        ))
         .filter(cd::id.eq_any(description_ids))
-        .order_by((cd::column_index.asc(), cd::count.desc()))
+        .order_by((cd::id.asc(), cd::column_index.asc(), cd::count.desc()))
         .load::<DescriptionBinary>(&mut conn)
         .await?;
 
     let top_n = top_n::top_n_binary
-        .inner_join(cd::column_description.on(cd::id.eq(top_n::description_id)))
-        .select((cd::column_index, top_n::value, top_n::count))
-        .filter(cd::id.eq_any(description_ids))
-        .order_by(cd::column_index.asc())
+        .select((top_n::description_id, top_n::value, top_n::count))
+        .filter(top_n::description_id.eq_any(description_ids))
+        .order_by(top_n::description_id.asc())
         .load::<TopNBinary>(&mut conn)
         .await?;
 

--- a/src/column_statistics/load/enum.rs
+++ b/src/column_statistics/load/enum.rs
@@ -2,7 +2,8 @@ use super::{
     schema::{
         column_description::dsl as cd, description_enum::dsl as desc, top_n_enum::dsl as top_n,
     },
-    ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
+    ColumnIndex, DescriptionIndex, Error, Statistics, ToDescription, ToElementCount,
+    ToNLargestCount,
 };
 use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
 use diesel_async::{pg::AsyncPgConnection, RunQueryDsl};
@@ -10,6 +11,7 @@ use structured::{Description, Element, ElementCount, NLargestCount};
 
 #[derive(Debug, Queryable)]
 struct DescriptionEnum {
+    id: i32,
     column_index: i32,
     count: i64,
     unique_count: i64,
@@ -19,6 +21,12 @@ struct DescriptionEnum {
 impl ColumnIndex for DescriptionEnum {
     fn column_index(&self) -> i32 {
         self.column_index
+    }
+}
+
+impl DescriptionIndex for DescriptionEnum {
+    fn description_index(&self) -> i32 {
+        self.id
     }
 }
 
@@ -46,14 +54,14 @@ impl ToNLargestCount for DescriptionEnum {
 
 #[derive(Debug, Queryable)]
 struct TopNEnum {
-    column_index: i32,
+    description_id: i32,
     value: String,
     count: i64,
 }
 
-impl ColumnIndex for TopNEnum {
-    fn column_index(&self) -> i32 {
-        self.column_index
+impl DescriptionIndex for TopNEnum {
+    fn description_index(&self) -> i32 {
+        self.description_id
     }
 }
 
@@ -72,17 +80,22 @@ pub(super) async fn get_enum_statistics(
 ) -> Result<Vec<Statistics>, Error> {
     let column_descriptions = desc::description_enum
         .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
-        .select((cd::column_index, cd::count, cd::unique_count, desc::mode))
+        .select((
+            cd::id,
+            cd::column_index,
+            cd::count,
+            cd::unique_count,
+            desc::mode,
+        ))
         .filter(cd::id.eq_any(description_ids))
-        .order_by((cd::column_index.asc(), cd::count.desc()))
+        .order_by((cd::id, cd::column_index.asc(), cd::count.desc()))
         .load::<DescriptionEnum>(&mut conn)
         .await?;
 
     let top_n = top_n::top_n_enum
-        .inner_join(cd::column_description.on(cd::id.eq(top_n::description_id)))
-        .select((cd::column_index, top_n::value, top_n::count))
-        .filter(cd::id.eq_any(description_ids))
-        .order_by(cd::column_index.asc())
+        .select((top_n::description_id, top_n::value, top_n::count))
+        .filter(top_n::description_id.eq_any(description_ids))
+        .order_by(top_n::description_id.asc())
         .load::<TopNEnum>(&mut conn)
         .await?;
 

--- a/src/column_statistics/load/float.rs
+++ b/src/column_statistics/load/float.rs
@@ -2,7 +2,8 @@ use super::{
     schema::{
         column_description::dsl as cd, description_float::dsl as desc, top_n_float::dsl as top_n,
     },
-    ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
+    ColumnIndex, DescriptionIndex, Error, Statistics, ToDescription, ToElementCount,
+    ToNLargestCount,
 };
 use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
 use diesel_async::{pg::AsyncPgConnection, RunQueryDsl};
@@ -10,6 +11,7 @@ use structured::{Description, Element, ElementCount, FloatRange, NLargestCount};
 
 #[derive(Debug, Queryable)]
 struct DescriptionFloat {
+    id: i32,
     column_index: i32,
     count: i64,
     unique_count: i64,
@@ -24,6 +26,12 @@ struct DescriptionFloat {
 impl ColumnIndex for DescriptionFloat {
     fn column_index(&self) -> i32 {
         self.column_index
+    }
+}
+
+impl DescriptionIndex for DescriptionFloat {
+    fn description_index(&self) -> i32 {
+        self.id
     }
 }
 
@@ -54,15 +62,15 @@ impl ToNLargestCount for DescriptionFloat {
 
 #[derive(Debug, Queryable)]
 struct TopNFloat {
-    column_index: i32,
+    description_id: i32,
     value_smallest: f64,
     value_largest: f64,
     count: i64,
 }
 
-impl ColumnIndex for TopNFloat {
-    fn column_index(&self) -> i32 {
-        self.column_index
+impl DescriptionIndex for TopNFloat {
+    fn description_index(&self) -> i32 {
+        self.description_id
     }
 }
 
@@ -85,6 +93,7 @@ pub(super) async fn get_float_statistics(
     let column_descriptions = desc::description_float
         .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
         .select((
+            cd::id,
             cd::column_index,
             cd::count,
             cd::unique_count,
@@ -96,20 +105,19 @@ pub(super) async fn get_float_statistics(
             desc::s_deviation,
         ))
         .filter(cd::id.eq_any(description_ids))
-        .order_by((cd::column_index.asc(), cd::count.desc()))
+        .order_by((cd::id.asc(), cd::column_index.asc(), cd::count.desc()))
         .load::<DescriptionFloat>(&mut conn)
         .await?;
 
     let top_n = top_n::top_n_float
-        .inner_join(cd::column_description.on(cd::id.eq(top_n::description_id)))
         .select((
-            cd::column_index,
+            top_n::description_id,
             top_n::value_smallest,
             top_n::value_largest,
             top_n::count,
         ))
-        .filter(cd::id.eq_any(description_ids))
-        .order_by(cd::column_index.asc())
+        .filter(top_n::description_id.eq_any(description_ids))
+        .order_by(top_n::description_id.asc())
         .load::<TopNFloat>(&mut conn)
         .await?;
 

--- a/src/column_statistics/load/ipaddr.rs
+++ b/src/column_statistics/load/ipaddr.rs
@@ -2,7 +2,8 @@ use super::{
     schema::{
         column_description::dsl as cd, description_ipaddr::dsl as desc, top_n_ipaddr::dsl as top_n,
     },
-    ColumnIndex, Error, Statistics, ToDescription, ToElementCount, ToNLargestCount,
+    ColumnIndex, DescriptionIndex, Error, Statistics, ToDescription, ToElementCount,
+    ToNLargestCount,
 };
 use diesel::{ExpressionMethods, JoinOnDsl, QueryDsl};
 use diesel_async::{pg::AsyncPgConnection, RunQueryDsl};
@@ -14,6 +15,7 @@ use structured::{Description, Element, ElementCount, NLargestCount};
 
 #[derive(Debug, Queryable)]
 struct DescriptionIpAddr {
+    id: i32,
     column_index: i32,
     count: i64,
     unique_count: i64,
@@ -23,6 +25,12 @@ struct DescriptionIpAddr {
 impl ColumnIndex for DescriptionIpAddr {
     fn column_index(&self) -> i32 {
         self.column_index
+    }
+}
+
+impl DescriptionIndex for DescriptionIpAddr {
+    fn description_index(&self) -> i32 {
+        self.id
     }
 }
 
@@ -53,14 +61,14 @@ impl ToNLargestCount for DescriptionIpAddr {
 
 #[derive(Debug, Queryable)]
 struct TopNIpAddr {
-    column_index: i32,
+    description_id: i32,
     value: String,
     count: i64,
 }
 
-impl ColumnIndex for TopNIpAddr {
-    fn column_index(&self) -> i32 {
-        self.column_index
+impl DescriptionIndex for TopNIpAddr {
+    fn description_index(&self) -> i32 {
+        self.description_id
     }
 }
 
@@ -82,17 +90,22 @@ pub(super) async fn get_ipaddr_statistics(
 ) -> Result<Vec<Statistics>, Error> {
     let column_descriptions = desc::description_ipaddr
         .inner_join(cd::column_description.on(cd::id.eq(desc::description_id)))
-        .select((cd::column_index, cd::count, cd::unique_count, desc::mode))
+        .select((
+            cd::id,
+            cd::column_index,
+            cd::count,
+            cd::unique_count,
+            desc::mode,
+        ))
         .filter(cd::id.eq_any(description_ids))
-        .order_by((cd::column_index.asc(), cd::count.desc()))
+        .order_by((cd::id, cd::column_index.asc(), cd::count.desc()))
         .load::<DescriptionIpAddr>(&mut conn)
         .await?;
 
     let top_n = top_n::top_n_ipaddr
-        .inner_join(cd::column_description.on(cd::id.eq(top_n::description_id)))
-        .select((cd::column_index, top_n::value, top_n::count))
-        .filter(cd::id.eq_any(description_ids))
-        .order_by(cd::column_index.asc())
+        .select((top_n::description_id, top_n::value, top_n::count))
+        .filter(top_n::description_id.eq_any(description_ids))
+        .order_by(top_n::description_id.asc())
         .load::<TopNIpAddr>(&mut conn)
         .await?;
 

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -32,7 +32,7 @@ use tracing::info;
 /// // the database format won't be changed in the future alpha or beta versions.
 /// const COMPATIBLE_VERSION: &str = ">=0.5.0-alpha.2,<=0.5.0-alpha.4";
 /// ```
-const COMPATIBLE_VERSION_REQ: &str = ">=0.16.0,<0.21.0-alpha";
+const COMPATIBLE_VERSION_REQ: &str = ">=0.16.0,<=0.21.0-alpha.1";
 
 /// Migrates the data directory to the up-to-date format if necessary.
 ///

--- a/src/model.rs
+++ b/src/model.rs
@@ -55,18 +55,8 @@ impl Model {
         (sql, batch_info, scores)
     }
 
-    pub fn from_storage(
-        (model, batch_info, scores): (
-            SqlModel,
-            Vec<crate::batch_info::BatchInfo>,
-            crate::scores::Scores,
-        ),
-    ) -> Self {
-        let batch_info = batch_info
-            .into_iter()
-            .map(crate::batch_info::BatchInfo::into_inner)
-            .collect();
-        let scores = scores.into_inner();
+    #[must_use]
+    pub fn from_storage(model: SqlModel) -> Self {
         Self {
             id: model.id,
             name: model.name,
@@ -76,8 +66,8 @@ impl Model {
             max_event_id_num: model.max_event_id_num,
             data_source_id: model.data_source_id,
             classification_id: model.classification_id.unwrap_or_default(),
-            batch_info,
-            scores,
+            batch_info: vec![],
+            scores: crate::types::ModelScores::new(),
         }
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -380,9 +380,9 @@ impl Database {
                 "column_description",
                 &["id"],
                 &[],
+                &[("cluster_id", Type::INT4_ARRAY)],
                 &[],
-                &[("event_range_ids", Type::INT4_ARRAY, Some("&&"))],
-                &[&event_range_ids],
+                &[&cluster_ids],
             )
             .await?;
         conn.delete_in(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -33,7 +33,8 @@ diesel::table! {
         type_id -> Int4,
         count -> Int8,
         unique_count -> Int8,
-        event_range_ids -> Array<Nullable<Int4>>,
+        cluster_id -> Int4,
+        batch_ts -> Timestamp,
     }
 }
 


### PR DESCRIPTION
- Deprecate `event_range`
- Fix `column_statistics` mismatch issue when some column contains unknown data type
- `batch_info`, `scores` are not needed when sending `Model` to `Reconverge`