### PR TITLE
Make `Table<Account>::iter` generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refactored `iter` method in `Table<Account>` to be part of a new `Iterable`
+  trait. This enhancement enables the `iter` method to be used universally on
+  any table that implements the `Iterable` trait, extending its functionality
+  beyond just the `Table<Account>`.
+
 ## [0.24.0] - 2024-01-29
 
 ### Changed
@@ -645,6 +654,7 @@ leading to a more streamlined system.
 
 - An initial version.
 
+[Unreleased]: https://github.com/petabi/review-database/compare/0.24.0...main
 [0.24.0]: https://github.com/petabi/review-database/compare/0.23.0...0.24.0
 [0.23.0]: https://github.com/petabi/review-database/compare/0.22.1...0.23.0
 [0.22.1]: https://github.com/petabi/review-database/compare/0.22.0...0.22.1

--- a/src/account.rs
+++ b/src/account.rs
@@ -12,8 +12,6 @@ use serde::{Deserialize, Serialize};
 use std::{net::IpAddr, num::NonZeroU32};
 use strum_macros::{Display, EnumString};
 
-use crate::tables::{Key, Value};
-
 /// Possible role types of `Account`.
 #[derive(Clone, Copy, Debug, Display, Eq, PartialEq, Deserialize, Serialize, EnumString)]
 pub enum Role {
@@ -104,22 +102,6 @@ impl Account {
     #[must_use]
     pub fn last_signin_time(&self) -> Option<DateTime<Utc>> {
         self.last_signin_time
-    }
-}
-
-impl Key for Account {
-    type Output<'a> = &'a [u8];
-
-    fn key(&self) -> Self::Output<'_> {
-        self.username.as_bytes()
-    }
-}
-
-impl Value for Account {
-    type Output<'a> = &'a Self;
-
-    fn value(&self) -> Self::Output<'_> {
-        self
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub use self::outlier::*;
 pub use self::qualifier::Qualifier;
 pub use self::status::Status;
 use self::tables::StateDb;
-pub use self::tables::{IndexedTable, Table};
+pub use self::tables::{IndexedTable, Iterable, Table};
 pub use self::ti::{Tidb, TidbKind, TidbRule};
 pub use self::time_series::*;
 pub use self::time_series::{ColumnTimeSeries, TimeCount, TimeSeriesResult};


### PR DESCRIPTION
Refactored `iter` method in `Table<Account>` to be part of a new `Iterable` trait. This enhancement enables the `iter` method to be used universally on any table that implements the `Iterable` trait, extending its functionality beyond just the `Table<Account>`.
