### PR TITLE
Remove `InterableMap` for `Table<Account>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `qualifier` table from PostgreSQL database is now deprecated.
 - `status` table from PostgreSQL database is now deprecated.
 
+### Removed
+
+- `Table<Account>` no longer implements `IterableMap`. Instead, the user should
+  use `Table<Account>::iter` to iterate over the accounts in the database. This
+  change eliminates the need for callers to deserialize records manually,
+  simplifying the interaction with the accounts table.
+
 ## [0.23.0] - 2024-01-18
 
 ### Added

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -221,17 +221,6 @@ pub struct MapIterator<'i> {
     >,
 }
 
-impl<'i> MapIterator<'i> {
-    pub(crate) fn new(
-        inner: rocksdb::DBIteratorWithThreadMode<
-            'i,
-            rocksdb::OptimisticTransactionDB<rocksdb::SingleThreaded>,
-        >,
-    ) -> Self {
-        Self { inner }
-    }
-}
-
 impl<'i> Iterator for MapIterator<'i> {
     type Item = (Box<[u8]>, Box<[u8]>);
 


### PR DESCRIPTION
Obsoleted by `Table<Account>::iter`.