### PR TITLE
Make node related setting names plural

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Introduced `TriagePolicyUpdate` to describe data for updating `IndexedTable<TriagePolicy>`.
 - Added new functions to facilitate insert, remove, and update operations,
   ensuring a more controlled and secure triage policy management.
-- Introduced `Node`, `NodeSetting` and `NodeUpdate` to describe data stored in `IndexedTable<Node>`.
+- Introduced `Node`, `NodeSettings` and `NodeUpdate` to describe data stored in `IndexedTable<Node>`.
 - Added new functions to facilitate insert, remove, and update operations,
   ensuring a more controlled and secure node management.
 - Added new functions to facilitate insert, remove, and update operations,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.27.0-alpha.9"
+version = "0.27.0-alpha.10"
 edition = "2021"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub use self::tables::{
     AccessToken, AllowNetwork, AllowNetworkUpdate, AttrCmpKind, BlockNetwork, BlockNetworkUpdate,
     Confidence, CsvColumnExtra as CsvColumnExtraConfig, Customer, CustomerNetwork, CustomerUpdate,
     DataSource, DataSourceUpdate, DataType, Filter, IndexedTable, Iterable, ModelIndicator,
-    Network, NetworkUpdate, Node, NodeSetting, NodeUpdate, PacketAttr, ProtocolPorts, Response,
+    Network, NetworkUpdate, Node, NodeSettings, NodeUpdate, PacketAttr, ProtocolPorts, Response,
     ResponseKind, SamplingInterval, SamplingKind, SamplingPeriod, SamplingPolicy,
     SamplingPolicyUpdate, Structured, StructuredClusteringAlgorithm, Table, Template, Ti,
     TiCmpKind, Tidb, TidbKind, TidbRule, TorExitNode, TrafficFilter, TriagePolicy,

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -32,7 +32,7 @@ use tracing::{info, warn};
 /// // the database format won't be changed in the future alpha or beta versions.
 /// const COMPATIBLE_VERSION: &str = ">=0.5.0-alpha.2,<=0.5.0-alpha.4";
 /// ```
-const COMPATIBLE_VERSION_REQ: &str = ">=0.26.0,<=0.27.0-alpha.9";
+const COMPATIBLE_VERSION_REQ: &str = ">=0.26.0,<=0.27.0-alpha.10";
 
 /// Migrates data exists in `PostgresQL` to Rocksdb if necessary.
 ///
@@ -191,7 +191,7 @@ fn read_version_file(path: &Path) -> Result<Version> {
 fn migrate_0_25_to_0_26(store: &super::Store) -> Result<()> {
     use crate::collections::Indexed;
     use crate::IterableMap;
-    use crate::{Node, NodeSetting};
+    use crate::{Node, NodeSettings};
     use bincode::Options;
     use chrono::{DateTime, Utc};
     use std::collections::HashMap;
@@ -202,13 +202,13 @@ fn migrate_0_25_to_0_26(store: &super::Store) -> Result<()> {
     pub struct OldNode {
         pub id: u32,
         pub creation_time: DateTime<Utc>,
-        as_is: Option<OldNodeSetting>,
-        to_be: Option<OldNodeSetting>,
+        as_is: Option<OldNodeSettings>,
+        to_be: Option<OldNodeSettings>,
     }
 
     #[allow(clippy::struct_excessive_bools, clippy::module_name_repetitions)]
     #[derive(Deserialize, Serialize)]
-    struct OldNodeSetting {
+    struct OldNodeSettings {
         pub name: String,
         pub customer_id: u32,
         pub description: String,
@@ -260,8 +260,8 @@ fn migrate_0_25_to_0_26(store: &super::Store) -> Result<()> {
         pub sensor_list: HashMap<String, bool>,
     }
 
-    impl From<OldNodeSetting> for NodeSetting {
-        fn from(input: OldNodeSetting) -> Self {
+    impl From<OldNodeSettings> for NodeSettings {
+        fn from(input: OldNodeSettings) -> Self {
             Self {
                 customer_id: input.customer_id,
                 description: input.description,
@@ -328,8 +328,8 @@ fn migrate_0_25_to_0_26(store: &super::Store) -> Result<()> {
                 id: input.id,
                 name,
                 name_draft,
-                setting: input.as_is.map(std::convert::Into::into),
-                setting_draft: input.to_be.map(std::convert::Into::into),
+                settings: input.as_is.map(std::convert::Into::into),
+                settings_draft: input.to_be.map(std::convert::Into::into),
                 creation_time: input.creation_time,
             })
         }
@@ -444,13 +444,13 @@ mod tests {
         pub struct OldNode {
             pub id: u32,
             pub creation_time: DateTime<Utc>,
-            pub as_is: Option<OldNodeSetting>,
-            pub to_be: Option<OldNodeSetting>,
+            pub as_is: Option<OldNodeSettings>,
+            pub to_be: Option<OldNodeSettings>,
         }
 
         #[allow(clippy::struct_excessive_bools, clippy::module_name_repetitions)]
         #[derive(Deserialize, Serialize, Clone)]
-        struct OldNodeSetting {
+        struct OldNodeSettings {
             pub name: String,
             pub customer_id: u32,
             pub description: String,
@@ -540,7 +540,7 @@ mod tests {
             id: 0,
             creation_time: Utc::now(),
             as_is: None,
-            to_be: Some(OldNodeSetting {
+            to_be: Some(OldNodeSettings {
                 name: "name".to_string(),
                 customer_id: 20,
                 description: "description".to_string(),

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -50,7 +50,7 @@ pub use self::data_source::{DataSource, DataType, Update as DataSourceUpdate};
 pub use self::filter::Filter;
 pub use self::model_indicator::ModelIndicator;
 pub use self::network::{Network, Update as NetworkUpdate};
-pub use self::node::{Node, Setting as NodeSetting, Update as NodeUpdate};
+pub use self::node::{Node, Settings as NodeSettings, Update as NodeUpdate};
 pub use self::sampling_policy::{
     Interval as SamplingInterval, Kind as SamplingKind, Period as SamplingPeriod, SamplingPolicy,
     Update as SamplingPolicyUpdate,
@@ -543,7 +543,7 @@ impl<'d, R> IndexedTable<'d, R> {
     ///
     /// # Errors
     ///
-    /// Returns an error if the map index is not found or the database operation fails.    
+    /// Returns an error if the map index is not found or the database operation fails.
     pub fn count(&self) -> Result<usize> {
         self.indexed_map.count()
     }

--- a/src/tables/node.rs
+++ b/src/tables/node.rs
@@ -13,7 +13,7 @@ type PortNumber = u16;
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Default, Deserialize, Serialize, PartialEq)]
-pub struct Setting {
+pub struct Settings {
     pub customer_id: u32,
     pub description: String,
     pub hostname: String,
@@ -69,8 +69,8 @@ pub struct Node {
     pub id: u32,
     pub name: String,
     pub name_draft: Option<String>,
-    pub setting: Option<Setting>,
-    pub setting_draft: Option<Setting>,
+    pub settings: Option<Settings>,
+    pub settings_draft: Option<Settings>,
     pub creation_time: DateTime<Utc>,
 }
 
@@ -130,8 +130,8 @@ impl<'d> IndexedTable<'d, Node> {
 pub struct Update {
     pub name: Option<String>,
     pub name_draft: Option<String>,
-    pub setting: Option<Setting>,
-    pub setting_draft: Option<Setting>,
+    pub settings: Option<Settings>,
+    pub settings_draft: Option<Settings>,
 }
 
 impl From<Node> for Update {
@@ -139,8 +139,8 @@ impl From<Node> for Update {
         Self {
             name: Some(input.name),
             name_draft: input.name_draft,
-            setting: input.setting,
-            setting_draft: input.setting_draft,
+            settings: input.settings,
+            settings_draft: input.settings_draft,
         }
     }
 }
@@ -157,8 +157,8 @@ impl IndexedMapUpdate for Update {
             value.name = n.to_owned();
         }
         value.name_draft = self.name_draft.clone();
-        value.setting = self.setting.clone();
-        value.setting_draft = self.setting_draft.clone();
+        value.settings = self.settings.clone();
+        value.settings_draft = self.settings_draft.clone();
         Ok(value)
     }
 
@@ -171,9 +171,9 @@ impl IndexedMapUpdate for Update {
         if self.name_draft != value.name_draft {
             return false;
         }
-        if self.setting != value.setting {
+        if self.settings != value.settings {
             return false;
         }
-        self.setting_draft == value.setting_draft
+        self.settings_draft == value.settings_draft
     }
 }


### PR DESCRIPTION
closes #262 

---

Notes
- Migration code is not necessary for this change, because name change does not affect serialization layout.
- I incremented the pre-release alpha version by 1, as advised by Sehkone.