### PR TITLE
Remove unnecessary trait `Iterable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Introduced the `UniqueKey` trait to provide a standardized way to retrieve a
   unique, opaque key (`Cow<[u8]>`) for instances of structs used as records in
   the database.
+- Implemented `iter` method not only for `Table<Account>` but for all `Table<R>`
+  where `R` implements `DeserializedOwned`. This enhancement enables the `iter`
+  method to be used universally on any table that contains a record that can be
+  deserialized from a key-value entry, extending its functionality beyond just
+  the `Table<Account>`.
 
 ### Changed
 
-- Refactored `iter` method in `Table<Account>` to be part of a new `Iterable`
-  trait. This enhancement enables the `iter` method to be used universally on
-  any table that implements the `Iterable` trait, extending its functionality
-  beyond just the `Table<Account>`.
 - Moved the csv_column_extra table from the PostgreSQL database to RocksDB.
   - The csv_column_extra table data is now stored in RocksDB for improved performance
     and scalability.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub use self::migration::{migrate_backend, migrate_data_dir};
 pub use self::model::{Digest as ModelDigest, Model};
 pub use self::outlier::*;
 use self::tables::StateDb;
-pub use self::tables::{IndexedTable, Iterable, Table, UniqueKey};
+pub use self::tables::{IndexedTable, Table, UniqueKey};
 pub use self::ti::{Tidb, TidbKind, TidbRule};
 pub use self::time_series::*;
 pub use self::time_series::{ColumnTimeSeries, TimeCount, TimeSeriesResult};

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -351,8 +351,9 @@ impl<'d, R: UniqueKey + Value> Table<'d, R> {
     }
 }
 
-impl<T: DeserializeOwned> Iterable<T> for Table<'_, T> {
-    fn iter(&self, direction: Direction, from: Option<&[u8]>) -> TableIter<'_, T> {
+impl<T: DeserializeOwned> Table<'_, T> {
+    #[must_use]
+    pub fn iter(&self, direction: Direction, from: Option<&[u8]>) -> TableIter<'_, T> {
         use rocksdb::IteratorMode;
 
         match direction {
@@ -523,11 +524,6 @@ pub trait UniqueKey {
 
 pub trait Value {
     fn value(&self) -> Cow<[u8]>;
-}
-
-pub trait Iterable<T: DeserializeOwned> {
-    /// Returns an iterator over the table, starting from the given key.
-    fn iter(&self, direction: Direction, from: Option<&[u8]>) -> TableIter<T>;
 }
 
 fn serialize<I: Serialize>(input: &I) -> anyhow::Result<Vec<u8>> {

--- a/src/tables/accounts.rs
+++ b/src/tables/accounts.rs
@@ -180,8 +180,6 @@ mod tests {
 
     #[test]
     fn iter() {
-        use crate::tables::Iterable;
-
         let db_dir = tempfile::tempdir().unwrap();
         let backup_dir = tempfile::tempdir().unwrap();
         let store = Arc::new(Store::new(db_dir.path(), backup_dir.path()).unwrap());


### PR DESCRIPTION
This PR implements `iter` method not only for `Table<Account>` but for all `Table<R>` where `R` implements `DeserializedOwned`. This enhancement enables the `iter` method to be used universally on any table that contains a record that can be deserialized from a key-value entry, extending its functionality beyond just the `Table<Account>`.