### PR TITLE
Fix clippy warnings with Rust 1.78

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
+    - name: Set PQ_LIB_DIR
+      if: runner.os == 'macOS'
+      run: echo "PQ_LIB_DIR=$(brew --prefix libpq)/lib" >> $GITHUB_ENV
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/src/event/common.rs
+++ b/src/event/common.rs
@@ -15,9 +15,12 @@ use std::{
 
 pub(super) trait Match {
     fn src_addr(&self) -> IpAddr;
+    #[allow(dead_code)] // for future use
     fn src_port(&self) -> u16;
     fn dst_addr(&self) -> IpAddr;
+    #[allow(dead_code)] // for future use
     fn dst_port(&self) -> u16;
+    #[allow(dead_code)] // for future use
     fn proto(&self) -> u8;
     fn category(&self) -> EventCategory;
     fn level(&self) -> NonZeroU8;

--- a/src/tables/accounts.rs
+++ b/src/tables/accounts.rs
@@ -102,19 +102,19 @@ impl<'d> Table<'d, Account> {
                     if account.name != *old {
                         bail!("old value mismatch");
                     }
-                    account.name = new.clone();
+                    account.name.clone_from(new);
                 }
                 if let Some((old, new)) = &department {
                     if account.department != *old {
                         bail!("old value mismatch");
                     }
-                    account.department = new.clone();
+                    account.department.clone_from(new);
                 }
                 if let Some((old, new)) = &allow_access_from {
                     if account.allow_access_from != *old {
                         bail!("old value mismatch");
                     }
-                    account.allow_access_from = new.clone();
+                    account.allow_access_from.clone_from(new);
                 }
                 if let Some((old, new)) = max_parallel_sessions {
                     if account.max_parallel_sessions != *old {

--- a/src/tables/allow_network.rs
+++ b/src/tables/allow_network.rs
@@ -66,7 +66,7 @@ impl IndexedMapUpdate for Update {
             value.name.push_str(name);
         }
         if let Some(networks) = self.networks.as_ref() {
-            value.networks = networks.to_owned();
+            networks.clone_into(&mut value.networks);
         }
         if let Some(description) = self.description.as_deref() {
             value.description.clear();

--- a/src/tables/block_network.rs
+++ b/src/tables/block_network.rs
@@ -66,7 +66,7 @@ impl IndexedMapUpdate for Update {
             value.name.push_str(name);
         }
         if let Some(networks) = self.networks.as_ref() {
-            value.networks = networks.to_owned();
+            networks.clone_into(&mut value.networks);
         }
         if let Some(description) = self.description.as_deref() {
             value.description.clear();

--- a/src/tables/node.rs
+++ b/src/tables/node.rs
@@ -154,11 +154,11 @@ impl IndexedMapUpdate for Update {
 
     fn apply(&self, mut value: Self::Entry) -> Result<Self::Entry, anyhow::Error> {
         if let Some(n) = self.name.as_deref() {
-            value.name = n.to_owned();
+            n.clone_into(&mut value.name);
         }
-        value.name_draft = self.name_draft.clone();
-        value.settings = self.settings.clone();
-        value.settings_draft = self.settings_draft.clone();
+        value.name_draft.clone_from(&self.name_draft);
+        value.settings.clone_from(&self.settings);
+        value.settings_draft.clone_from(&self.settings_draft);
         Ok(value)
     }
 

--- a/src/tables/sampling_policy.rs
+++ b/src/tables/sampling_policy.rs
@@ -151,7 +151,7 @@ impl IndexedMapUpdate for Update {
 
         value.dst_ip = self.dst_ip;
 
-        value.node = self.node.clone();
+        value.node.clone_from(&self.node);
 
         value.column = self.column;
 

--- a/src/tables/traffic_filter.rs
+++ b/src/tables/traffic_filter.rs
@@ -86,7 +86,7 @@ impl TrafficFilter {
     }
 
     fn check_duplicate(&self, network: IpNet) -> Option<IpNet> {
-        if network.addr().is_unspecified() && self.rules.get(&network).is_some() {
+        if network.addr().is_unspecified() && self.rules.contains_key(&network) {
             return Some(network);
         }
         self.rules

--- a/src/top_n/column.rs
+++ b/src/top_n/column.rs
@@ -158,7 +158,7 @@ impl Database {
         let mut conn = self.pool.get_diesel_conn().await?;
         let columns_for_top_n = get_columns_for_top_n(&mut conn, model_id).await?;
         let mut column_types = self.get_column_types_of_model(model_id).await?;
-        column_types.retain(|c| columns_for_top_n.get(&c.column_index).is_some());
+        column_types.retain(|c| columns_for_top_n.contains(&c.column_index));
 
         let cluster_sizes = super::get_cluster_sizes(&mut conn, model_id).await?;
         let cluster_ids = get_limited_cluster_ids(


### PR DESCRIPTION
This fixes clippy warnings and a build issue with recent macOS runner.