### PR TITLE
Move `open_backup_engine` out of `StateDb`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-doc-valid-idents = [ "PostgreSQL" ]
+doc-valid-idents = ["PostgreSQL", "RocksDB"]


### PR DESCRIPTION
This is a convenience function that is not really related to the `StateDb` itself.