### PR TITLE
Implement `FromKeyValue` for each type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   decision has been made to streamline and focus on providing precise abstractions
   for database operations. Users are advised to update their codebase accordingly
   and leverage alternative methods for scheduling periodic backups.
+- The `FromKeyValue` implementation for `DeserializeOwned` has been removed. This
+  change was made to ensure that the `FromKeyValue` trait is only implemented for
+  types that are explicitly intended to be deserialized from key-value entries.
 
 ### Fixed
 

--- a/src/collections/indexed_map.rs
+++ b/src/collections/indexed_map.rs
@@ -69,12 +69,19 @@ impl<'a> IndexedMap<'a> {
 mod tests {
     use std::borrow::Cow;
 
-    use crate::{Indexable, Indexed, IndexedMapUpdate, Store};
+    use crate::{types::FromKeyValue, Indexable, Indexed, IndexedMapUpdate, Store};
 
     #[derive(serde::Deserialize, serde::Serialize, Clone)]
     struct TestEntry {
         id: u32,
         name: String,
+    }
+
+    impl FromKeyValue for TestEntry {
+        fn from_key_value(_key: &[u8], value: &[u8]) -> anyhow::Result<Self> {
+            use bincode::Options;
+            Ok(bincode::DefaultOptions::new().deserialize(value)?)
+        }
     }
 
     impl Indexable for TestEntry {

--- a/src/node.rs
+++ b/src/node.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, collections::HashMap, net::IpAddr};
 
-use crate::Indexable;
+use crate::{types::FromKeyValue, Indexable};
 
 type PortNumber = u16;
 
@@ -57,6 +57,12 @@ pub struct Node {
     pub creation_time: DateTime<Utc>,
     pub apply_target_id: Option<u32>,
     pub apply_in_progress: bool,
+}
+
+impl FromKeyValue for Node {
+    fn from_key_value(_key: &[u8], value: &[u8]) -> anyhow::Result<Self> {
+        Ok(bincode::DefaultOptions::new().deserialize(value)?)
+    }
 }
 
 impl Indexable for Node {

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -492,15 +492,12 @@ impl<R: FromKeyValue> Iterable<R> for Table<'_, R> {
     }
 }
 
-pub struct IndexedTable<'d, R: Indexable> {
+pub struct IndexedTable<'d, R> {
     indexed_map: IndexedMap<'d>,
     _phantom: std::marker::PhantomData<R>,
 }
 
-impl<'d, R> IndexedTable<'d, R>
-where
-    R: Indexable,
-{
+impl<'d, R> IndexedTable<'d, R> {
     fn new(indexed_map: IndexedMap<'d>) -> Self {
         Self {
             indexed_map,
@@ -536,7 +533,7 @@ where
     }
 }
 
-impl<R: FromKeyValue + Indexable> Iterable<R> for IndexedTable<'_, R> {
+impl<R: FromKeyValue> Iterable<R> for IndexedTable<'_, R> {
     fn iter(&self, direction: Direction, from: Option<&[u8]>) -> TableIter<'_, R> {
         use rocksdb::IteratorMode;
 

--- a/src/tables/accounts.rs
+++ b/src/tables/accounts.rs
@@ -6,7 +6,16 @@ use anyhow::{bail, Context};
 use bincode::Options;
 use rocksdb::OptimisticTransactionDB;
 
-use crate::{types::Account, Map, Role, Table, EXCLUSIVE};
+use crate::{
+    types::{Account, FromKeyValue},
+    Map, Role, Table, EXCLUSIVE,
+};
+
+impl FromKeyValue for Account {
+    fn from_key_value(_key: &[u8], value: &[u8]) -> anyhow::Result<Self> {
+        super::deserialize(value)
+    }
+}
 
 /// Functions for the accounts table.
 impl<'d> Table<'d, Account> {

--- a/src/tables/batch_info.rs
+++ b/src/tables/batch_info.rs
@@ -3,7 +3,13 @@
 use anyhow::Result;
 use rocksdb::{IteratorMode, OptimisticTransactionDB};
 
-use crate::{batch_info::BatchInfo, Map, Table};
+use crate::{batch_info::BatchInfo, types::FromKeyValue, Map, Table};
+
+impl FromKeyValue for BatchInfo {
+    fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
+        super::deserialize(value)
+    }
+}
 
 impl<'d> Table<'d, crate::batch_info::BatchInfo> {
     /// Opens the batch info table in the database.

--- a/src/tables/category.rs
+++ b/src/tables/category.rs
@@ -6,6 +6,12 @@ use crate::{category::Category, types::FromKeyValue, Indexed, IndexedMap, Indexe
 
 const DEFAULT_ENTRIES: [(u32, &str); 2] = [(1, "Non-Specified Alert"), (2, "Irrelevant Alert")];
 
+impl FromKeyValue for Category {
+    fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
+        super::deserialize(value)
+    }
+}
+
 impl<'d> IndexedTable<'d, Category> {
     /// Opens the category table in the database.
     ///

--- a/src/tables/csv_column_extra.rs
+++ b/src/tables/csv_column_extra.rs
@@ -10,6 +10,12 @@ use crate::{
     IndexedMapUpdate, IndexedTable,
 };
 
+impl FromKeyValue for CsvColumnExtra {
+    fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
+        super::deserialize(value)
+    }
+}
+
 impl Indexable for CsvColumnExtra {
     fn key(&self) -> Cow<[u8]> {
         Cow::Owned(self.model_id.to_be_bytes().to_vec())

--- a/src/tables/qualifier.rs
+++ b/src/tables/qualifier.rs
@@ -17,6 +17,12 @@ const DEFAULT_ENTRIES: [(u32, &str); 4] = [
     (4, "mixed"),
 ];
 
+impl FromKeyValue for Qualifier {
+    fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
+        super::deserialize(value)
+    }
+}
+
 impl Indexable for Qualifier {
     fn key(&self) -> Cow<[u8]> {
         Cow::Borrowed(self.description.as_bytes())

--- a/src/tables/status.rs
+++ b/src/tables/status.rs
@@ -12,6 +12,12 @@ use crate::{
 // The following will be used when PostgreSQL status table is deleted
 const DEFAULT_ENTRIES: [(u32, &str); 3] = [(1, "reviewed"), (2, "pending review"), (3, "disabled")];
 
+impl FromKeyValue for Status {
+    fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
+        super::deserialize(value)
+    }
+}
+
 impl Indexable for Status {
     fn key(&self) -> Cow<[u8]> {
         Cow::Borrowed(self.description.as_bytes())

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,7 +8,7 @@ use chrono::{
 use data_encoding::BASE64;
 use flate2::read::GzDecoder;
 use ipnet::IpNet;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::{
     borrow::Cow,
@@ -28,16 +28,6 @@ pub trait FromKeyValue: Sized {
     ///
     /// Returns an error if the key or value cannot be deserialized.
     fn from_key_value(key: &[u8], value: &[u8]) -> Result<Self>;
-}
-
-impl<T> FromKeyValue for T
-where
-    T: DeserializeOwned,
-{
-    fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
-        let entry = bincode::DefaultOptions::new().deserialize::<Self>(value)?;
-        Ok(entry)
-    }
 }
 
 pub(crate) type Timestamp = i64;
@@ -118,6 +108,12 @@ pub struct Customer {
     pub creation_time: DateTime<Utc>,
 }
 
+impl FromKeyValue for Customer {
+    fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
+        Ok(bincode::DefaultOptions::new().deserialize(value)?)
+    }
+}
+
 impl Indexable for Customer {
     fn key(&self) -> Cow<[u8]> {
         Cow::Borrowed(self.name.as_bytes())
@@ -169,6 +165,12 @@ pub struct DataSource {
     pub kind: Option<String>,
 
     pub description: String,
+}
+
+impl FromKeyValue for DataSource {
+    fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
+        Ok(bincode::DefaultOptions::new().deserialize(value)?)
+    }
 }
 
 impl Indexable for DataSource {
@@ -426,6 +428,12 @@ pub struct Template {
     pub numbers_of_top_n: Option<Vec<i64>>,
 }
 
+impl FromKeyValue for Template {
+    fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
+        Ok(bincode::DefaultOptions::new().deserialize(value)?)
+    }
+}
+
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
 pub enum TiCmpKind {
     IpAddress,
@@ -623,6 +631,12 @@ pub struct TriagePolicy {
     pub confidence: Vec<Confidence>,
     pub response: Vec<Response>,
     pub creation_time: DateTime<Utc>,
+}
+
+impl FromKeyValue for TriagePolicy {
+    fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
+        Ok(bincode::DefaultOptions::new().deserialize(value)?)
+    }
 }
 
 impl Indexable for TriagePolicy {


### PR DESCRIPTION
The implementation for any `DeserializeOwned` has been removed, in order to allow more flexible implementations.