### PR TITLE
Remove redundant log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   introduced to provide greater flexibility and avoid potential ownership and
   borrowing issues. `Cow<[u8]>` allows users to efficiently handle both owned
   and borrowed data, depending on their specific use case.
+- `backup::restore` no longer leaves log messages regarding the result of the
+  restoration process, since its messages don't provide any information that the
+  caller doesn't already have. This change aims to reduce unnecessary verbosity
+  and improve the overall clarity and readability of the log output. The same
+  information, if needed, can be obtained by checking the return value of the
+  `restore` function, and the caller can decide whether to log it or not.
 
 ### Deprecated
 

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -113,27 +113,10 @@ pub async fn list(store: &Arc<RwLock<Store>>) -> Result<Vec<BackupInfo>> {
 /// Returns an error if the restore operation fails.
 pub async fn restore(store: &Arc<RwLock<Store>>, backup_id: Option<u32>) -> Result<()> {
     // TODO: This function should be expanded to support PostgreSQL backups as well.
-    info!("restoring database from {:?}", backup_id);
-    let res = {
-        let mut store = store.write().await;
-        match &backup_id {
-            Some(id) => store.restore_from_backup(*id),
-            None => store.restore_from_latest_backup(),
-        }
-    };
-
-    match res {
-        Ok(()) => {
-            info!("database restored from backup {:?}", backup_id);
-            Ok(())
-        }
-        Err(e) => {
-            warn!(
-                "failed to restore database from backup {:?}: {:?}",
-                backup_id, e
-            );
-            Err(e)
-        }
+    let mut store = store.write().await;
+    match &backup_id {
+        Some(id) => store.restore_from_backup(*id),
+        None => store.restore_from_latest_backup(),
     }
 }
 


### PR DESCRIPTION
With this PR, `backup::restore` no longer leaves log messages regarding the result of the restoration process, since its messages don't provide any information that the caller doesn't already have. This change aims to reduce unnecessary verbosity and improve the overall clarity and readability of the log output. The same information, if needed, can be obtained by checking the return value of the `restore` function, and the caller can decide whether to log it or not.

Part of #215.