### PR TITLE
Modify `node::Settings` struct.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   and TLS protocols.
 - Fixed to provide crypto libraries directly as `builder_with_provider` when
   generating `rustls::ClientConfig`.
+- Modified the `NodeSettings` fields.
+  - Removed `reconverge_giganto_[ip|port]` fields.
+  - Removed central server's address fields.
+  - Removed the redundant `html` field as both `html` and `txt` represented the
+    existing `MIME FileType::Text`. The `txt` field should be used for `MIME FileType::Text`.
+  - Added `vbs` field.
+  - Merged `protocols` (boolean) and `protocol_list` (`HashMap<String, bool>`) into
+    `protocols: Option<Vec<String>>`.
+    - The new protocols field should be sorted in alphabetical order.
+  - Merged `sensors` (boolean) and `sensor_list` (`HashMap<String, bool>`) into
+    `sensors: Option<Vec<String>>`.
+    - The new sensors field should also be sorted in alphabetical order.
 
 ## [0.28.0] - 2024-05-16
 

--- a/src/tables/node.rs
+++ b/src/tables/node.rs
@@ -1,6 +1,6 @@
 //! The `network` table.
 
-use std::{borrow::Cow, collections::HashMap, net::IpAddr};
+use std::{borrow::Cow, net::IpAddr};
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
@@ -18,22 +18,16 @@ pub struct Settings {
     pub description: String,
     pub hostname: String,
 
-    pub review: bool,
-    pub review_port: Option<PortNumber>,
-    pub review_web_port: Option<PortNumber>,
-
     pub piglet: bool,
     pub piglet_giganto_ip: Option<IpAddr>,
     pub piglet_giganto_port: Option<PortNumber>,
-    pub piglet_review_ip: Option<IpAddr>,
-    pub piglet_review_port: Option<PortNumber>,
     pub save_packets: bool,
     pub http: bool,
     pub office: bool,
     pub exe: bool,
     pub pdf: bool,
-    pub html: bool,
     pub txt: bool,
+    pub vbs: bool,
     pub smtp_eml: bool,
     pub ftp: bool,
 
@@ -47,21 +41,13 @@ pub struct Settings {
     pub retention_period: Option<u16>,
 
     pub reconverge: bool,
-    pub reconverge_review_ip: Option<IpAddr>,
-    pub reconverge_review_port: Option<PortNumber>,
-    pub reconverge_giganto_ip: Option<IpAddr>,
-    pub reconverge_giganto_port: Option<PortNumber>,
 
     pub hog: bool,
-    pub hog_review_ip: Option<IpAddr>,
-    pub hog_review_port: Option<PortNumber>,
     pub hog_giganto_ip: Option<IpAddr>,
     pub hog_giganto_port: Option<PortNumber>,
-    pub protocols: bool,
-    pub protocol_list: HashMap<String, bool>,
+    pub protocols: Option<Vec<String>>,
 
-    pub sensors: bool,
-    pub sensor_list: HashMap<String, bool>,
+    pub sensors: Option<Vec<String>>,
 }
 
 #[derive(Clone, Deserialize, Serialize)]


### PR DESCRIPTION
- Remove `reconverge_giganto` fields from node struct `Settings`
- Remove the central server's address from node struct `Settings`
- Remove the `html` and redundant fields, add the vbs field
- Add migration code for `Node` struct

0.25 -> 0.26의 node 변경 migration 코드에 0.26ver의 node struct를 추가하였습니다.

Closes: #273
Closes: #280
Closes: #281
Closes: #287
Closes: #282 