### PR TITLE
Add `Iterable` for `Table` and `IndexedTable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   unique, opaque key (`Cow<[u8]>`) for instances of structs used as records in
   the database.
 - Implemented `iter` method not only for `Table<Account>` but for all `Table<R>`
-  where `R` implements `DeserializedOwned`. This enhancement enables the `iter`
-  method to be used universally on any table that contains a record that can be
+  and `IndexedTable<R>` where `R` implements `DeserializedOwned`, through the
+  newly-introduced `Iterable` trait. This enhancement enables the `iter` method
+  to be used universally on any table that contains a record that can be
   deserialized from a key-value entry, extending its functionality beyond just
   the `Table<Account>`.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub use self::migration::{migrate_backend, migrate_data_dir};
 pub use self::model::{Digest as ModelDigest, Model};
 pub use self::outlier::*;
 use self::tables::StateDb;
-pub use self::tables::{IndexedTable, Table, UniqueKey};
+pub use self::tables::{IndexedTable, Iterable, Table, UniqueKey};
 pub use self::ti::{Tidb, TidbKind, TidbRule};
 pub use self::time_series::*;
 pub use self::time_series::{ColumnTimeSeries, TimeCount, TimeSeriesResult};

--- a/src/tables/accounts.rs
+++ b/src/tables/accounts.rs
@@ -180,6 +180,8 @@ mod tests {
 
     #[test]
     fn iter() {
+        use crate::Iterable;
+
         let db_dir = tempfile::tempdir().unwrap();
         let backup_dir = tempfile::tempdir().unwrap();
         let store = Arc::new(Store::new(db_dir.path(), backup_dir.path()).unwrap());


### PR DESCRIPTION
Implemented `iter` method not only for `Table<Account>` but for all `Table<R>` and `IndexedTable<R>` where `R` implements `DeserializedOwned`, through the newly-introduced `Iterable` trait. This enhancement enables the `iter` method to be used universally on any table that contains a record that can be deserialized from a key-value entry, extending its functionality beyond just the `Table<Account>`.