### PR TITLE
Use `FromKeyValue` to deserialize key-value pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   decide whether to log it or not.
 - Changed the return type of `Store::access_token_map` to `Table<AccessToken>` to
   enhance security by preventing direct exposure of `Map`.
+- The `get_by_id` method in the `IndexedMap` struct has been updated to return a
+  key-value pair (`(Vec<u8>, Vec<u8>)`) instead of just the value (`impl
+  AsRef<[u8]>`). This change accommodates scenarios where the information stored
+  in a key may not be present in the value for some Column Families. Previously,
+  if you called `get_by_id` with a specific ID, you would receive the
+  corresponding value as `Option<impl AsRef<[u8]>>`. Now, calling `get_by_id`
+  with an ID will return an `Option` containing a tuple of `Vec<u8>` for both
+  the key and the value, effectively giving you direct access to the stored key
+  along with its corresponding value.
 
 ### Deprecated
 

--- a/src/collections/indexed_map.rs
+++ b/src/collections/indexed_map.rs
@@ -36,17 +36,20 @@ impl<'a> IndexedMap<'a> {
             .ok_or_else(|| anyhow!("database error: cannot find column family \"{}\"", name))
     }
 
-    /// Gets a value corresponding to the given index.
+    /// Gets a key-value pair corresponding to the given index.
     ///
     /// # Errors
     ///
     /// Returns an error if the index is invalid or cannot be read.
-    pub fn get_by_id(&self, id: u32) -> Result<Option<impl AsRef<[u8]>>> {
+    pub fn get_by_id(&self, id: u32) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
         let index = self.index()?;
         let Some(key) = index.get(id).context("invalid ID")? else {
             return Ok(None);
         };
-        self.db.get_cf(self.cf, key).context("cannot read entry")
+        self.db
+            .get_cf(self.cf, key)
+            .context("cannot read entry")
+            .map(|value| value.map(|value| (key.to_vec(), value)))
     }
 
     /// Gets a value corresponding to the given key.

--- a/src/tables/category.rs
+++ b/src/tables/category.rs
@@ -2,7 +2,7 @@
 use anyhow::Result;
 use rocksdb::OptimisticTransactionDB;
 
-use crate::{category::Category, Indexed, IndexedMap, IndexedTable};
+use crate::{category::Category, types::FromKeyValue, Indexed, IndexedMap, IndexedTable};
 
 const DEFAULT_ENTRIES: [(u32, &str); 2] = [(1, "Non-Specified Alert"), (2, "Irrelevant Alert")];
 
@@ -55,12 +55,11 @@ impl<'d> IndexedTable<'d, Category> {
     ///
     /// Returns an error if the database query fails.
     pub fn get(&self, id: u32) -> Result<Category> {
-        use bincode::Options;
-        let res = self
+        let (key, value) = self
             .indexed_map
             .get_by_id(id)
             .and_then(|r| r.ok_or(anyhow::anyhow!("category {id} unavailable")))?;
-        let c = bincode::DefaultOptions::new().deserialize(res.as_ref())?;
+        let c = Category::from_key_value(&key, &value)?;
         Ok(c)
     }
 

--- a/src/tables/csv_column_extra.rs
+++ b/src/tables/csv_column_extra.rs
@@ -6,8 +6,8 @@ use rocksdb::OptimisticTransactionDB;
 use structured::arrow::datatypes::ToByteSlice;
 
 use crate::{
-    csv_column_extra::CsvColumnExtra, Indexable, Indexed, IndexedMap, IndexedMapUpdate,
-    IndexedTable,
+    csv_column_extra::CsvColumnExtra, types::FromKeyValue, Indexable, Indexed, IndexedMap,
+    IndexedMapUpdate, IndexedTable,
 };
 
 impl Indexable for CsvColumnExtra {
@@ -123,13 +123,13 @@ impl<'d> IndexedTable<'d, CsvColumnExtra> {
         column_1: Option<&[bool]>,
         column_n: Option<&[bool]>,
     ) -> Result<()> {
-        let old: CsvColumnExtra = {
-            let res = self
+        let old = {
+            let (key, value) = self
                 .indexed_map
                 .get_by_id(id)
                 .and_then(|r| r.ok_or(anyhow::anyhow!("csv column extra {id} unavailable")))?;
-            super::deserialize(res.as_ref())
-        }?;
+            CsvColumnExtra::from_key_value(&key, &value)?
+        };
         let new = CsvColumnExtra {
             id,
             model_id: old.model_id,

--- a/src/tables/qualifier.rs
+++ b/src/tables/qualifier.rs
@@ -4,7 +4,10 @@ use std::borrow::Cow;
 use anyhow::Result;
 use rocksdb::OptimisticTransactionDB;
 
-use crate::{types::Qualifier, Indexable, Indexed, IndexedMap, IndexedMapUpdate, IndexedTable};
+use crate::{
+    types::{FromKeyValue, Qualifier},
+    Indexable, Indexed, IndexedMap, IndexedMapUpdate, IndexedTable,
+};
 
 // The following will be used when PostgreSQL qualifier table is deleted
 const DEFAULT_ENTRIES: [(u32, &str); 4] = [
@@ -104,11 +107,11 @@ impl<'d> IndexedTable<'d, Qualifier> {
     ///
     /// Returns an error if the database query fails.
     pub fn get(&self, id: u32) -> Result<Qualifier> {
-        let res = self
+        let (key, value) = self
             .indexed_map
             .get_by_id(id)
             .and_then(|r| r.ok_or(anyhow::anyhow!("qualifier {id} unavailable")))?;
-        let c = super::deserialize(res.as_ref())?;
+        let c = Qualifier::from_key_value(&key, &value)?;
         Ok(c)
     }
 

--- a/src/tables/status.rs
+++ b/src/tables/status.rs
@@ -4,7 +4,10 @@ use std::borrow::Cow;
 use anyhow::Result;
 use rocksdb::OptimisticTransactionDB;
 
-use crate::{types::Status, Indexable, Indexed, IndexedMap, IndexedMapUpdate, IndexedTable};
+use crate::{
+    types::{FromKeyValue, Status},
+    Indexable, Indexed, IndexedMap, IndexedMapUpdate, IndexedTable,
+};
 
 // The following will be used when PostgreSQL status table is deleted
 const DEFAULT_ENTRIES: [(u32, &str); 3] = [(1, "reviewed"), (2, "pending review"), (3, "disabled")];
@@ -99,11 +102,11 @@ impl<'d> IndexedTable<'d, Status> {
     ///
     /// Returns an error if the database query fails.
     pub fn get(&self, id: u32) -> Result<Status> {
-        let res = self
+        let (key, value) = self
             .indexed_map
             .get_by_id(id)
             .and_then(|r| r.ok_or(anyhow::anyhow!("status {id} unavailable")))?;
-        let c = super::deserialize(res.as_ref())?;
+        let c = Status::from_key_value(&key, &value)?;
         Ok(c)
     }
 


### PR DESCRIPTION
This reduces the amount of boilerplate required to deserialize key-value pairs. It also allows for more flexibility in the deserialization process by allowing the deserialization to be done in a separate function.