### PR TITLE
Remove unused backup recovery codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,10 +90,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - To ensure data integrity and avoid potential data loss, users currently
     utilizing review-database versions below 0.24.0 must migrate to version
     0.24.0 before proceeding with any further migrations.
-- The `backup::schedule_periodic` function has been permanently removed. This
-  decision has been made to streamline and focus on providing precise abstractions
-  for database operations. Users are advised to update their codebase accordingly
-  and leverage alternative methods for scheduling periodic backups.
+- The `backup::schedule_periodic` function has been permanently removed. Users
+  are advised to update their codebase accordingly and leverage alternative
+  methods for scheduling periodic backups.
+- The `backup::recover` and `Store::recover` functions have been removed. These
+  functions were designed to attempt recovery from the most recent backup until
+  success. We recommend implementing backup recovery strategies at the
+  application level to better suit specific needs.
 - The `FromKeyValue` implementation for `DeserializeOwned` has been removed. This
   change was made to ensure that the `FromKeyValue` trait is only implemented for
   types that are explicitly intended to be deserialized from key-value entries.

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -89,31 +89,6 @@ pub async fn restore(store: &Arc<RwLock<Store>>, backup_id: Option<u32>) -> Resu
     }
 }
 
-/// Restores the database from a backup with the specified ID.
-///
-/// # Errors
-///
-/// Returns an error if the restore operation fails.
-pub async fn recover(store: &Arc<RwLock<Store>>) -> Result<()> {
-    // TODO: This function should be expanded to support PostgreSQL backups as well.
-    info!("recovering database from latest valid backup");
-    let res = {
-        let mut store = store.write().await;
-        store.recover()
-    };
-
-    match res {
-        Ok(()) => {
-            info!("database recovered from backup");
-            Ok(())
-        }
-        Err(e) => {
-            warn!("failed to recover database from backup: {e:?}");
-            Err(e)
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::{event::DnsEventFields, EventKind, EventMessage, Store};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,16 +416,6 @@ impl Store {
         self.states.restore_from_latest_backup()
     }
 
-    /// Recover from the latest valid backup on file
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when all the available backups are not valid
-    /// for restoration.
-    pub fn recover(&mut self) -> Result<()> {
-        self.states.recover()
-    }
-
     /// Purge old backups and only keep `num_backups_to_keep` backups on file
     ///
     /// # Errors


### PR DESCRIPTION
The `backup::recover` and `Store::recover` functions have been removed. These functions were designed to attempt recovery from the most recent backup until success, and should be implemented at the application level to better suit specific needs.