### PR TITLE
Convert `Node` into `InnerNode` and `Agent` to be stored in the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Introduced `Agent`, `AgentKind` to describe data stored in `Table<Agent>`.
+- Added new functions to facilitate insert, remove operations, ensuring a more
+  controlled and secure agent management.
+
 ### Changed
 
 - Change the fields for events detected from the HTTP, SMTP, CONN, NTLM, SSH,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.29.0-alpha.1"
+version = "0.29.0-alpha.2"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ strum_macros = "0.26"
 thiserror = "1"
 tokio = { version = "1", features = ["macros"] }
 tokio-postgres-rustls = "0.12"
+toml = "0.8.13"
 tracing = "0.1"
 
 [dev-dependencies]

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -1,6 +1,8 @@
 use anyhow::{anyhow, bail, Context, Result};
 use rocksdb::IteratorMode;
 
+use crate::{IterableMap, EXCLUSIVE};
+
 #[derive(Clone)]
 pub struct Map<'a> {
     pub(crate) db: &'a rocksdb::OptimisticTransactionDB,

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -1,9 +1,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use rocksdb::IteratorMode;
 
-use super::IterableMap;
-use crate::EXCLUSIVE;
-
+#[derive(Clone)]
 pub struct Map<'a> {
     pub(crate) db: &'a rocksdb::OptimisticTransactionDB,
     pub(crate) cf: &'a rocksdb::ColumnFamily,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ impl Store {
 
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
-    pub fn agents_map(&self) -> IndexedTable<Agent> {
+    pub fn agents_map(&self) -> Table<Agent> {
         self.states.agents()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,13 +69,13 @@ pub use self::tables::{
     AccessToken, AccountPolicy, Agent, AgentKind, AllowNetwork, AllowNetworkUpdate, AttrCmpKind,
     BlockNetwork, BlockNetworkUpdate, Confidence, CsvColumnExtra as CsvColumnExtraConfig, Customer,
     CustomerNetwork, CustomerUpdate, DataSource, DataSourceUpdate, DataType, Filter, IndexedTable,
-    Iterable, ModelIndicator, Network, NetworkUpdate, Node, NodeSettings, NodeUpdate, OutlierInfo,
-    OutlierInfoKey, OutlierInfoValue, PacketAttr, ProtocolPorts, Response, ResponseKind,
-    SamplingInterval, SamplingKind, SamplingPeriod, SamplingPolicy, SamplingPolicyUpdate,
-    Structured, StructuredClusteringAlgorithm, Table, Template, Ti, TiCmpKind, Tidb, TidbKind,
-    TidbRule, TorExitNode, TrafficFilter, TriagePolicy, TriagePolicyUpdate, TriageResponse,
-    TriageResponseUpdate, TrustedDomain, TrustedUserAgent, UniqueKey, Unstructured,
-    UnstructuredClusteringAlgorithm, ValueKind,
+    Iterable, ModelIndicator, Network, NetworkUpdate, Node, NodeSettings, NodeTable, NodeUpdate,
+    OutlierInfo, OutlierInfoKey, OutlierInfoValue, PacketAttr, ProtocolPorts, Response,
+    ResponseKind, SamplingInterval, SamplingKind, SamplingPeriod, SamplingPolicy,
+    SamplingPolicyUpdate, Structured, StructuredClusteringAlgorithm, Table, Template, Ti,
+    TiCmpKind, Tidb, TidbKind, TidbRule, TorExitNode, TrafficFilter, TriagePolicy,
+    TriagePolicyUpdate, TriageResponse, TriageResponseUpdate, TrustedDomain, TrustedUserAgent,
+    UniqueKey, Unstructured, UnstructuredClusteringAlgorithm, ValueKind,
 };
 pub use self::time_series::*;
 pub use self::time_series::{ColumnTimeSeries, TimeCount, TimeSeriesResult};
@@ -254,7 +254,7 @@ impl Store {
 
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
-    pub fn node_map(&self) -> IndexedTable<Node> {
+    pub fn node_map(&self) -> NodeTable {
         self.states.nodes()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,13 +69,13 @@ pub use self::tables::{
     AccessToken, AccountPolicy, Agent, AgentKind, AllowNetwork, AllowNetworkUpdate, AttrCmpKind,
     BlockNetwork, BlockNetworkUpdate, Confidence, CsvColumnExtra as CsvColumnExtraConfig, Customer,
     CustomerNetwork, CustomerUpdate, DataSource, DataSourceUpdate, DataType, Filter, IndexedTable,
-    Iterable, ModelIndicator, Network, NetworkUpdate, Node, NodeSettings, NodeTable, OutlierInfo,
-    OutlierInfoKey, OutlierInfoValue, PacketAttr, ProtocolPorts, Response, ResponseKind,
-    SamplingInterval, SamplingKind, SamplingPeriod, SamplingPolicy, SamplingPolicyUpdate,
-    Structured, StructuredClusteringAlgorithm, Table, Template, Ti, TiCmpKind, Tidb, TidbKind,
-    TidbRule, TorExitNode, TrafficFilter, TriagePolicy, TriagePolicyUpdate, TriageResponse,
-    TriageResponseUpdate, TrustedDomain, TrustedUserAgent, UniqueKey, Unstructured,
-    UnstructuredClusteringAlgorithm, ValueKind,
+    Iterable, ModelIndicator, Network, NetworkUpdate, Node, NodeSettings, NodeTable, NodeUpdate,
+    OutlierInfo, OutlierInfoKey, OutlierInfoValue, PacketAttr, ProtocolPorts, Response,
+    ResponseKind, SamplingInterval, SamplingKind, SamplingPeriod, SamplingPolicy,
+    SamplingPolicyUpdate, Structured, StructuredClusteringAlgorithm, Table, Template, Ti,
+    TiCmpKind, Tidb, TidbKind, TidbRule, TorExitNode, TrafficFilter, TriagePolicy,
+    TriagePolicyUpdate, TriageResponse, TriageResponseUpdate, TrustedDomain, TrustedUserAgent,
+    UniqueKey, Unstructured, UnstructuredClusteringAlgorithm, ValueKind,
 };
 pub use self::time_series::*;
 pub use self::time_series::{ColumnTimeSeries, TimeCount, TimeSeriesResult};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,13 +69,13 @@ pub use self::tables::{
     AccessToken, AccountPolicy, Agent, AgentKind, AllowNetwork, AllowNetworkUpdate, AttrCmpKind,
     BlockNetwork, BlockNetworkUpdate, Confidence, CsvColumnExtra as CsvColumnExtraConfig, Customer,
     CustomerNetwork, CustomerUpdate, DataSource, DataSourceUpdate, DataType, Filter, IndexedTable,
-    Iterable, ModelIndicator, Network, NetworkUpdate, Node, NodeSettings, NodeTable, NodeUpdate,
-    OutlierInfo, OutlierInfoKey, OutlierInfoValue, PacketAttr, ProtocolPorts, Response,
-    ResponseKind, SamplingInterval, SamplingKind, SamplingPeriod, SamplingPolicy,
-    SamplingPolicyUpdate, Structured, StructuredClusteringAlgorithm, Table, Template, Ti,
-    TiCmpKind, Tidb, TidbKind, TidbRule, TorExitNode, TrafficFilter, TriagePolicy,
-    TriagePolicyUpdate, TriageResponse, TriageResponseUpdate, TrustedDomain, TrustedUserAgent,
-    UniqueKey, Unstructured, UnstructuredClusteringAlgorithm, ValueKind,
+    Iterable, ModelIndicator, Network, NetworkUpdate, Node, NodeSettings, NodeTable, OutlierInfo,
+    OutlierInfoKey, OutlierInfoValue, PacketAttr, ProtocolPorts, Response, ResponseKind,
+    SamplingInterval, SamplingKind, SamplingPeriod, SamplingPolicy, SamplingPolicyUpdate,
+    Structured, StructuredClusteringAlgorithm, Table, Template, Ti, TiCmpKind, Tidb, TidbKind,
+    TidbRule, TorExitNode, TrafficFilter, TriagePolicy, TriagePolicyUpdate, TriageResponse,
+    TriageResponseUpdate, TrustedDomain, TrustedUserAgent, UniqueKey, Unstructured,
+    UnstructuredClusteringAlgorithm, ValueKind,
 };
 pub use self::time_series::*;
 pub use self::time_series::{ColumnTimeSeries, TimeCount, TimeSeriesResult};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,8 +66,8 @@ pub use self::model::{Digest as ModelDigest, Model};
 pub use self::outlier::*;
 use self::tables::StateDb;
 pub use self::tables::{
-    AccessToken, AccountPolicy, AllowNetwork, AllowNetworkUpdate, AttrCmpKind, BlockNetwork,
-    BlockNetworkUpdate, Confidence, CsvColumnExtra as CsvColumnExtraConfig, Customer,
+    AccessToken, AccountPolicy, Agent, AgentKind, AllowNetwork, AllowNetworkUpdate, AttrCmpKind,
+    BlockNetwork, BlockNetworkUpdate, Confidence, CsvColumnExtra as CsvColumnExtraConfig, Customer,
     CustomerNetwork, CustomerUpdate, DataSource, DataSourceUpdate, DataType, Filter, IndexedTable,
     Iterable, ModelIndicator, Network, NetworkUpdate, Node, NodeSettings, NodeUpdate, OutlierInfo,
     OutlierInfoKey, OutlierInfoValue, PacketAttr, ProtocolPorts, Response, ResponseKind,
@@ -156,6 +156,12 @@ impl Store {
     #[allow(clippy::missing_panics_doc)]
     pub fn account_policy_map(&self) -> Table<AccountPolicy> {
         self.states.account_policy()
+    }
+
+    #[must_use]
+    #[allow(clippy::missing_panics_doc)]
+    pub fn agents_map(&self) -> IndexedTable<Agent> {
+        self.states.agents()
     }
 
     #[must_use]

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -582,7 +582,7 @@ fn migrate_0_25_to_0_26(store: &super::Store) -> Result<()> {
         pub smtp_eml: bool,
         pub ftp: bool,
 
-        pub giganto: bool,
+        pub giganto: bool, 
         pub giganto_ingestion_ip: Option<IpAddr>,
         pub giganto_ingestion_port: Option<PortNumber>,
         pub giganto_publish_ip: Option<IpAddr>,

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -179,9 +179,9 @@ impl StateDb {
     }
 
     #[must_use]
-    pub(crate) fn agents(&self) -> IndexedTable<Agent> {
+    pub(crate) fn agents(&self) -> Table<Agent> {
         let inner = self.inner.as_ref().expect("database must be open");
-        IndexedTable::<Agent>::open(inner).expect("{AGENTS} table must be present")
+        Table::<Agent>::open(inner).expect("{AGENTS} table must be present")
     }
 
     #[must_use]

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -46,7 +46,7 @@ pub use self::data_source::{DataSource, DataType, Update as DataSourceUpdate};
 pub use self::filter::Filter;
 pub use self::model_indicator::ModelIndicator;
 pub use self::network::{Network, Update as NetworkUpdate};
-pub use self::node::{Node, Settings as NodeSettings, Table as NodeTable, Update as NodeUpdate};
+pub use self::node::{Node, Settings as NodeSettings, Table as NodeTable};
 pub use self::outlier_info::{Key as OutlierInfoKey, OutlierInfo, Value as OutlierInfoValue};
 pub use self::sampling_policy::{
     Interval as SamplingInterval, Kind as SamplingKind, Period as SamplingPeriod, SamplingPolicy,

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -46,7 +46,7 @@ pub use self::data_source::{DataSource, DataType, Update as DataSourceUpdate};
 pub use self::filter::Filter;
 pub use self::model_indicator::ModelIndicator;
 pub use self::network::{Network, Update as NetworkUpdate};
-pub use self::node::{Node, NodeTable, Settings as NodeSettings, Update as NodeUpdate};
+pub use self::node::{Node, Settings as NodeSettings, Table as NodeTable, Update as NodeUpdate};
 pub use self::outlier_info::{Key as OutlierInfoKey, OutlierInfo, Value as OutlierInfoValue};
 pub use self::sampling_policy::{
     Interval as SamplingInterval, Kind as SamplingKind, Period as SamplingPeriod, SamplingPolicy,
@@ -492,6 +492,7 @@ where
 }
 
 /// A database table storing records of type `R`.
+#[derive(Clone)]
 pub struct Table<'d, R> {
     map: Map<'d>,
     _phantom: std::marker::PhantomData<R>,

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -1,6 +1,7 @@
 mod access_token;
 mod account_policy;
 mod accounts;
+mod agent;
 mod allow_network;
 mod batch_info;
 mod block_network;
@@ -36,6 +37,7 @@ use serde::{Deserialize, Serialize};
 
 pub use self::access_token::AccessToken;
 pub use self::account_policy::AccountPolicy;
+pub use self::agent::{Agent, Kind as AgentKind};
 pub use self::allow_network::{AllowNetwork, Update as AllowNetworkUpdate};
 pub use self::block_network::{BlockNetwork, Update as BlockNetworkUpdate};
 pub use self::csv_column_extra::CsvColumnExtra;
@@ -78,6 +80,7 @@ use crate::{
 pub(super) const ACCESS_TOKENS: &str = "access_tokens";
 pub(super) const ACCOUNTS: &str = "accounts";
 pub(super) const ACCOUNT_POLICY: &str = "account policy";
+pub(super) const AGENTS: &str = "agents";
 pub(super) const ALLOW_NETWORKS: &str = "allow networks";
 pub(super) const BATCH_INFO: &str = "batch_info";
 pub(super) const BLOCK_NETWORKS: &str = "block networks";
@@ -104,10 +107,11 @@ pub(super) const TRIAGE_RESPONSE: &str = "triage response";
 pub(super) const TRUSTED_DNS_SERVERS: &str = "trusted DNS servers";
 pub(super) const TRUSTED_USER_AGENTS: &str = "trusted user agents";
 
-const MAP_NAMES: [&str; 28] = [
+const MAP_NAMES: [&str; 29] = [
     ACCESS_TOKENS,
     ACCOUNTS,
     ACCOUNT_POLICY,
+    AGENTS,
     ALLOW_NETWORKS,
     BATCH_INFO,
     BLOCK_NETWORKS,
@@ -172,6 +176,12 @@ impl StateDb {
     pub(crate) fn account_policy(&self) -> Table<AccountPolicy> {
         let inner = self.inner.as_ref().expect("database must be open");
         Table::<AccountPolicy>::open(inner).expect("{ACCOUNT_POLICY} table must be present")
+    }
+
+    #[must_use]
+    pub(crate) fn agents(&self) -> IndexedTable<Agent> {
+        let inner = self.inner.as_ref().expect("database must be open");
+        IndexedTable::<Agent>::open(inner).expect("{AGENTS} table must be present")
     }
 
     #[must_use]

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -46,7 +46,7 @@ pub use self::data_source::{DataSource, DataType, Update as DataSourceUpdate};
 pub use self::filter::Filter;
 pub use self::model_indicator::ModelIndicator;
 pub use self::network::{Network, Update as NetworkUpdate};
-pub use self::node::{Node, Settings as NodeSettings, Update as NodeUpdate};
+pub use self::node::{Node, NodeTable, Settings as NodeSettings, Update as NodeUpdate};
 pub use self::outlier_info::{Key as OutlierInfoKey, OutlierInfo, Value as OutlierInfoValue};
 pub use self::sampling_policy::{
     Interval as SamplingInterval, Kind as SamplingKind, Period as SamplingPeriod, SamplingPolicy,
@@ -289,9 +289,9 @@ impl StateDb {
         IndexedTable::<DataSource>::open(inner).expect("{DATA_SOURCES} table must be present")
     }
 
-    pub(crate) fn nodes(&self) -> IndexedTable<Node> {
+    pub(crate) fn nodes(&self) -> NodeTable {
         let inner = self.inner.as_ref().expect("database must be open");
-        IndexedTable::<Node>::open(inner).expect("{NETWORKS} table must be present")
+        NodeTable::open(inner).expect("{NETWORKS} table must be present")
     }
 
     #[must_use]

--- a/src/tables/agent.rs
+++ b/src/tables/agent.rs
@@ -1,0 +1,164 @@
+//! The agent table.
+
+use std::{borrow::Cow, fmt::Display, mem::size_of};
+
+use anyhow::Result;
+use num_derive::{FromPrimitive, ToPrimitive};
+use rocksdb::OptimisticTransactionDB;
+use serde::{Deserialize, Serialize};
+use strum_macros::EnumString;
+
+use crate::{types::FromKeyValue, Indexable, IndexedMap, IndexedTable};
+
+#[derive(
+    Serialize,
+    Deserialize,
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    EnumString,
+    FromPrimitive,
+    ToPrimitive,
+)]
+#[repr(u32)]
+#[strum(serialize_all = "snake_case")]
+pub enum Kind {
+    Reconverge = 1,
+    Piglet = 2,
+    Hog = 3,
+    // Crusher,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Config {
+    inner: String,
+}
+
+impl TryFrom<String> for Config {
+    type Error = anyhow::Error;
+
+    fn try_from(inner: String) -> Result<Self> {
+        toml::from_str(&inner)?;
+        Ok(Self { inner })
+    }
+}
+
+impl AsRef<str> for Config {
+    fn as_ref(&self) -> &str {
+        &self.inner
+    }
+}
+
+impl Display for Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+pub struct Agent {
+    node: u32,
+    key: String,
+    id: u32,
+    kind: Kind,
+    config: Option<Config>,
+    draft: Option<Config>,
+}
+
+impl Agent {
+    /// # Errors
+    ///
+    /// Returns an error if `config` fails to be `validate`-ed.
+    pub fn new(
+        node: u32,
+        key: String,
+        kind: Kind,
+        config: Option<String>,
+        draft: Option<String>,
+    ) -> Result<Self> {
+        let id = u32::MAX;
+        let config = config.map(TryInto::try_into).transpose()?;
+        let draft = draft.map(TryInto::try_into).transpose()?;
+        Ok(Self {
+            node,
+            key,
+            id,
+            kind,
+            config,
+            draft,
+        })
+    }
+}
+
+impl FromKeyValue for Agent {
+    fn from_key_value(key: &[u8], value: &[u8]) -> Result<Self> {
+        let value: Value = super::deserialize(value)?;
+
+        let (node, key) = key.split_at(size_of::<u32>());
+        let mut buf = [0; size_of::<u32>()];
+        buf.copy_from_slice(node);
+        let node = u32::from_be_bytes(buf);
+        let key = std::str::from_utf8(key)?.to_string();
+
+        Ok(Self {
+            node,
+            key,
+            id: value.id,
+            kind: value.kind,
+            config: value.config,
+            draft: value.draft,
+        })
+    }
+}
+
+impl Indexable for Agent {
+    fn key(&self) -> Cow<[u8]> {
+        let mut buf = self.node.to_be_bytes().to_vec();
+        buf.extend(self.key.as_bytes());
+        Cow::Owned(buf)
+    }
+
+    fn index(&self) -> u32 {
+        self.id
+    }
+
+    fn make_indexed_key(key: Cow<[u8]>, _index: u32) -> Cow<[u8]> {
+        key
+    }
+
+    fn value(&self) -> Vec<u8> {
+        let value = Value {
+            id: self.id,
+            kind: self.kind,
+            config: self.config.clone(),
+            draft: self.draft.clone(),
+        };
+        super::serialize(&value).expect("value should be serializable.")
+    }
+
+    fn set_index(&mut self, index: u32) {
+        self.id = index;
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct Value {
+    id: u32,
+    kind: Kind,
+    config: Option<Config>,
+    draft: Option<Config>,
+}
+
+/// Functions for the agents table.
+impl<'d> IndexedTable<'d, Agent> {
+    /// Opens the agents table in the database.
+    ///
+    /// Returns `None` if the table does not exist.
+    pub(super) fn open(db: &'d OptimisticTransactionDB) -> Option<Self> {
+        IndexedMap::new(db, super::AGENTS)
+            .map(IndexedTable::new)
+            .ok()
+    }
+}

--- a/src/tables/agent.rs
+++ b/src/tables/agent.rs
@@ -32,7 +32,7 @@ pub enum Kind {
     // Crusher,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 pub struct Config {
     inner: String,
 }
@@ -58,7 +58,7 @@ impl Display for Config {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct Agent {
     pub node: u32,
     pub key: String,
@@ -168,5 +168,16 @@ impl<'d> Table<'d, Agent> {
         let mut key = node.to_be_bytes().to_vec();
         key.extend(id.as_bytes());
         self.map.delete(&key)
+    }
+
+    /// Updates the `Agent` in the database.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the serialization fails or the database operation fails.
+    pub fn update(&self, old: &Agent, new: &Agent) -> Result<()> {
+        let (ok, ov) = (old.unique_key(), old.value());
+        let (nk, nv) = (new.unique_key(), new.value());
+        self.map.update((&ok, &ov), (&nk, &nv))
     }
 }

--- a/src/tables/agent.rs
+++ b/src/tables/agent.rs
@@ -59,11 +59,11 @@ impl Display for Config {
 }
 
 pub struct Agent {
-    node: u32,
-    key: String,
-    kind: Kind,
-    config: Option<Config>,
-    draft: Option<Config>,
+    pub node: u32,
+    pub key: String,
+    pub kind: Kind,
+    pub config: Option<Config>,
+    pub draft: Option<Config>,
 }
 
 impl Agent {
@@ -131,5 +131,14 @@ impl<'d> Table<'d, Agent> {
     /// Returns `None` if the table does not exist.
     pub(super) fn open(db: &'d OptimisticTransactionDB) -> Option<Self> {
         Map::open(db, super::AGENTS).map(Table::new)
+    }
+
+    pub fn get(&self, node: u32, id: &str) -> Result<Option<Agent>> {
+        let mut key = node.to_be_bytes().to_vec();
+        key.extend(id.as_bytes());
+        let Some(value) = self.map.get(&key)? else {
+            return Ok(None);
+        };
+        Ok(Some(Agent::from_key_value(&key, value.as_ref())?))
     }
 }

--- a/src/tables/node.rs
+++ b/src/tables/node.rs
@@ -16,7 +16,7 @@ use super::{agent::Config, TableIter as TI};
 
 type PortNumber = u16;
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 struct Giganto {
     pub ingestion_ip: Option<IpAddr>,
     pub ingestion_port: Option<PortNumber>,
@@ -431,7 +431,7 @@ impl Settings {
     fn add_agent(&mut self, kind: AgentKind, config: Option<&Config>) -> Result<()> {
         match kind {
             AgentKind::Reconverge => {
-                if let Some(config) = config {
+                if let Some(_) = config {
                     self.reconverge = true;
                     
                 }
@@ -442,8 +442,6 @@ impl Settings {
                     self.piglet = true;
                     self.piglet_giganto_ip = config.giganto_ip;
                     self.piglet_giganto_port = config.giganto_port;
-                    self.piglet_review_ip = config.review_ip;
-                    self.piglet_review_port = config.review_port;
                 }
             }
             AgentKind::Hog => {
@@ -452,8 +450,6 @@ impl Settings {
                     self.hog = true;
                     self.hog_giganto_ip = config.giganto_ip;
                     self.hog_giganto_port = config.giganto_port;
-                    self.hog_review_ip = config.review_ip;
-                    self.hog_review_port = config.review_port;
                 }
             }
         }


### PR DESCRIPTION
The Node structure has been split into InnerNode and Agent components for improved database storage. The Agent components, which include Hog, Piglet, and Reconverge, will now be stored in a separate Agent table.

Key changes:

* The node + key combination will serve as the primary key for Agent.
* Each agent's configuration should be a TOML formatted string.
* The interpretation of an agent's configuration is delegated to the agent and the user. The database will not enforce any restrictions beyond ensuring the configuration is in TOML format in the future.
