### PR TITLE
Use `TagSet` for network tags, removing `IndexedSet` from public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Modified `Node` to have `name` and `name_draft` field, replacing its previous
   location within `NodeSetting`. Also, renamed `as_is` and `to_be` to `setting`
   and `setting_draft`.
+- `Store::network_tag_set` now returns `TagSet` instead of `IndexSet`. This
+  change is made to leverage the new `TagSet` structure for a more user-friendly
+  approach in accessing tags. The `TagSet` allows users to interact with tags
+  through the `Tag` struct, which includes `name` and `id` fields, offering a
+  more straightforward and human-readable format compared to the raw binary
+  format exposed by `IndexSet`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `IndexedMultiMap` has been removed from the codebase, for table that currently
   use `IndexedMultiMap` use `IndexedMap` with a customized `Indexable::make_indexed_key`
   for entries stored instead.
+- `IndexedSet` has been removed, replaced by `TagSet`.
 
 ## [0.25.0] - 2024-03-05
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub use rocksdb::backup::BackupEngineInfo;
 use std::io;
 use std::path::{Path, PathBuf};
 pub use tags::TagSet;
-use tags::{EventTagId, WorkflowTagId};
+use tags::{EventTagId, NetworkTagId, WorkflowTagId};
 use thiserror::Error;
 
 #[derive(Clone)]
@@ -246,12 +246,18 @@ impl Store {
         self.states.networks()
     }
 
-    #[must_use]
+    /// Returns the tag set for network.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if database operation fails or the data is invalid.
     #[allow(clippy::missing_panics_doc)]
-    pub fn network_tag_set(&self) -> IndexedSet {
-        self.states
+    pub fn network_tag_set(&self) -> Result<TagSet<NetworkTagId>> {
+        let set = self
+            .states
             .indexed_set(tables::NETWORK_TAGS)
-            .expect("always available")
+            .expect("always available");
+        TagSet::new(set)
     }
 
     #[must_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,8 @@ pub use self::batch_info::BatchInfo;
 pub use self::category::Category;
 pub use self::cluster::*;
 pub use self::collections::{
-    Indexable, Indexed, IndexedMap, IndexedMapIterator, IndexedMapUpdate, IndexedSet, IterableMap,
-    Map, MapIterator,
+    Indexable, Indexed, IndexedMap, IndexedMapIterator, IndexedMapUpdate, IterableMap, Map,
+    MapIterator,
 };
 pub use self::column_statistics::*;
 pub use self::csv_column_extra::CsvColumnExtra as CsvColumnExtraConfig;

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -16,13 +16,14 @@ mod triage_response;
 use crate::{
     batch_info::BatchInfo,
     category::Category,
+    collections::IndexedSet,
     csv_column_extra::CsvColumnExtra,
     scores::Scores,
     types::{Account, FromKeyValue, Qualifier, Status},
     Direction, Indexable,
 };
 
-use super::{event, Indexed, IndexedMap, IndexedSet, Map};
+use super::{event, Indexed, IndexedMap, Map};
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::{

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -1,9 +1,12 @@
-use crate::{IndexedSet, IndexedTable, TriageResponse};
+use crate::{IndexedSet, IndexedTable, Network, TriageResponse};
 
 // Kinds of tag IDs. They are used to define the behavior of tag sets.
 
 /// A compile-time tag indicating that tag IDs are for event tags.
 pub struct EventTagId;
+
+/// A compile-time tag indicating that tag IDs are for network tags.
+pub struct NetworkTagId;
 
 /// A compile-time tag indicating that tag IDs are for network tags.
 // will be used when `Store::network_tag_set` is converted to use `TagSet`.
@@ -92,6 +95,26 @@ impl<'a> TagSet<'a, EventTagId> {
     ) -> anyhow::Result<String> {
         let key = self.set.deactivate(id)?;
         triage_responses.remove_tag(id)?;
+        self.set.clear_inactive()?;
+
+        let name = String::from_utf8(key)?;
+        Ok(name)
+    }
+}
+
+impl<'a> TagSet<'a, NetworkTagId> {
+    /// Removes a tag from the network tag set, returning its name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `id` is invalid or any database operation fails.
+    pub fn remove_network_tag(
+        &mut self,
+        id: u32,
+        networks: &IndexedTable<Network>,
+    ) -> anyhow::Result<String> {
+        let key = self.set.deactivate(id)?;
+        networks.remove_tag(id)?;
         self.set.clear_inactive()?;
 
         let name = String::from_utf8(key)?;

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -1,4 +1,4 @@
-use crate::{IndexedSet, IndexedTable, Network, TriageResponse};
+use crate::{collections::IndexedSet, IndexedTable, Network, TriageResponse};
 
 // Kinds of tag IDs. They are used to define the behavior of tag sets.
 

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -79,7 +79,7 @@ impl<'a, IdKind> TagSet<'a, IdKind> {
     }
 }
 
-impl<'a, EventTagId> TagSet<'a, EventTagId> {
+impl<'a> TagSet<'a, EventTagId> {
     /// Removes a tag from the event tag set, returning its name.
     ///
     /// # Errors
@@ -99,7 +99,7 @@ impl<'a, EventTagId> TagSet<'a, EventTagId> {
     }
 }
 
-impl<'a, WorkflowTagId> TagSet<'a, WorkflowTagId> {
+impl<'a> TagSet<'a, WorkflowTagId> {
     /// Removes a tag from the workflow tag set, returning its name.
     ///
     /// # Errors

--- a/src/test.rs
+++ b/src/test.rs
@@ -9,7 +9,7 @@
 
 use rocksdb::OptimisticTransactionDB;
 
-use crate::IndexedSet;
+use crate::collections::IndexedSet;
 
 pub(super) struct Store {
     db: OptimisticTransactionDB,


### PR DESCRIPTION
`TagSet`, unlike `IndexedSet`, does not expose the database internals to API callers.