### PR TITLE
Replace `IndexSet` with `TagSet` as the return value of `Store::workflow_tag_set`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   ensuring a more controlled and secure access_token management.
 - Added new functions to facilitate insert, remove, get and list operations,
   ensuring a more controlled and secure filter management.
+- Introduced a new data structure `TagSet` to facilitate easier access and
+  manipulation of tags stored in the database.
 
 ### Changed
 
@@ -65,6 +67,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   and improved code organization.
 - Modified `ModelIndicator` struct to include the `name` property, representing the
   associated name for the specific `ModelIndicator`.
+- `Store::workflow_tag_set` now returns `TagSet` instead of `IndexSet`. This
+  change is made to leverage the new `TagSet` structure for a more user-friendly
+  approach in accessing tags. The `TagSet` allows users to interact with tags
+  through the `Tag` struct, which includes `name` and `id` fields, offering a
+  more straightforward and human-readable format compared to the raw binary
+  format exposed by `IndexSet`.
 
 ### Deprecated
 

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -594,35 +594,6 @@ pub trait IndexedMapUpdate {
 
 #[cfg(test)]
 mod tests {
-    use super::{IndexedMultimap, IndexedSet};
-    use rocksdb::OptimisticTransactionDB;
-
-    pub(super) struct TestStore {
-        db: OptimisticTransactionDB,
-    }
-
-    impl TestStore {
-        pub(super) fn new() -> Self {
-            let db_dir = tempfile::tempdir().unwrap();
-            let db_path = db_dir.path().join("test.db");
-
-            let mut opts = rocksdb::Options::default();
-            opts.create_if_missing(true);
-            opts.create_missing_column_families(true);
-            let db =
-                rocksdb::OptimisticTransactionDB::open_cf(&opts, db_path, ["test_cf"]).unwrap();
-            Self { db }
-        }
-
-        pub(super) fn indexed_multimap(&self) -> IndexedMultimap {
-            IndexedMultimap::new(&self.db, "test_cf").unwrap()
-        }
-
-        pub(super) fn indexed_set(&self) -> IndexedSet {
-            IndexedSet::new(&self.db, "test_cf", b"indexed set").unwrap()
-        }
-    }
-
     #[test]
     fn index_clear_inactive() {
         let mut index = super::KeyIndex::default();

--- a/src/collections/indexed_multimap.rs
+++ b/src/collections/indexed_multimap.rs
@@ -65,8 +65,8 @@ impl<'a> IndexedMultimap<'a> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        collections::{tests::TestStore, Indexable, Indexed},
-        IterableMap,
+        collections::{Indexable, Indexed},
+        test, IterableMap,
     };
     use std::{borrow::Cow, mem::size_of};
 
@@ -96,7 +96,7 @@ mod tests {
 
     #[test]
     fn insert_duplicate() {
-        let db = TestStore::new();
+        let db = test::Store::new();
         let map = db.indexed_multimap();
 
         assert_eq!(map.count().unwrap(), 0);
@@ -121,7 +121,7 @@ mod tests {
 
     #[test]
     fn remove() {
-        let db = TestStore::new();
+        let db = test::Store::new();
         let map = db.indexed_multimap();
         map.insert(TestEntry {
             indexed_key: vec![b'a', 0, 0, 0, 0],

--- a/src/collections/indexed_set.rs
+++ b/src/collections/indexed_set.rs
@@ -222,11 +222,11 @@ impl<'a> IndexedSet<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::collections::tests::TestStore;
+    use crate::test;
 
     #[test]
     fn deactivate() {
-        let db = TestStore::new();
+        let db = test::Store::new();
         let set = db.indexed_set();
         let id_a = set.insert(b"a").unwrap();
         assert_eq!(id_a, 0);
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn remove() {
-        let db = TestStore::new();
+        let db = test::Store::new();
         let set = db.indexed_set();
         let _id_a = set.insert(b"a").unwrap();
         let id_b = set.insert(b"b").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod outlier;
 mod schema;
 mod scores;
 mod tables;
+mod tags;
 #[cfg(test)]
 mod test;
 mod ti;
@@ -83,6 +84,7 @@ use bb8_postgres::{
 pub use rocksdb::backup::BackupEngineInfo;
 use std::io;
 use std::path::{Path, PathBuf};
+use tags::TagSet;
 use thiserror::Error;
 
 #[derive(Clone)]
@@ -347,12 +349,18 @@ impl Store {
             .expect("always available")
     }
 
-    #[must_use]
+    /// Returns the tag set for workflow.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if database operation fails or the data is invalid.
     #[allow(clippy::missing_panics_doc)]
-    pub fn workflow_tag_set(&self) -> IndexedSet {
-        self.states
+    pub fn workflow_tag_set(&self) -> Result<TagSet> {
+        let set = self
+            .states
             .indexed_set(tables::WORKFLOW_TAGS)
-            .expect("always available")
+            .expect("always available");
+        TagSet::new(set)
     }
 
     /// Fetch the most recent pretrained model with `name`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ mod outlier;
 mod schema;
 mod scores;
 mod tables;
+#[cfg(test)]
+mod test;
 mod ti;
 mod time_series;
 mod top_n;

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -1,0 +1,123 @@
+use crate::IndexedSet;
+
+#[derive(Default)]
+pub struct Tag {
+    pub id: u32,
+    pub name: String,
+}
+
+pub struct TagSet<'a> {
+    set: IndexedSet<'a>, // will be needed when we implement write operations
+    tags: Vec<Tag>,
+}
+
+impl<'a> TagSet<'a> {
+    pub(crate) fn new(set: IndexedSet<'a>) -> anyhow::Result<Self> {
+        use anyhow::Context;
+
+        let index = set.index()?;
+        let mut tags = Vec::new();
+        for (id, name) in index.iter() {
+            tags.push(Tag {
+                id,
+                name: String::from_utf8(name.to_vec()).context("invalid data")?,
+            });
+        }
+        Ok(Self { set, tags })
+    }
+
+    /// Inserts a new tag into the set, returning its ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any database operation fails.
+    pub fn insert(&mut self, name: &str) -> anyhow::Result<u32> {
+        // TODO: Reject a duplicate name. Not implemented yet, because it
+        // requires searching the name in the set. We need to convert the format
+        // so that keys are stored as actual RocksDB keys.
+        self.set.insert(name.as_bytes())
+    }
+
+    /// Removes a tag from the set, returning its name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `id` is invalid or any database operation fails.
+    pub fn remove(&mut self, id: u32) -> anyhow::Result<String> {
+        let key = self.set.remove(id)?;
+        let name = String::from_utf8(key)?;
+        Ok(name)
+    }
+
+    /// Updates an old tag name to a new one for the given ID.
+    ///
+    /// It returns `true` if the name was updated successfully, and `false` if
+    /// the old name was different from what was stored or not found.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `id` is invalid or any database operation fails.
+    pub fn update(&mut self, id: u32, old: &str, new: &str) -> anyhow::Result<bool> {
+        self.set.update(id, old.as_bytes(), new.as_bytes())
+    }
+
+    /// Returns an iterator over the tags in the set.
+    pub fn tags(&self) -> Tags {
+        Tags {
+            tags: self.tags.as_slice(),
+            index: 0,
+        }
+    }
+}
+
+/// An iterator over the tags in a `TagSet`.
+pub struct Tags<'a> {
+    tags: &'a [Tag],
+    index: usize,
+}
+
+impl<'a> Iterator for Tags<'a> {
+    type Item = &'a Tag;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.tags.len() {
+            let tag = &self.tags[self.index];
+            self.index += 1;
+            Some(tag)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TagSet;
+    use crate::test;
+
+    #[test]
+    fn tag_set() {
+        let db = test::Store::new();
+        let set = db.indexed_set();
+        let mut tag_set = TagSet::new(set).unwrap();
+
+        let id = tag_set.insert("tag1").unwrap();
+        assert_eq!(id, 0);
+        let id = tag_set.insert("tag2").unwrap();
+        assert_eq!(id, 1);
+        let id = tag_set.insert("tag3").unwrap();
+        assert_eq!(id, 2);
+
+        assert!(tag_set.remove(5).is_err());
+        let removed_name = tag_set.remove(1).unwrap();
+        assert_eq!(removed_name, "tag2");
+        assert!(tag_set.remove(1).is_err());
+
+        let updated = tag_set.update(2, "tag3", "tag3.1").unwrap();
+        assert_eq!(updated, true);
+        let updated = tag_set.update(2, "tag3", "tag3.2").unwrap();
+        assert_eq!(updated, false);
+        let updated = tag_set.update(2, "tag5", "tag5.1").unwrap();
+        assert_eq!(updated, false);
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,37 @@
+//! # Test Utilities Module
+//!
+//! The `test` module provides shared utilities and data structures for
+//! conducting unit tests throughout the `review-database` crate. Its primary
+//! focus is on facilitating the setup and management of a test database
+//! environment, utilizing the `OptimisticTransactionDB` from the `rocksdb`
+//! crate. This setup is crucial for tests that require interaction with a
+//! database, ensuring they run against a realistic and isolated environment.
+
+use rocksdb::OptimisticTransactionDB;
+
+use crate::{IndexedMultimap, IndexedSet};
+
+pub(super) struct Store {
+    db: OptimisticTransactionDB,
+}
+
+impl Store {
+    pub(super) fn new() -> Self {
+        let db_dir = tempfile::tempdir().unwrap();
+        let db_path = db_dir.path().join("test.db");
+
+        let mut opts = rocksdb::Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+        let db = rocksdb::OptimisticTransactionDB::open_cf(&opts, db_path, ["test_cf"]).unwrap();
+        Self { db }
+    }
+
+    pub(super) fn indexed_multimap(&self) -> IndexedMultimap {
+        IndexedMultimap::new(&self.db, "test_cf").unwrap()
+    }
+
+    pub(super) fn indexed_set(&self) -> IndexedSet {
+        IndexedSet::new(&self.db, "test_cf", b"indexed set").unwrap()
+    }
+}


### PR DESCRIPTION
With this change, `Store::workflow_tag_set` now returns `TagSet` instead of `IndexSet`. This change is made to leverage the new `TagSet` structure for a more user-friendly approach in accessing tags. The `TagSet` allows users to interact with tags through the `Tag` struct, which includes `name` and `id` fields, offering a more straightforward and human-readable format compared to the raw binary format exposed by `IndexSet`.