### PR TITLE
Introduce `UniqueKey`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Introduced the `UniqueKey` trait to provide a standardized way to retrieve a
+  unique, opaque key (`Cow<[u8]>`) for instances of structs used as records in
+  the database.
+
 ### Changed
 
 - Refactored `iter` method in `Table<Account>` to be part of a new `Iterable`

--- a/src/account.rs
+++ b/src/account.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, net::IpAddr, num::NonZeroU32};
 use strum_macros::{Display, EnumString};
 
-use crate::tables::{Key, Value};
+use crate::{tables::Value, UniqueKey};
 
 /// Possible role types of `Account`.
 #[derive(Clone, Copy, Debug, Display, Eq, PartialEq, Deserialize, Serialize, EnumString)]
@@ -107,8 +107,8 @@ impl Account {
     }
 }
 
-impl Key for Account {
-    fn key(&self) -> Cow<[u8]> {
+impl UniqueKey for Account {
+    fn unique_key(&self) -> Cow<[u8]> {
         Cow::Borrowed(self.username.as_bytes())
     }
 }

--- a/src/batch_info.rs
+++ b/src/batch_info.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 
-use crate::tables::{Key, Value};
+use crate::{tables::Value, UniqueKey};
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct BatchInfo {
@@ -31,8 +31,8 @@ impl From<crate::types::ModelBatchInfo> for BatchInfo {
     }
 }
 
-impl Key for BatchInfo {
-    fn key(&self) -> Cow<[u8]> {
+impl UniqueKey for BatchInfo {
+    fn unique_key(&self) -> Cow<[u8]> {
         use bincode::Options;
         let Ok(key) = bincode::DefaultOptions::new().serialize(&(self.model, self.inner.id)) else {
             unreachable!("serialization into memory should never fail")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub use self::outlier::*;
 pub use self::qualifier::Qualifier;
 pub use self::status::Status;
 use self::tables::StateDb;
-pub use self::tables::{IndexedTable, Iterable, Table};
+pub use self::tables::{IndexedTable, Iterable, Table, UniqueKey};
 pub use self::ti::{Tidb, TidbKind, TidbRule};
 pub use self::time_series::*;
 pub use self::time_series::{ColumnTimeSeries, TimeCount, TimeSeriesResult};

--- a/src/scores.rs
+++ b/src/scores.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 
-use crate::tables::{Key, Value};
+use crate::{tables::Value, UniqueKey};
 
 #[derive(Deserialize, Serialize, Debug, Default, PartialEq)]
 pub struct Scores {
@@ -20,8 +20,8 @@ impl Scores {
     }
 }
 
-impl Key for Scores {
-    fn key(&self) -> Cow<[u8]> {
+impl UniqueKey for Scores {
+    fn unique_key(&self) -> Cow<[u8]> {
         use bincode::Options;
         let Ok(key) = bincode::DefaultOptions::new().serialize(&self.model) else {
             unreachable!("serialization into memory should never fail")


### PR DESCRIPTION
Introduces the `UniqueKey` trait to provide a standardized way to retrieve a unique, opaque key (`Cow<[u8]>`) for instances of structs used as records in the database.

This would allow review-web to implement a common routine that handles cursor operations for all the structs stored in `Map`.