### PR TITLE
Simplify return types and remove unnecessary cloning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Updated the `insert` and `update` methods in the `Tidb` class to simplify
+  return types and remove unnecessary cloning. These methods no longer return
+  redundant tuple values `(String, String)` representing the name and version of
+  the TI database, instead returning a `Result<()>`. Additionally, the update
+  eliminates the need for cloning `name` and `version`, as these values are now
+  directly accessible through the public member variables of the `Tidb`
+  instance.
+
 ## [0.23.0] - 2024-01-18
 
 ### Added
@@ -610,6 +622,7 @@ leading to a more streamlined system.
 
 - An initial version.
 
+[Unreleased]: https://github.com/petabi/review-database/compare/0.23.0...main
 [0.23.0]: https://github.com/petabi/review-database/compare/0.22.1...0.23.0
 [0.22.1]: https://github.com/petabi/review-database/compare/0.22.0...0.22.1
 [0.22.0]: https://github.com/petabi/review-database/compare/0.21.0...0.22.0

--- a/src/ti.rs
+++ b/src/ti.rs
@@ -51,13 +51,11 @@ impl Tidb {
     ///
     /// * Returns an error if it fails to encode TI database
     /// * Returns an error if it fails to save TI database
-    pub fn insert(&self, store: &Store) -> Result<(String, String)> {
-        let name = self.name.clone();
-        let version = self.version.clone();
+    pub fn insert(&self, store: &Store) -> Result<()> {
         let value = bincode::DefaultOptions::new().serialize(&self)?;
         let map = store.tidb_map();
-        map.put(name.as_bytes(), &value)?;
-        Ok((name, version))
+        map.put(self.name.as_bytes(), &value)?;
+        Ok(())
     }
 
     /// Replace TI database with the new
@@ -67,17 +65,15 @@ impl Tidb {
     /// * Returns an error if the TI database name does not match
     /// * Returns an error if it fails to encode TI database
     /// * Returns an error if it fails to delete or save TI database
-    pub fn update(&self, store: &Store, name: &str) -> Result<(String, String)> {
+    pub fn update(&self, store: &Store, name: &str) -> Result<()> {
         if *name != self.name {
             bail!("Tidb name does not matched");
         }
-        let new_name = self.name.clone();
-        let new_version = self.version.clone();
         let value = bincode::DefaultOptions::new().serialize(&self)?;
         let map = store.tidb_map();
         map.delete(name.as_bytes())?;
         map.put(name.as_bytes(), &value)?;
-        Ok((new_name, new_version))
+        Ok(())
     }
 
     /// Returns TI database


### PR DESCRIPTION
Updated the `insert` and `update` methods in the `Tidb` class to simplify return types and remove unnecessary cloning. These methods no longer return redundant tuple values `(String, String)` representing the name and version of the TI database, instead returning a `Result<()>`. Additionally, the update eliminates the need for cloning `name` and `version`, as these values are now directly accessible through the public member variables of the `Tidb` instance.