### PR TITLE
Modify display message format of EventMessage and Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   and TLS protocols.
 - Fixed to provide crypto libraries directly as `builder_with_provider` when
   generating `rustls::ClientConfig`.
+- Change the display message format of `EventMessage` and `Event` to RFC5424.
+  Modified messages will be sent to syslog.
 
 ### Removed
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -23,7 +23,7 @@ mod tor;
 use std::{
     collections::HashMap,
     convert::TryInto,
-    fmt,
+    fmt::{self},
     net::IpAddr,
     num::NonZeroU8,
     sync::{Arc, Mutex, MutexGuard},
@@ -168,6 +168,257 @@ pub enum Event {
     ExtraThreat(ExtraThreat),
 
     LockyRansomware(LockyRansomware),
+}
+
+impl fmt::Display for Event {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let (event_kind, category) = self.kind_and_category();
+        let event_kind = format!("{event_kind:?}");
+        let category = format!("{category:?}");
+
+        match self {
+            Event::DnsCovertChannel(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::HttpThreat(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::RdpBruteForce(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::RepeatedHttpSessions(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::TorConnection(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::DomainGenerationAlgorithm(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::FtpBruteForce(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::FtpPlainText(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::PortScan(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::MultiHostPortScan(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::ExternalDdos(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::NonBrowser(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::LdapBruteForce(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::LdapPlainText(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::CryptocurrencyMiningPool(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::BlockList(record_type) => match record_type {
+                RecordType::Conn(event) => {
+                    write!(
+                        f,
+                        "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                        event.time.to_rfc3339(),
+                    )
+                }
+                RecordType::DceRpc(event) => {
+                    write!(
+                        f,
+                        "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                        event.time.to_rfc3339(),
+                    )
+                }
+                RecordType::Dns(event) => {
+                    write!(
+                        f,
+                        "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                        event.time.to_rfc3339(),
+                    )
+                }
+                RecordType::Ftp(event) => {
+                    write!(
+                        f,
+                        "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                        event.time.to_rfc3339(),
+                    )
+                }
+                RecordType::Http(event) => {
+                    write!(
+                        f,
+                        "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                        event.time.to_rfc3339(),
+                    )
+                }
+                RecordType::Kerberos(event) => {
+                    write!(
+                        f,
+                        "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                        event.time.to_rfc3339(),
+                    )
+                }
+                RecordType::Ldap(event) => {
+                    write!(
+                        f,
+                        "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                        event.time.to_rfc3339(),
+                    )
+                }
+                RecordType::Mqtt(event) => {
+                    write!(
+                        f,
+                        "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                        event.time.to_rfc3339(),
+                    )
+                }
+                RecordType::Nfs(event) => {
+                    write!(
+                        f,
+                        "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                        event.time.to_rfc3339(),
+                    )
+                }
+                RecordType::Ntlm(event) => {
+                    write!(
+                        f,
+                        "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                        event.time.to_rfc3339(),
+                    )
+                }
+                RecordType::Rdp(event) => {
+                    write!(
+                        f,
+                        "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                        event.time.to_rfc3339(),
+                    )
+                }
+                RecordType::Smb(event) => {
+                    write!(
+                        f,
+                        "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                        event.time.to_rfc3339(),
+                    )
+                }
+                RecordType::Smtp(event) => {
+                    write!(
+                        f,
+                        "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                        event.time.to_rfc3339(),
+                    )
+                }
+                RecordType::Ssh(event) => {
+                    write!(
+                        f,
+                        "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                        event.time.to_rfc3339(),
+                    )
+                }
+                RecordType::Tls(event) => {
+                    write!(
+                        f,
+                        "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                        event.time.to_rfc3339(),
+                    )
+                }
+            },
+            Event::WindowsThreat(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::NetworkThreat(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::ExtraThreat(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+            Event::LockyRansomware(event) => {
+                write!(
+                    f,
+                    "time={:?} event_kind={event_kind:?} category={category:?} {event}",
+                    event.time.to_rfc3339(),
+                )
+            }
+        }
+    }
 }
 
 pub enum RecordType {
@@ -597,6 +848,51 @@ impl Event {
             }
         }
         Ok(kind)
+    }
+
+    fn kind_and_category(&self) -> (EventKind, EventCategory) {
+        match self {
+            Event::DnsCovertChannel(e) => (EventKind::DnsCovertChannel, e.category()),
+            Event::HttpThreat(e) => (EventKind::HttpThreat, e.category()),
+            Event::RdpBruteForce(e) => (EventKind::RdpBruteForce, e.category()),
+            Event::RepeatedHttpSessions(e) => (EventKind::RepeatedHttpSessions, e.category()),
+            Event::TorConnection(e) => (EventKind::TorConnection, e.category()),
+            Event::DomainGenerationAlgorithm(e) => {
+                (EventKind::DomainGenerationAlgorithm, e.category())
+            }
+            Event::FtpBruteForce(e) => (EventKind::FtpBruteForce, e.category()),
+            Event::FtpPlainText(e) => (EventKind::FtpPlainText, e.category()),
+            Event::PortScan(e) => (EventKind::PortScan, e.category()),
+            Event::MultiHostPortScan(e) => (EventKind::MultiHostPortScan, e.category()),
+            Event::ExternalDdos(e) => (EventKind::ExternalDdos, e.category()),
+            Event::NonBrowser(e) => (EventKind::NonBrowser, e.category()),
+            Event::LdapBruteForce(e) => (EventKind::LdapBruteForce, e.category()),
+            Event::LdapPlainText(e) => (EventKind::LdapPlainText, e.category()),
+            Event::CryptocurrencyMiningPool(e) => {
+                (EventKind::CryptocurrencyMiningPool, e.category())
+            }
+            Event::BlockList(record_type) => match record_type {
+                RecordType::Conn(e) => (EventKind::BlockListConn, e.category()),
+                RecordType::Dns(e) => (EventKind::BlockListDns, e.category()),
+                RecordType::DceRpc(e) => (EventKind::BlockListDceRpc, e.category()),
+                RecordType::Ftp(e) => (EventKind::BlockListFtp, e.category()),
+                RecordType::Http(e) => (EventKind::BlockListHttp, e.category()),
+                RecordType::Kerberos(e) => (EventKind::BlockListKerberos, e.category()),
+                RecordType::Ldap(e) => (EventKind::BlockListLdap, e.category()),
+                RecordType::Mqtt(e) => (EventKind::BlockListMqtt, e.category()),
+                RecordType::Nfs(e) => (EventKind::BlockListNfs, e.category()),
+                RecordType::Ntlm(e) => (EventKind::BlockListNtlm, e.category()),
+                RecordType::Rdp(e) => (EventKind::BlockListRdp, e.category()),
+                RecordType::Smb(e) => (EventKind::BlockListSmb, e.category()),
+                RecordType::Smtp(e) => (EventKind::BlockListSmtp, e.category()),
+                RecordType::Ssh(e) => (EventKind::BlockListSsh, e.category()),
+                RecordType::Tls(e) => (EventKind::BlockListTls, e.category()),
+            },
+            Event::WindowsThreat(e) => (EventKind::WindowsThreat, e.category()),
+            Event::NetworkThreat(e) => (EventKind::NetworkThreat, e.category()),
+            Event::ExtraThreat(e) => (EventKind::ExtraThreat, e.category()),
+            Event::LockyRansomware(e) => (EventKind::LockyRansomware, e.category()),
+        }
     }
 
     // TODO: Need to implement country counting for `WindowsThreat`.
@@ -1313,6 +1609,13 @@ impl Event {
             }
         }
     }
+
+    /// Generate syslog msgid and message body for RFC5424.
+    #[must_use]
+    pub fn syslog_message(&self) -> (String, String, String) {
+        let (kind, _category) = self.kind_and_category();
+        ("DETECT".to_string(), format!("{kind:?}"), format!("{self}"))
+    }
 }
 
 fn find_network(ip: IpAddr, networks: &[Network]) -> Option<u32> {
@@ -1361,6 +1664,52 @@ pub enum EventKind {
     WindowsThreat,
     NetworkThreat,
     LockyRansomware,
+}
+
+impl From<&EventKind> for EventCategory {
+    fn from(kind: &EventKind) -> Self {
+        match *kind {
+            EventKind::DnsCovertChannel
+            | EventKind::TorConnection
+            | EventKind::DomainGenerationAlgorithm
+            | EventKind::NonBrowser
+            | EventKind::CryptocurrencyMiningPool => EventCategory::CommandAndControl,
+
+            EventKind::HttpThreat => EventCategory::HttpThreat,
+
+            EventKind::RdpBruteForce | EventKind::RepeatedHttpSessions => {
+                EventCategory::Exfiltration
+            }
+
+            EventKind::FtpBruteForce | EventKind::LdapBruteForce => EventCategory::CredentialAccess,
+            EventKind::FtpPlainText | EventKind::LdapPlainText => EventCategory::LateralMovement,
+
+            EventKind::BlockListConn
+            | EventKind::BlockListDns
+            | EventKind::BlockListDceRpc
+            | EventKind::BlockListFtp
+            | EventKind::BlockListHttp
+            | EventKind::BlockListKerberos
+            | EventKind::BlockListLdap
+            | EventKind::BlockListMqtt
+            | EventKind::BlockListNfs
+            | EventKind::BlockListNtlm
+            | EventKind::BlockListRdp
+            | EventKind::BlockListSmb
+            | EventKind::BlockListSmtp
+            | EventKind::BlockListSsh
+            | EventKind::BlockListTls => EventCategory::InitialAccess,
+
+            EventKind::PortScan
+            | EventKind::MultiHostPortScan
+            | EventKind::NetworkThreat
+            | EventKind::ExtraThreat => EventCategory::Reconnaissance,
+
+            EventKind::ExternalDdos | EventKind::WindowsThreat | EventKind::LockyRansomware => {
+                EventCategory::Impact
+            }
+        }
+    }
 }
 
 /// Machine Learning Method.
@@ -1503,252 +1852,108 @@ pub struct EventMessage {
     pub fields: Vec<u8>,
 }
 
+impl EventMessage {
+    #[must_use]
+    pub fn syslog_message(&self) -> (String, String, String) {
+        (
+            "DETECT".to_string(),
+            format!("{:?}", self.kind),
+            format!("{self}"),
+        )
+    }
+}
+
 impl fmt::Display for EventMessage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{},", self.time.to_rfc3339())?;
-        match self.kind {
-            EventKind::DnsCovertChannel => {
-                if let Ok(fields) = bincode::deserialize::<DnsEventFields>(&self.fields) {
-                    write!(f, "DnsCovertChannel,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::HttpThreat => {
-                if let Ok(fields) = bincode::deserialize::<HttpThreatFields>(&self.fields) {
-                    write!(f, "HttpThreat,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::RdpBruteForce => {
-                if let Ok(fields) = bincode::deserialize::<RdpBruteForceFields>(&self.fields) {
-                    write!(f, "RdpBruteForce,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
+        write!(
+            f,
+            "time={:?} event_kind={:?} category={:?} ",
+            self.time.to_rfc3339(),
+            format!("{:?}", self.kind),
+            EventCategory::from(&self.kind).to_string()
+        )?;
+        let _r = match self.kind {
+            EventKind::DnsCovertChannel => bincode::deserialize::<DnsEventFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::HttpThreat => bincode::deserialize::<HttpThreatFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::RdpBruteForce => bincode::deserialize::<RdpBruteForceFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
             EventKind::RepeatedHttpSessions => {
-                if let Ok(fields) = bincode::deserialize::<RepeatedHttpSessionsFields>(&self.fields)
-                {
-                    write!(f, "RepeatedHttpSessions,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
+                bincode::deserialize::<RepeatedHttpSessionsFields>(&self.fields)
+                    .map(|fields| write!(f, "{fields}"))
             }
-            EventKind::TorConnection => {
-                if let Ok(fields) = bincode::deserialize::<TorConnectionFields>(&self.fields) {
-                    write!(f, "TorConnection,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
+            EventKind::TorConnection => bincode::deserialize::<TorConnectionFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
             EventKind::DomainGenerationAlgorithm => {
-                if let Ok(fields) = bincode::deserialize::<DgaFields>(&self.fields) {
-                    write!(f, "DomainGenerationAlgorithm,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
+                bincode::deserialize::<DgaFields>(&self.fields).map(|fields| write!(f, "{fields}"))
             }
-            EventKind::FtpBruteForce => {
-                if let Ok(fields) = bincode::deserialize::<FtpBruteForceFields>(&self.fields) {
-                    write!(f, "FtpBruteForce,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::FtpPlainText => {
-                if let Ok(fields) = bincode::deserialize::<FtpPlainTextFields>(&self.fields) {
-                    write!(f, "FtpPlainText,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::PortScan => {
-                if let Ok(fields) = bincode::deserialize::<PortScanFields>(&self.fields) {
-                    write!(f, "PortScan,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
+            EventKind::FtpBruteForce => bincode::deserialize::<FtpBruteForceFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::FtpPlainText => bincode::deserialize::<FtpPlainTextFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::PortScan => bincode::deserialize::<PortScanFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
             EventKind::MultiHostPortScan => {
-                if let Ok(fields) = bincode::deserialize::<MultiHostPortScanFields>(&self.fields) {
-                    write!(f, "MultiHostPortScan,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
+                bincode::deserialize::<MultiHostPortScanFields>(&self.fields)
+                    .map(|fields| write!(f, "{fields}"))
             }
-            EventKind::NonBrowser => {
-                if let Ok(fields) = bincode::deserialize::<NonBrowserFields>(&self.fields) {
-                    write!(f, "NonBrowser,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::LdapBruteForce => {
-                if let Ok(fields) = bincode::deserialize::<LdapBruteForceFields>(&self.fields) {
-                    write!(f, "LdapBruteForce,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::LdapPlainText => {
-                if let Ok(fields) = bincode::deserialize::<LdapPlainTextFields>(&self.fields) {
-                    write!(f, "LdapPlainText,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::ExternalDdos => {
-                if let Ok(fields) = bincode::deserialize::<ExternalDdosFields>(&self.fields) {
-                    write!(f, "ExternalDdos,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
+            EventKind::NonBrowser => bincode::deserialize::<NonBrowserFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::LdapBruteForce => bincode::deserialize::<LdapBruteForceFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::LdapPlainText => bincode::deserialize::<LdapPlainTextFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::ExternalDdos => bincode::deserialize::<ExternalDdosFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
             EventKind::CryptocurrencyMiningPool => {
-                if let Ok(fields) =
-                    bincode::deserialize::<CryptocurrencyMiningPoolFields>(&self.fields)
-                {
-                    write!(f, "CryptocurrencyMiningPool,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
+                bincode::deserialize::<CryptocurrencyMiningPoolFields>(&self.fields)
+                    .map(|fields| write!(f, "{fields}"))
             }
-            EventKind::BlockListConn => {
-                if let Ok(fields) = bincode::deserialize::<BlockListConnFields>(&self.fields) {
-                    write!(f, "BlockListConn,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::BlockListDns => {
-                if let Ok(fields) = bincode::deserialize::<BlockListDnsFields>(&self.fields) {
-                    write!(f, "BlockListDns,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
+            EventKind::BlockListConn => bincode::deserialize::<BlockListConnFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::BlockListDns => bincode::deserialize::<BlockListDnsFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
             EventKind::BlockListDceRpc => {
-                if let Ok(fields) = bincode::deserialize::<BlockListDceRpcFields>(&self.fields) {
-                    write!(f, "BlockListDceRpc,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
+                bincode::deserialize::<BlockListDceRpcFields>(&self.fields)
+                    .map(|fields| write!(f, "{fields}"))
             }
-            EventKind::BlockListFtp => {
-                if let Ok(fields) = bincode::deserialize::<BlockListFtpFields>(&self.fields) {
-                    write!(f, "BlockListFtp,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::BlockListHttp => {
-                if let Ok(fields) = bincode::deserialize::<BlockListHttpFields>(&self.fields) {
-                    write!(f, "BlockListHttp,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
+            EventKind::BlockListFtp => bincode::deserialize::<BlockListFtpFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::BlockListHttp => bincode::deserialize::<BlockListHttpFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
             EventKind::BlockListKerberos => {
-                if let Ok(fields) = bincode::deserialize::<BlockListKerberosFields>(&self.fields) {
-                    write!(f, "BlockListKerberos,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
+                bincode::deserialize::<BlockListKerberosFields>(&self.fields)
+                    .map(|fields| write!(f, "{fields}"))
             }
-            EventKind::BlockListLdap => {
-                if let Ok(fields) = bincode::deserialize::<BlockListLdapFields>(&self.fields) {
-                    write!(f, "BlockListLdap,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::BlockListMqtt => {
-                if let Ok(fields) = bincode::deserialize::<BlockListMqttFields>(&self.fields) {
-                    write!(f, "BlcokListMqtt,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::BlockListNfs => {
-                if let Ok(fields) = bincode::deserialize::<BlockListNfsFields>(&self.fields) {
-                    write!(f, "BlockListNfs,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::BlockListNtlm => {
-                if let Ok(fields) = bincode::deserialize::<BlockListNtlmFields>(&self.fields) {
-                    write!(f, "BlockListNtlm,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::BlockListRdp => {
-                if let Ok(fields) = bincode::deserialize::<BlockListRdpFields>(&self.fields) {
-                    write!(f, "BlockListRdp,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::BlockListSmb => {
-                if let Ok(fields) = bincode::deserialize::<BlockListSmbFields>(&self.fields) {
-                    write!(f, "BlockListSmb,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::BlockListSmtp => {
-                if let Ok(fields) = bincode::deserialize::<BlockListSmtpFields>(&self.fields) {
-                    write!(f, "BlockListSmtp,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::BlockListSsh => {
-                if let Ok(fields) = bincode::deserialize::<BlockListSshFields>(&self.fields) {
-                    write!(f, "BlockListSsh,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::BlockListTls => {
-                if let Ok(fields) = bincode::deserialize::<BlockListTlsFields>(&self.fields) {
-                    write!(f, "BlockListTls,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::WindowsThreat => {
-                if let Ok(fields) = bincode::deserialize::<WindowsThreat>(&self.fields) {
-                    write!(f, "WindowsThreat,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::NetworkThreat => {
-                if let Ok(fields) = bincode::deserialize::<NetworkThreat>(&self.fields) {
-                    write!(f, "NetworkThreat,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::ExtraThreat => {
-                if let Ok(fields) = bincode::deserialize::<ExtraThreat>(&self.fields) {
-                    write!(f, "ExtraThreat,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-            EventKind::LockyRansomware => {
-                if let Ok(fields) = bincode::deserialize::<DnsEventFields>(&self.fields) {
-                    write!(f, "LockyRansomware,{fields}")
-                } else {
-                    write!(f, "invalid event")
-                }
-            }
-        }
+            EventKind::BlockListLdap => bincode::deserialize::<BlockListLdapFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::BlockListMqtt => bincode::deserialize::<BlockListMqttFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::BlockListNfs => bincode::deserialize::<BlockListNfsFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::BlockListNtlm => bincode::deserialize::<BlockListNtlmFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::BlockListRdp => bincode::deserialize::<BlockListRdpFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::BlockListSmb => bincode::deserialize::<BlockListSmbFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::BlockListSmtp => bincode::deserialize::<BlockListSmtpFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::BlockListSsh => bincode::deserialize::<BlockListSshFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::BlockListTls => bincode::deserialize::<BlockListTlsFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::WindowsThreat => bincode::deserialize::<WindowsThreat>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::NetworkThreat => bincode::deserialize::<NetworkThreat>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::ExtraThreat => bincode::deserialize::<ExtraThreat>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+            EventKind::LockyRansomware => bincode::deserialize::<DnsEventFields>(&self.fields)
+                .map(|fields| write!(f, "{fields}")),
+        };
+        Ok(())
     }
 }
 
@@ -2281,8 +2486,20 @@ mod tests {
     use chrono::{TimeZone, Utc};
 
     use crate::{
-        event::{DgaFields, DnsEventFields, LOCKY_RANSOMWARE},
-        DomainGenerationAlgorithm, EventCategory, EventFilter, EventKind, EventMessage, Store,
+        event::{
+            http::RepeatedHttpSessionsFields, CryptocurrencyMiningPoolFields, DgaFields,
+            DnsEventFields, ExternalDdosFields, FtpBruteForceFields, FtpPlainTextFields,
+            HttpThreatFields, LdapBruteForceFields, LdapPlainTextFields, MultiHostPortScanFields,
+            NonBrowserFields, PortScanFields, RdpBruteForceFields, TorConnectionFields,
+            LOCKY_RANSOMWARE,
+        },
+        BlockListConnFields, BlockListDceRpcFields, BlockListDnsFields, BlockListFtpFields,
+        BlockListHttp, BlockListHttpFields, BlockListKerberosFields, BlockListLdapFields,
+        BlockListMqttFields, BlockListNfsFields, BlockListNtlmFields, BlockListRdpFields,
+        BlockListSmbFields, BlockListSmtpFields, BlockListSshFields, BlockListTlsFields,
+        DomainGenerationAlgorithm, Event, EventCategory, EventFilter, EventKind, EventMessage,
+        ExternalDdos, ExtraThreat, HttpThreat, NetworkThreat, RecordType, Store, TriageScore,
+        WindowsThreat,
     };
 
     fn example_message(kind: EventKind) -> EventMessage {
@@ -2392,7 +2609,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn event_display_for_syslog() {
+    async fn syslog_for_dga() {
         let fields = DgaFields {
             source: "collector1".to_string(),
             src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
@@ -2400,7 +2617,7 @@ mod tests {
             dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
             dst_port: 80,
             proto: 6,
-            duration: Utc::now().timestamp_nanos_opt().unwrap(),
+            duration: 1000,
             method: "GET".to_string(),
             host: "example.com".to_string(),
             uri: "/uri/path".to_string(),
@@ -2417,11 +2634,11 @@ mod tests {
             content_encoding: "encoding type".to_string(),
             content_type: "content type".to_string(),
             cache_control: "no cache".to_string(),
-            orig_filenames: Vec::new(),
+            orig_filenames: vec!["a1".to_string(), "a2".to_string()],
             orig_mime_types: Vec::new(),
             resp_filenames: Vec::new(),
-            resp_mime_types: Vec::new(),
-            post_body: Vec::new(),
+            resp_mime_types: vec!["b1".to_string(), "b2".to_string()],
+            post_body: "12345678901234567890".to_string().into_bytes(),
             state: String::new(),
             confidence: 0.8,
         };
@@ -2431,16 +2648,21 @@ mod tests {
             fields: bincode::serialize(&fields).expect("serializable"),
         };
         let syslog_message = format!("{msg}");
-        assert_eq!(syslog_message, "1970-01-01T00:01:01+00:00,DomainGenerationAlgorithm,127.0.0.1,10000,127.0.0.2,80,6,DGA,3,GET,example.com,/uri/path,-,200,browser".to_string());
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T00:01:01+00:00" event_kind="DomainGenerationAlgorithm" category="CommandAndControl" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="80" proto="6" duration="1000" method="GET" host="example.com" uri="/uri/path" referer="-" version="1.1" user_agent="browser" request_len="100" response_len="100" status_code="200" status_msg="-" username="-" password="-" cookie="cookie" content_encoding="encoding type" content_type="content type" cache_control="no cache" orig_filenames="a1,a2" orig_mime_types="" resp_filenames="" resp_mime_types="b1,b2" post_body="1234567890..." state="" confidence="0.8""#
+        );
 
         let dga = DomainGenerationAlgorithm::new(
             Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
             fields,
         );
-        let dga_display = format!("{dga}");
-        assert!(dga_display.ends_with(
-            ",127.0.0.1,10000,127.0.0.2,80,6,DGA,GET,example.com,/uri/path,-,200,browser"
-        ));
+        let event = Event::DomainGenerationAlgorithm(dga);
+        let dga_display = format!("{event}");
+        assert_eq!(
+            &dga_display,
+            r#"time="1970-01-01T00:01:01+00:00" event_kind="DomainGenerationAlgorithm" category="CommandAndControl" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="80" proto="6" duration="1000" method="GET" host="example.com" uri="/uri/path" referer="-" version="1.1" user_agent="browser" request_len="100" response_len="100" status_code="200" status_msg="-" username="-" password="-" cookie="cookie" content_encoding="encoding type" content_type="content type" cache_control="no cache" orig_filenames="a1,a2" orig_mime_types="" resp_filenames="" resp_mime_types="b1,b2" post_body="1234567890..." state="" confidence="0.8" triage_scores="""#
+        );
     }
 
     #[tokio::test]
@@ -2518,5 +2740,1447 @@ mod tests {
         let info = backup.get_backup_info();
         assert_eq!(info.len(), 1);
         assert_eq!(info[0].backup_id, 1);
+    }
+
+    #[tokio::test]
+    async fn syslog_for_httpthreat() {
+        let fields = HttpThreatFields {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 80,
+            proto: 6,
+            duration: 1000,
+            method: "GET".to_string(),
+            host: "example.com".to_string(),
+            uri: "/uri/path".to_string(),
+            referer: "-".to_string(),
+            version: "1.1".to_string(),
+            user_agent: "browser".to_string(),
+            request_len: 100,
+            response_len: 100,
+            status_code: 200,
+            status_msg: "-".to_string(),
+            username: "-".to_string(),
+            password: "-".to_string(),
+            cookie: "cookie".to_string(),
+            content_encoding: "encoding type".to_string(),
+            content_type: "content type".to_string(),
+            cache_control: "no cache".to_string(),
+            orig_filenames: vec!["a1".to_string(), "a2".to_string()],
+            orig_mime_types: Vec::new(),
+            resp_filenames: Vec::new(),
+            resp_mime_types: vec!["b1".to_string(), "b2".to_string()],
+            post_body: "12345678901234567890".to_string().into_bytes(),
+            state: String::new(),
+            db_name: "db".to_string(),
+            rule_id: 12000,
+            cluster_id: 1111,
+            matched_to: "match".to_string(),
+            attack_kind: "attack".to_string(),
+            confidence: 0.8,
+        };
+        let msg = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            kind: EventKind::HttpThreat,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+        let syslog_message = format!("{msg}");
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T00:01:01+00:00" event_kind="HttpThreat" category="HttpThreat" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="80" proto="6" duration="1000" method="GET" host="example.com" uri="/uri/path" referer="-" version="1.1" user_agent="browser" request_len="100" response_len="100" status_code="200" status_msg="-" username="-" password="-" cookie="cookie" content_encoding="encoding type" content_type="content type" cache_control="no cache" orig_filenames="a1,a2" orig_mime_types="" resp_filenames="" resp_mime_types="b1,b2" post_body="1234567890..." state="" db_name="db" rule_id="12000" matched_to="match" cluster_id="1111" attack_kind="attack" confidence="0.8""#
+        );
+
+        let http_threat =
+            HttpThreat::new(Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(), fields);
+        let event = Event::HttpThreat(http_threat);
+        let http_threat_display = format!("{event}");
+        assert!(http_threat_display.contains("post_body=\"1234567890...\""));
+        assert!(http_threat_display.contains("confidence=\"0.8\""));
+    }
+
+    #[tokio::test]
+    async fn syslog_for_nonbrowser() {
+        let fields = NonBrowserFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 80,
+            proto: 6,
+            session_end_time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 10, 10).unwrap(),
+            method: "GET".to_string(),
+            host: "example.com".to_string(),
+            uri: "/uri/path".to_string(),
+            referrer: "-".to_string(),
+            version: "1.1".to_string(),
+            user_agent: "browser".to_string(),
+            request_len: 100,
+            response_len: 100,
+            status_code: 200,
+            status_msg: "-".to_string(),
+            username: "-".to_string(),
+            password: "-".to_string(),
+            cookie: "cookie".to_string(),
+            content_encoding: "encoding type".to_string(),
+            content_type: "content type".to_string(),
+            cache_control: "no cache".to_string(),
+            orig_filenames: vec!["a1".to_string(), "a2".to_string()],
+            orig_mime_types: Vec::new(),
+            resp_filenames: Vec::new(),
+            resp_mime_types: vec!["b1".to_string(), "b2".to_string()],
+            post_body: "12345678901234567890".to_string().into_bytes(),
+            state: String::new(),
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            kind: EventKind::NonBrowser,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T00:01:01+00:00" event_kind="NonBrowser" category="CommandAndControl" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="80" proto="6" session_end_time="1970-01-01T00:10:10+00:00" method="GET" host="example.com" uri="/uri/path" referrer="-" version="1.1" user_agent="browser" request_len="100" response_len="100" status_code="200" status_msg="-" username="-" password="-" cookie="cookie" content_encoding="encoding type" content_type="content type" cache_control="no cache" orig_filenames="a1,a2" orig_mime_types="" resp_filenames="" resp_mime_types="b1,b2" post_body="1234567890..." state="""#
+        );
+
+        let non_browser = Event::NonBrowser(crate::NonBrowser::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            &fields,
+        ))
+        .to_string();
+        assert!(non_browser.contains("post_body=\"1234567890...\""));
+        assert!(non_browser.contains("state=\"\""));
+    }
+
+    #[tokio::test]
+    async fn syslog_for_blocklist_http() {
+        let fields = BlockListHttpFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 80,
+            proto: 6,
+            last_time: 600,
+            method: "GET".to_string(),
+            host: "example.com".to_string(),
+            uri: "/uri/path".to_string(),
+            referrer: "-".to_string(),
+            version: "1.1".to_string(),
+            user_agent: "browser".to_string(),
+            request_len: 100,
+            response_len: 100,
+            status_code: 200,
+            status_msg: "-".to_string(),
+            username: "-".to_string(),
+            password: "-".to_string(),
+            cookie: "cookie".to_string(),
+            content_encoding: "encoding type".to_string(),
+            content_type: "content type".to_string(),
+            cache_control: "no cache".to_string(),
+            orig_filenames: vec!["a1".to_string(), "a2".to_string()],
+            orig_mime_types: Vec::new(),
+            resp_filenames: Vec::new(),
+            resp_mime_types: vec!["b1".to_string(), "b2".to_string()],
+            post_body: "12345678901234567890".to_string().into_bytes(),
+            state: String::new(),
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            kind: EventKind::BlockListHttp,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T00:01:01+00:00" event_kind="BlockListHttp" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="80" proto="6" last_time="600" method="GET" host="example.com" uri="/uri/path" referrer="-" version="1.1" user_agent="browser" request_len="100" response_len="100" status_code="200" status_msg="-" username="-" password="-" cookie="cookie" content_encoding="encoding type" content_type="content type" cache_control="no cache" orig_filenames="a1,a2" orig_mime_types="" resp_filenames="" resp_mime_types="b1,b2" post_body="1234567890..." state="""#
+        );
+
+        let blocklist_http = Event::BlockList(RecordType::Http(BlockListHttp::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            fields,
+        )))
+        .to_string();
+
+        assert!(blocklist_http.contains("post_body=\"1234567890...\""));
+        assert!(blocklist_http.contains("resp_mime_types=\"b1,b2\""));
+    }
+
+    #[tokio::test]
+    async fn syslog_for_lockyransomware() {
+        let fields = DnsEventFields {
+            source: "collector1".to_string(),
+            session_end_time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 4)),
+            dst_port: 53,
+            proto: 17,
+            query: "locky.com".to_string(),
+            answer: vec!["1.1.1.100".to_string()],
+            trans_id: 1100,
+            rtt: 1,
+            qclass: 0,
+            qtype: 0,
+            rcode: 0,
+            aa_flag: false,
+            tc_flag: true,
+            rd_flag: false,
+            ra_flag: false,
+            ttl: vec![120; 5],
+            confidence: 0.8,
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            kind: EventKind::LockyRansomware,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T00:01:01+00:00" event_kind="LockyRansomware" category="Impact" source="collector1" session_end_time="1970-01-01T01:01:01+00:00" src_addr="127.0.0.3" src_port="10000" dst_addr="127.0.0.4" dst_port="53" proto="17" query="locky.com" answer="1.1.1.100" trans_id="1100" rtt="1" qclass="0" qtype="0" rcode="0" aa_flag="false" tc_flag="true" rd_flag="false" ra_flag="false" ttl="120,120,120,120,120" confidence="0.8""#
+        );
+
+        let locky_ransomware = Event::LockyRansomware(crate::LockyRansomware::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            fields,
+        ))
+        .to_string();
+        assert!(locky_ransomware.contains("source=\"collector1\""));
+        assert!(locky_ransomware.contains("query=\"locky.com\""));
+        assert!(locky_ransomware.contains("ttl=\"120,120,120,120,120\""));
+        assert!(locky_ransomware.contains("confidence=\"0.8\""));
+        assert!(locky_ransomware.contains("triage_scores=\"\""));
+    }
+
+    #[tokio::test]
+    async fn syslog_for_portscan() {
+        let fields = PortScanFields {
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_ports: vec![80, 443, 8000, 8080, 8888, 8443, 9000, 9001, 9002],
+            start_time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            last_time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 2).unwrap(),
+            proto: 6,
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            kind: EventKind::PortScan,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T00:01:01+00:00" event_kind="PortScan" category="Reconnaissance" src_addr="127.0.0.1" dst_addr="127.0.0.2" dst_ports="80,443,8000,8080,8888,8443,9000,9001,9002" start_time="1970-01-01T00:01:01+00:00" last_time="1970-01-01T00:01:02+00:00" proto="6""#
+        );
+
+        let port_scan = Event::PortScan(crate::PortScan::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            &fields,
+        ))
+        .to_string();
+        assert_eq!(
+            &port_scan,
+            r#"time="1970-01-01T00:01:01+00:00" event_kind="PortScan" category="Reconnaissance" src_addr="127.0.0.1" dst_addr="127.0.0.2" dst_ports="80,443,8000,8080,8888,8443,9000,9001,9002" start_time="1970-01-01T00:01:01+00:00" last_time="1970-01-01T00:01:02+00:00" proto="6" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_multihostportscan() {
+        let fields = MultiHostPortScanFields {
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            dst_addrs: vec![
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3)),
+            ],
+            dst_port: 80,
+            start_time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            last_time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 2).unwrap(),
+            proto: 6,
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            kind: EventKind::MultiHostPortScan,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T00:01:01+00:00" event_kind="MultiHostPortScan" category="Reconnaissance" src_addr="127.0.0.1" dst_addrs="127.0.0.2,127.0.0.3" dst_port="80" proto="6" start_time="1970-01-01T00:01:01+00:00" last_time="1970-01-01T00:01:02+00:00""#
+        );
+
+        let multi_host_port_scan = Event::MultiHostPortScan(crate::MultiHostPortScan::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            &fields,
+        ))
+        .to_string();
+        assert_eq!(
+            &multi_host_port_scan,
+            r#"time="1970-01-01T00:01:01+00:00" event_kind="MultiHostPortScan" category="Reconnaissance" src_addr="127.0.0.1" dst_addrs="127.0.0.2,127.0.0.3" dst_port="80" proto="6" start_time="1970-01-01T00:01:01+00:00" last_time="1970-01-01T00:01:02+00:00" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_externalddos() {
+        let fields = ExternalDdosFields {
+            src_addrs: vec![
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3)),
+            ],
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            start_time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            last_time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 2).unwrap(),
+            proto: 6,
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::ExternalDdos,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="ExternalDdos" category="Impact" src_addrs="127.0.0.2,127.0.0.3" dst_addr="127.0.0.1" proto="6" start_time="1970-01-01T00:01:01+00:00" last_time="1970-01-01T00:01:02+00:00""#
+        );
+
+        let external_ddos = Event::ExternalDdos(ExternalDdos::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            &fields,
+        ))
+        .to_string();
+        assert_eq!(
+            &external_ddos,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="ExternalDdos" category="Impact" src_addrs="127.0.0.2,127.0.0.3" dst_addr="127.0.0.1" proto="6" start_time="1970-01-01T00:01:01+00:00" last_time="1970-01-01T00:01:02+00:00" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_blocklist_conn() {
+        let fields = BlockListConnFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 80,
+            proto: 6,
+            conn_state: "SAF".to_string(),
+            duration: 1000,
+            service: "http".to_string(),
+            orig_bytes: 100,
+            orig_pkts: 1,
+            resp_bytes: 100,
+            resp_pkts: 1,
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::BlockListConn,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListConn" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="80" proto="6" conn_state="SAF" duration="1000" service="http" orig_bytes="100" resp_bytes="100" orig_pkts="1" resp_pkts="1""#
+        );
+
+        let block_list_conn = Event::BlockList(RecordType::Conn(crate::BlockListConn::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            fields,
+        )))
+        .to_string();
+        assert_eq!(
+            &block_list_conn,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListConn" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="80" proto="6" conn_state="SAF" duration="1000" service="http" orig_bytes="100" resp_bytes="100" orig_pkts="1" resp_pkts="1" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_blocklist_dcerpc() {
+        let fields = BlockListDceRpcFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 135,
+            proto: 6,
+            last_time: 100,
+            rtt: 1,
+            named_pipe: "svcctl".to_string(),
+            endpoint: "epmapper".to_string(),
+            operation: "bind".to_string(),
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::BlockListDceRpc,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListDceRpc" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="135" proto="6" last_time="100" rtt="1" named_pipe="svcctl" endpoint="epmapper" operation="bind""#
+        );
+
+        let block_list_dce_rpc = Event::BlockList(RecordType::DceRpc(crate::BlockListDceRpc::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            fields,
+        )))
+        .to_string();
+        assert_eq!(
+            &block_list_dce_rpc,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListDceRpc" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="135" proto="6" last_time="100" rtt="1" named_pipe="svcctl" endpoint="epmapper" operation="bind" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_dnscovertchannel() {
+        let fields = DnsEventFields {
+            source: "collector1".to_string(),
+            session_end_time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 53,
+            proto: 17,
+            query: "foo.com".to_string(),
+            answer: vec!["10.10.10.10".to_string(), "20.20.20.20".to_string()],
+            trans_id: 123,
+            rtt: 1,
+            qclass: 0,
+            qtype: 0,
+            rcode: 0,
+            aa_flag: false,
+            tc_flag: false,
+            rd_flag: false,
+            ra_flag: true,
+            ttl: vec![120; 5],
+            confidence: 0.9,
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::DnsCovertChannel,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="DnsCovertChannel" category="CommandAndControl" source="collector1" session_end_time="1970-01-01T01:01:01+00:00" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="53" proto="17" query="foo.com" answer="10.10.10.10,20.20.20.20" trans_id="123" rtt="1" qclass="0" qtype="0" rcode="0" aa_flag="false" tc_flag="false" rd_flag="false" ra_flag="true" ttl="120,120,120,120,120" confidence="0.9""#
+        );
+
+        let triage_scores = vec![TriageScore {
+            policy_id: 109,
+            score: 0.9,
+        }];
+        let mut dns_covert_channel = Event::DnsCovertChannel(crate::DnsCovertChannel::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            fields,
+        ));
+        dns_covert_channel.set_triage_scores(triage_scores);
+        let dns_covert_channel = dns_covert_channel.to_string();
+
+        assert_eq!(
+            &dns_covert_channel,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="DnsCovertChannel" category="CommandAndControl" source="collector1" session_end_time="1970-01-01T01:01:01+00:00" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="53" proto="17" query="foo.com" answer="10.10.10.10,20.20.20.20" trans_id="123" rtt="1" qclass="0" qtype="0" rcode="0" aa_flag="false" tc_flag="false" rd_flag="false" ra_flag="true" ttl="120,120,120,120,120" confidence="0.9" triage_scores="109:0.90""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_cryptocurrencyminingpool() {
+        let fields = CryptocurrencyMiningPoolFields {
+            source: "collector1".to_string(),
+            session_end_time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 53,
+            proto: 17,
+            query: "foo.com".to_string(),
+            answer: vec!["10.10.10.10".to_string(), "20.20.20.20".to_string()],
+            trans_id: 123,
+            rtt: 1,
+            qclass: 0,
+            qtype: 0,
+            rcode: 0,
+            aa_flag: false,
+            tc_flag: false,
+            rd_flag: false,
+            ra_flag: true,
+            ttl: vec![120; 5],
+            coins: vec!["bitcoin".to_string(), "monero".to_string()],
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::CryptocurrencyMiningPool,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="CryptocurrencyMiningPool" category="CommandAndControl" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="53" proto="17" session_end_time="1970-01-01T01:01:01+00:00" query="foo.com" answer="10.10.10.10,20.20.20.20" trans_id="123" rtt="1" qclass="0" qtype="0" rcode="0" aa_flag="false" tc_flag="false" rd_flag="false" ra_flag="true" ttl="120,120,120,120,120" coins="bitcoin,monero""#
+        );
+
+        let cryptocurrency_mining_pool =
+            Event::CryptocurrencyMiningPool(crate::CryptocurrencyMiningPool::new(
+                Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+                fields,
+            ))
+            .to_string();
+        assert_eq!(
+            &cryptocurrency_mining_pool,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="CryptocurrencyMiningPool" category="CommandAndControl" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="53" proto="17" session_end_time="1970-01-01T01:01:01+00:00" query="foo.com" answer="10.10.10.10,20.20.20.20" trans_id="123" rtt="1" qclass="0" qtype="0" rcode="0" aa_flag="false" tc_flag="false" rd_flag="false" ra_flag="true" ttl="120,120,120,120,120" coins="bitcoin,monero" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_blocklist_dns() {
+        let fields = BlockListDnsFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 53,
+            proto: 17,
+            last_time: 100,
+            query: "foo.com".to_string(),
+            answer: vec!["10.10.10.10".to_string(), "20.20.20.20".to_string()],
+            trans_id: 123,
+            rtt: 1,
+            qclass: 0,
+            qtype: 0,
+            rcode: 0,
+            aa_flag: false,
+            tc_flag: false,
+            rd_flag: false,
+            ra_flag: true,
+            ttl: vec![120; 5],
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::BlockListDns,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListDns" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="53" proto="17" last_time="100" query="foo.com" answer="10.10.10.10,20.20.20.20" trans_id="123" rtt="1" qclass="0" qtype="0" rcode="0" aa_flag="false" tc_flag="false" rd_flag="false" ra_flag="true" ttl="120,120,120,120,120""#
+        );
+        let block_list_dns = Event::BlockList(RecordType::Dns(crate::BlockListDns::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            fields,
+        )))
+        .to_string();
+        assert_eq!(
+            &block_list_dns,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListDns" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="53" proto="17" last_time="100" query="foo.com" answer="10.10.10.10,20.20.20.20" trans_id="123" rtt="1" qclass="0" qtype="0" rcode="0" aa_flag="false" tc_flag="false" rd_flag="false" ra_flag="true" ttl="120,120,120,120,120" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_ftpbruteforce() {
+        let fields = FtpBruteForceFields {
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 21,
+            proto: 6,
+            user_list: vec!["user1".to_string(), "user_2".to_string()],
+            start_time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            last_time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 2).unwrap(),
+            is_internal: true,
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            kind: EventKind::FtpBruteForce,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T00:01:01+00:00" event_kind="FtpBruteForce" category="CredentialAccess" src_addr="127.0.0.1" dst_addr="127.0.0.2" dst_port="21" proto="6" user_list="user1,user_2" start_time="1970-01-01T00:01:01+00:00" last_time="1970-01-01T00:01:02+00:00" is_internal="true""#
+        );
+
+        let ftp_brute_force = Event::FtpBruteForce(crate::FtpBruteForce::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            &fields,
+        ))
+        .to_string();
+
+        assert_eq!(
+            &ftp_brute_force,
+            r#"time="1970-01-01T00:01:01+00:00" event_kind="FtpBruteForce" category="CredentialAccess" src_addr="127.0.0.1" dst_addr="127.0.0.2" dst_port="21" proto="6" user_list="user1,user_2" start_time="1970-01-01T00:01:01+00:00" last_time="1970-01-01T00:01:02+00:00" is_internal="true" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_ftpplaintext() {
+        let fields = FtpPlainTextFields {
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 21,
+            proto: 6,
+            last_time: 100,
+            user: "user1".to_string(),
+            password: "password".to_string(),
+            command: "ls".to_string(),
+            reply_code: "200".to_string(),
+            reply_msg: "OK".to_string(),
+            data_passive: false,
+            data_orig_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3)),
+            source: "collector1".to_string(),
+            data_resp_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 4)),
+            data_resp_port: 10001,
+            file: "/etc/passwd".to_string(),
+            file_size: 5000,
+            file_id: "123".to_string(),
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::FtpPlainText,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="FtpPlainText" category="LateralMovement" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="21" proto="6" last_time="100" user="user1" password="password" command="ls" reply_code="200" reply_msg="OK" data_passive="false" data_orig_addr="127.0.0.3" data_resp_addr="127.0.0.4" data_resp_port="10001" file="/etc/passwd" file_size="5000" file_id="123""#
+        );
+
+        let ftp_plain_text = Event::FtpPlainText(crate::FtpPlainText::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            fields,
+        ))
+        .to_string();
+        assert_eq!(
+            &ftp_plain_text,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="FtpPlainText" category="LateralMovement" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="21" proto="6" last_time="100" user="user1" password="password" command="ls" reply_code="200" reply_msg="OK" data_passive="false" data_orig_addr="127.0.0.3" data_resp_addr="127.0.0.4" data_resp_port="10001" file="/etc/passwd" file_size="5000" file_id="123" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_blocklist_ftp() {
+        let fields = BlockListFtpFields {
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 21,
+            proto: 6,
+            last_time: 100,
+            user: "user1".to_string(),
+            password: "password".to_string(),
+            command: "ls".to_string(),
+            reply_code: "200".to_string(),
+            reply_msg: "OK".to_string(),
+            data_passive: false,
+            data_orig_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3)),
+            source: "collector1".to_string(),
+            data_resp_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 4)),
+            data_resp_port: 10001,
+            file: "/etc/passwd".to_string(),
+            file_size: 5000,
+            file_id: "123".to_string(),
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::BlockListFtp,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListFtp" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="21" proto="6" last_time="100" user="user1" password="password" command="ls" reply_code="200" reply_msg="OK" data_passive="false" data_orig_addr="127.0.0.3" data_resp_addr="127.0.0.4" data_resp_port="10001" file="/etc/passwd" file_size="5000" file_id="123""#
+        );
+
+        let block_list_ftp = Event::BlockList(RecordType::Ftp(crate::BlockListFtp::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            fields,
+        )))
+        .to_string();
+
+        assert_eq!(
+            &block_list_ftp,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListFtp" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="21" proto="6" last_time="100" user="user1" password="password" command="ls" reply_code="200" reply_msg="OK" data_passive="false" data_orig_addr="127.0.0.3" data_resp_addr="127.0.0.4" data_resp_port="10001" file="/etc/passwd" file_size="5000" file_id="123" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_repeatedhttpsessions() {
+        let fields = RepeatedHttpSessionsFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 443,
+            proto: 6,
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::RepeatedHttpSessions,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="RepeatedHttpSessions" category="Exfiltration" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="443" proto="6""#
+        );
+        let repeated_http_sessions = Event::RepeatedHttpSessions(crate::RepeatedHttpSessions::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            &fields,
+        ))
+        .to_string();
+        assert_eq!(
+            &repeated_http_sessions,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="RepeatedHttpSessions" category="Exfiltration" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="443" proto="6" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_blocklist_kerberos() {
+        let fields = BlockListKerberosFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 88,
+            proto: 17,
+            last_time: 100,
+            client_time: 100,
+            server_time: 101,
+            error_code: 0,
+            client_realm: "EXAMPLE.COM".to_string(),
+            cname_type: 1,
+            client_name: vec!["user1".to_string()],
+            realm: "EXAMPLE.COM".to_string(),
+            sname_type: 1,
+            service_name: vec!["krbtgt/EXAMPLE.COM".to_string()],
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::BlockListKerberos,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListKerberos" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="88" proto="17" last_time="100" client_time="100" server_time="101" error_code="0" client_realm="EXAMPLE.COM" cname_type="1" client_name="user1" realm="EXAMPLE.COM" sname_type="1" service_name="krbtgt/EXAMPLE.COM""#
+        );
+
+        let block_list_kerberos =
+            Event::BlockList(RecordType::Kerberos(crate::BlockListKerberos::new(
+                Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+                fields,
+            )))
+            .to_string();
+
+        assert_eq!(
+            &block_list_kerberos,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListKerberos" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="88" proto="17" last_time="100" client_time="100" server_time="101" error_code="0" client_realm="EXAMPLE.COM" cname_type="1" client_name="user1" realm="EXAMPLE.COM" sname_type="1" service_name="krbtgt/EXAMPLE.COM" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_ldapbruteforce() {
+        let fields = LdapBruteForceFields {
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 389,
+            proto: 6,
+            user_pw_list: vec![
+                ("user1".to_string(), "pw1".to_string()),
+                ("user_2".to_string(), "pw2".to_string()),
+            ],
+            start_time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            last_time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 2).unwrap(),
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            kind: EventKind::LdapBruteForce,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T00:01:01+00:00" event_kind="LdapBruteForce" category="CredentialAccess" src_addr="127.0.0.1" dst_addr="127.0.0.2" dst_port="389" proto="6" user_pw_list="user1:pw1,user_2:pw2" start_time="1970-01-01T00:01:01+00:00" last_time="1970-01-01T00:01:02+00:00""#
+        );
+
+        let ldap_brute_force = Event::LdapBruteForce(crate::LdapBruteForce::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            &fields,
+        ))
+        .to_string();
+
+        assert_eq!(
+            &ldap_brute_force,
+            r#"time="1970-01-01T00:01:01+00:00" event_kind="LdapBruteForce" category="CredentialAccess" src_addr="127.0.0.1" dst_addr="127.0.0.2" dst_port="389" proto="6" user_pw_list="user1:pw1,user_2:pw2" start_time="1970-01-01T00:01:01+00:00" last_time="1970-01-01T00:01:02+00:00" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_ldapplaintext() {
+        let fields = LdapPlainTextFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 389,
+            proto: 6,
+            last_time: 100,
+            message_id: 1,
+            version: 3,
+            opcode: vec!["bind".to_string()],
+            result: vec!["success".to_string()],
+            diagnostic_message: vec!["msg".to_string()],
+            object: vec!["object".to_string()],
+            argument: vec!["argument".to_string()],
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::LdapPlainText,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="LdapPlainText" category="LateralMovement" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="389" proto="6" last_time="100" message_id="1" version="3" opcode="bind" result="success" diagnostic_message="msg" object="object" argument="argument""#
+        );
+
+        let ldap_plain_text = Event::LdapPlainText(crate::LdapPlainText::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            fields,
+        ))
+        .to_string();
+
+        assert_eq!(
+            &ldap_plain_text,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="LdapPlainText" category="LateralMovement" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="389" proto="6" last_time="100" message_id="1" version="3" opcode="bind" result="success" diagnostic_message="msg" object="object" argument="argument" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_blocklist_ldap() {
+        let fields = BlockListLdapFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 389,
+            proto: 6,
+            last_time: 100,
+            message_id: 1,
+            version: 3,
+            opcode: vec!["bind".to_string()],
+            result: vec!["success".to_string()],
+            diagnostic_message: vec!["msg".to_string()],
+            object: vec!["object".to_string()],
+            argument: vec!["argument".to_string()],
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::BlockListLdap,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListLdap" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="389" proto="6" last_time="100" message_id="1" version="3" opcode="bind" result="success" diagnostic_message="msg" object="object" argument="argument""#
+        );
+
+        let block_list_ldap = Event::BlockList(RecordType::Ldap(crate::BlockListLdap::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            fields,
+        )))
+        .to_string();
+
+        assert_eq!(
+            &block_list_ldap,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListLdap" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="389" proto="6" last_time="100" message_id="1" version="3" opcode="bind" result="success" diagnostic_message="msg" object="object" argument="argument" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_extrathreat() {
+        let fields = ExtraThreat {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            source: "collector1".to_string(),
+            service: "service".to_string(),
+            content: "content".to_string(),
+            db_name: "db_name".to_string(),
+            rule_id: 1,
+            matched_to: "matched_to".to_string(),
+            cluster_id: 1,
+            attack_kind: "attack_kind".to_string(),
+            confidence: 0.9,
+            triage_scores: None,
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::ExtraThreat,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="ExtraThreat" category="Reconnaissance" source="collector1" service="service" content="content" db_name="db_name" rule_id="1" matched_to="matched_to" cluster_id="1" attack_kind="attack_kind" confidence="0.9" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_blocklist_mqtt() {
+        let fields = BlockListMqttFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 1883,
+            proto: 6,
+            last_time: 100,
+            protocol: "mqtt".to_string(),
+            version: 211,
+            client_id: "client1".to_string(),
+            connack_reason: 0,
+            subscribe: vec!["topic".to_string()],
+            suback_reason: "error".to_string().into_bytes(),
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::BlockListMqtt,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListMqtt" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="1883" proto="6" last_time="100" protocol="mqtt" version="211" client_id="client1" connack_reason="0" subscribe="topic" suback_reason="error""#
+        );
+
+        let block_list_mqtt = Event::BlockList(RecordType::Mqtt(crate::BlockListMqtt::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            fields,
+        )))
+        .to_string();
+
+        assert_eq!(
+            &block_list_mqtt,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListMqtt" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="1883" proto="6" last_time="100" protocol="mqtt" version="211" client_id="client1" connack_reason="0" subscribe="topic" suback_reason="error" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_networkthreat() {
+        let fields = NetworkThreat {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            source: "collector1".to_string(),
+            orig_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            orig_port: 10000,
+            resp_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            resp_port: 80,
+            proto: 6,
+            service: "http".to_string(),
+            last_time: 100,
+            content: "content".to_string(),
+            db_name: "db_name".to_string(),
+            rule_id: 1,
+            matched_to: "matched_to".to_string(),
+            cluster_id: 1,
+            attack_kind: "attack_kind".to_string(),
+            confidence: 0.9,
+            triage_scores: None,
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::NetworkThreat,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="NetworkThreat" category="Reconnaissance" source="collector1" orig_addr="127.0.0.1" orig_port="10000" resp_addr="127.0.0.2" resp_port="80" proto="6" service="http" last_time="100" content="content" db_name="db_name" rule_id="1" matched_to="matched_to" cluster_id="1" attack_kind="attack_kind" confidence="0.9" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_blocklist_nfs() {
+        let fields = BlockListNfsFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 2049,
+            proto: 6,
+            last_time: 100,
+            read_files: vec!["/etc/passwd".to_string()],
+            write_files: vec!["/etc/shadow".to_string()],
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::BlockListNfs,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListNfs" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="2049" proto="6" last_time="100" read_files="/etc/passwd" write_files="/etc/shadow""#
+        );
+
+        let block_list_nfs = Event::BlockList(RecordType::Nfs(crate::BlockListNfs::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            fields,
+        )))
+        .to_string();
+
+        assert_eq!(
+            &block_list_nfs,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListNfs" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="2049" proto="6" last_time="100" read_files="/etc/passwd" write_files="/etc/shadow" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_blocklist_ntlm() {
+        let fields = BlockListNtlmFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 445,
+            proto: 6,
+            last_time: 100,
+            protocol: "ntlm".to_string(),
+            username: "user1".to_string(),
+            hostname: "host1".to_string(),
+            domainname: "domain1".to_string(),
+            success: "true".to_string(),
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::BlockListNtlm,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListNtlm" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="445" proto="6" last_time="100" protocol="ntlm" username="user1" hostname="host1" domainname="domain1" success="true""#
+        );
+
+        let block_list_ntlm = Event::BlockList(RecordType::Ntlm(crate::BlockListNtlm::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            fields,
+        )))
+        .to_string();
+
+        assert_eq!(
+            &block_list_ntlm,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListNtlm" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="445" proto="6" last_time="100" protocol="ntlm" username="user1" hostname="host1" domainname="domain1" success="true" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_rdpbruteforce() {
+        let fields = RdpBruteForceFields {
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            dst_addrs: vec![
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3)),
+            ],
+            start_time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            last_time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 10, 2).unwrap(),
+            proto: 6,
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            kind: EventKind::RdpBruteForce,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T00:01:01+00:00" event_kind="RdpBruteForce" category="Exfiltration" src_addr="127.0.0.1" dst_addrs="127.0.0.2,127.0.0.3" start_time="1970-01-01T00:01:01+00:00" last_time="1970-01-01T00:10:02+00:00" proto="6""#
+        );
+
+        let rdp_brute_force = Event::RdpBruteForce(crate::RdpBruteForce::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            &fields,
+        ))
+        .to_string();
+
+        assert_eq!(
+            &rdp_brute_force,
+            r#"time="1970-01-01T00:01:01+00:00" event_kind="RdpBruteForce" category="Exfiltration" src_addr="127.0.0.1" dst_addrs="127.0.0.2,127.0.0.3" start_time="1970-01-01T00:01:01+00:00" last_time="1970-01-01T00:10:02+00:00" proto="6" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_blocklist_rdp() {
+        let fields = BlockListRdpFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 3389,
+            proto: 6,
+            last_time: 100,
+            cookie: "cookie".to_string(),
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::BlockListRdp,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListRdp" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="3389" proto="6" last_time="100" cookie="cookie""#
+        );
+
+        let block_list_rdp = Event::BlockList(RecordType::Rdp(crate::BlockListRdp::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            fields,
+        )))
+        .to_string();
+
+        assert_eq!(
+            &block_list_rdp,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListRdp" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="3389" proto="6" last_time="100" cookie="cookie" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_blocklist_smb() {
+        let fields = BlockListSmbFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 445,
+            proto: 6,
+            last_time: 100,
+            command: 1,
+            path: "path".to_string(),
+            service: "service".to_string(),
+            file_name: "file_name".to_string(),
+            file_size: 100,
+            resource_type: 1,
+            fid: 1,
+            create_time: 100,
+            access_time: 200,
+            write_time: 300,
+            change_time: 400,
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::BlockListSmb,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListSmb" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="445" proto="6" last_time="100" command="1" path="path" service="service" file_name="file_name" file_size="100" resource_type="1" fid="1" create_time="100" access_time="200" write_time="300" change_time="400""#
+        );
+
+        let block_list_smb = Event::BlockList(RecordType::Smb(crate::BlockListSmb::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            fields,
+        )))
+        .to_string();
+
+        assert_eq!(
+            &block_list_smb,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListSmb" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="445" proto="6" last_time="100" command="1" path="path" service="service" file_name="file_name" file_size="100" resource_type="1" fid="1" create_time="100" access_time="200" write_time="300" change_time="400" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_blocklist_smtp() {
+        let fields = BlockListSmtpFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 25,
+            proto: 6,
+            last_time: 100,
+            mailfrom: "mailfrom".to_string(),
+            date: "date".to_string(),
+            from: "from".to_string(),
+            to: "to".to_string(),
+            subject: "subject".to_string(),
+            agent: "agent".to_string(),
+            state: "state".to_string(),
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::BlockListSmtp,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListSmtp" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="25" proto="6" last_time="100" mailfrom="mailfrom" date="date" from="from" to="to" subject="subject" agent="agent" state="state""#
+        );
+
+        let block_list_smtp = Event::BlockList(RecordType::Smtp(crate::BlockListSmtp::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            fields,
+        )))
+        .to_string();
+
+        assert_eq!(
+            &block_list_smtp,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListSmtp" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="25" proto="6" last_time="100" mailfrom="mailfrom" date="date" from="from" to="to" subject="subject" agent="agent" state="state" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_blocklist_ssh() {
+        let fields = BlockListSshFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 22,
+            proto: 6,
+            last_time: 100,
+            client: "client".to_string(),
+            server: "server".to_string(),
+            cipher_alg: "cipher_alg".to_string(),
+            mac_alg: "mac_alg".to_string(),
+            compression_alg: "compression_alg".to_string(),
+            kex_alg: "kex_alg".to_string(),
+            host_key_alg: "host_key_alg".to_string(),
+            hassh_algorithms: "hassh_algorithms".to_string(),
+            hassh: "hassh".to_string(),
+            hassh_server_algorithms: "hassh_server_algorithms".to_string(),
+            hassh_server: "hassh_server".to_string(),
+            client_shka: "client_shka".to_string(),
+            server_shka: "server_shka".to_string(),
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::BlockListSsh,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListSsh" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="22" proto="6" last_time="100" client="client" server="server" cipher_alg="cipher_alg" mac_alg="mac_alg" compression_alg="compression_alg" kex_alg="kex_alg" host_key_alg="host_key_alg" hassh_algorithms="hassh_algorithms" hassh="hassh" hassh_server_algorithms="hassh_server_algorithms" hassh_server="hassh_server" client_shka="client_shka" server_shka="server_shka""#
+        );
+
+        let block_list_ssh = Event::BlockList(RecordType::Ssh(crate::BlockListSsh::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            fields,
+        )))
+        .to_string();
+
+        assert_eq!(
+            &block_list_ssh,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListSsh" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="22" proto="6" last_time="100" client="client" server="server" cipher_alg="cipher_alg" mac_alg="mac_alg" compression_alg="compression_alg" kex_alg="kex_alg" host_key_alg="host_key_alg" hassh_algorithms="hassh_algorithms" hassh="hassh" hassh_server_algorithms="hassh_server_algorithms" hassh_server="hassh_server" client_shka="client_shka" server_shka="server_shka" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_windowsthreat() {
+        let fields = WindowsThreat {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            source: "collector1".to_string(),
+            service: "notepad".to_string(),
+            agent_name: "win64".to_string(),
+            agent_id: "e7e2386a-5485-4da9-b388-b3e50ee7cbb0".to_string(),
+            process_guid: "{bac98147-6b03-64d4-8200-000000000700}".to_string(),
+            process_id: 2972,
+            image: r#"C:\Users\vboxuser\Desktop\mal_bazaar\ransomware\918504.exe"#.to_string(),
+            user: r#"WIN64\vboxuser"#.to_string(),
+            content: r#"cmd /c "vssadmin.exe Delete Shadows /all /quiet""#.to_string(),
+            db_name: "db".to_string(),
+            rule_id: 100,
+            matched_to: "match".to_string(),
+            cluster_id: 900,
+            attack_kind: "Ransomware_Alcatraz".to_string(),
+            confidence: 0.9,
+            triage_scores: None,
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(),
+            kind: EventKind::WindowsThreat,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = format!("{message}");
+        assert_eq!(&syslog_message,
+            "time=\"1970-01-01T00:01:01+00:00\" event_kind=\"WindowsThreat\" category=\"Impact\" source=\"collector1\" service=\"notepad\" agent_name=\"win64\" agent_id=\"e7e2386a-5485-4da9-b388-b3e50ee7cbb0\" process_guid=\"{bac98147-6b03-64d4-8200-000000000700}\" process_id=\"2972\" image=\"C:\\Users\\vboxuser\\Desktop\\mal_bazaar\\ransomware\\918504.exe\" user=\"WIN64\\vboxuser\" content=\"cmd /c \"vssadmin.exe Delete Shadows /all /quiet\"\" db_name=\"db\" rule_id=\"100\" matched_to=\"match\" cluster_id=\"900\" attack_kind=\"Ransomware_Alcatraz\" confidence=\"0.9\" triage_scores=\"\""
+        );
+        assert!(syslog_message.contains("user=\"WIN64\\vboxuser\""));
+        assert!(syslog_message
+            .contains("content=\"cmd /c \"vssadmin.exe Delete Shadows /all /quiet\"\""));
+
+        let windows_threat = Event::WindowsThreat(fields).to_string();
+        assert_eq!(&windows_threat,
+            "time=\"1970-01-01T00:01:01+00:00\" event_kind=\"WindowsThreat\" category=\"Impact\" source=\"collector1\" service=\"notepad\" agent_name=\"win64\" agent_id=\"e7e2386a-5485-4da9-b388-b3e50ee7cbb0\" process_guid=\"{bac98147-6b03-64d4-8200-000000000700}\" process_id=\"2972\" image=\"C:\\Users\\vboxuser\\Desktop\\mal_bazaar\\ransomware\\918504.exe\" user=\"WIN64\\vboxuser\" content=\"cmd /c \"vssadmin.exe Delete Shadows /all /quiet\"\" db_name=\"db\" rule_id=\"100\" matched_to=\"match\" cluster_id=\"900\" attack_kind=\"Ransomware_Alcatraz\" confidence=\"0.9\" triage_scores=\"\""
+        );
+        assert!(windows_threat.contains("process_guid=\"{bac98147-6b03-64d4-8200-000000000700}\""));
+        assert!(windows_threat
+            .contains(r#"image="C:\Users\vboxuser\Desktop\mal_bazaar\ransomware\918504.exe""#));
+    }
+
+    #[tokio::test]
+    async fn syslog_for_blocklist_tls() {
+        let fields = BlockListTlsFields {
+            source: "collector1".to_string(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 443,
+            proto: 6,
+            last_time: 100,
+            server_name: "server".to_string(),
+            alpn_protocol: "alpn".to_string(),
+            ja3: "ja3".to_string(),
+            version: "version".to_string(),
+            client_cipher_suites: vec![1, 2, 3],
+            client_extensions: vec![4, 5, 6],
+            cipher: 1,
+            extensions: vec![7, 8, 9],
+            ja3s: "ja3s".to_string(),
+            serial: "serial".to_string(),
+            subject_country: "country".to_string(),
+            subject_org_name: "org".to_string(),
+            subject_common_name: "common".to_string(),
+            validity_not_before: 100,
+            validity_not_after: 200,
+            subject_alt_name: "alt".to_string(),
+            issuer_country: "country".to_string(),
+            issuer_org_name: "org".to_string(),
+            issuer_org_unit_name: "unit".to_string(),
+            issuer_common_name: "common".to_string(),
+            last_alert: 1,
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::BlockListTls,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListTls" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="443" proto="6" last_time="100" server_name="server" alpn_protocol="alpn" ja3="ja3" version="version" client_cipher_suites="1,2,3" client_extensions="4,5,6" cipher="1" extensions="7,8,9" ja3s="ja3s" serial="serial" subject_country="country" subject_org_name="org" subject_common_name="common" validity_not_before="100" validity_not_after="200" subject_alt_name="alt" issuer_country="country" issuer_org_name="org" issuer_org_unit_name="unit" issuer_common_name="common" last_alert="1""#
+        );
+
+        let block_list_tls = Event::BlockList(RecordType::Tls(crate::BlockListTls::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            fields,
+        )))
+        .to_string();
+
+        assert_eq!(
+            &block_list_tls,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListTls" category="InitialAccess" source="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="443" proto="6" last_time="100" server_name="server" alpn_protocol="alpn" ja3="ja3" version="version" client_cipher_suites="1,2,3" client_extensions="4,5,6" cipher="1" extensions="7,8,9" ja3s="ja3s" serial="serial" subject_country="country" subject_org_name="org" subject_common_name="common" validity_not_before="100" validity_not_after="200" subject_alt_name="alt" issuer_country="country" issuer_org_name="org" issuer_org_unit_name="unit" issuer_common_name="common" last_alert="1" triage_scores="""#
+        );
+    }
+
+    #[tokio::test]
+    async fn syslog_for_torconnection() {
+        let fields = TorConnectionFields {
+            source: "collector1".to_string(),
+            session_end_time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            src_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            src_port: 10000,
+            dst_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+            dst_port: 443,
+            proto: 6,
+            method: "GET".to_string(),
+            host: "host".to_string(),
+            uri: "uri".to_string(),
+            referrer: "referrer".to_string(),
+            version: "version".to_string(),
+            user_agent: "user_agent".to_string(),
+            request_len: 100,
+            response_len: 200,
+            status_code: 200,
+            status_msg: "OK".to_string(),
+            username: "user".to_string(),
+            password: "password".to_string(),
+            cookie: "cookie".to_string(),
+            content_encoding: "content_encoding".to_string(),
+            content_type: "content_type".to_string(),
+            cache_control: "cache_control".to_string(),
+        };
+
+        let message = EventMessage {
+            time: Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            kind: EventKind::TorConnection,
+            fields: bincode::serialize(&fields).expect("serializable"),
+        };
+
+        let syslog_message = message.to_string();
+        assert_eq!(
+            &syslog_message,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="TorConnection" category="CommandAndControl" source="collector1" session_end_time="1970-01-01T01:01:01+00:00" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="443" proto="6" method="GET" host="host" uri="uri" referrer="referrer" version="version" user_agent="user_agent" request_len="100" response_len="200" status_code="200" status_msg="OK" username="user" password="password" cookie="cookie" content_encoding="content_encoding" content_type="content_type" cache_control="cache_control""#
+        );
+
+        let tor_connection = Event::TorConnection(crate::TorConnection::new(
+            Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(),
+            &fields,
+        ))
+        .to_string();
+
+        assert_eq!(
+            &tor_connection,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="TorConnection" category="CommandAndControl" source="collector1" session_end_time="1970-01-01T01:01:01+00:00" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="443" proto="6" method="GET" host="host" uri="uri" referrer="referrer" version="version" user_agent="user_agent" request_len="100" response_len="200" status_code="200" status_msg="OK" username="user" password="password" cookie="cookie" content_encoding="content_encoding" content_type="content_type" cache_control="cache_control" triage_scores="""#
+        );
     }
 }

--- a/src/event/common.rs
+++ b/src/event/common.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::{self, Formatter},
     net::IpAddr,
     num::NonZeroU8,
     sync::{Arc, Mutex},
@@ -237,4 +238,32 @@ pub(super) trait Match {
 pub struct TriageScore {
     pub policy_id: u32,
     pub score: f64,
+}
+
+impl fmt::Display for TriageScore {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}:{:.2}", self.policy_id, self.score)
+    }
+}
+
+pub fn triage_scores_to_string(v: &Option<Vec<TriageScore>>) -> String {
+    if let Some(v) = v {
+        v.iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(",")
+    } else {
+        String::new()
+    }
+}
+
+pub fn vector_to_string<T: ToString>(v: &[T]) -> String {
+    if v.is_empty() {
+        String::new()
+    } else {
+        v.iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(",")
+    }
 }

--- a/src/event/conn.rs
+++ b/src/event/conn.rs
@@ -4,10 +4,11 @@ use std::{
     num::NonZeroU8,
 };
 
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use crate::event::common::{triage_scores_to_string, vector_to_string};
 
 #[derive(Serialize, Deserialize)]
 pub struct PortScanFields {
@@ -23,8 +24,13 @@ impl fmt::Display for PortScanFields {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{},-,{},-,{},Port Scan,3,{},{}",
-            self.src_addr, self.dst_addr, self.proto, self.start_time, self.last_time,
+            "src_addr={:?} dst_addr={:?} dst_ports={:?} start_time={:?} last_time={:?} proto={:?}",
+            self.src_addr.to_string(),
+            self.dst_addr.to_string(),
+            vector_to_string(&self.dst_ports),
+            self.start_time.to_rfc3339(),
+            self.last_time.to_rfc3339(),
+            self.proto.to_string()
         )
     }
 }
@@ -45,13 +51,14 @@ impl fmt::Display for PortScan {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{},{},-,{},-,{},Port Scan,{},{}",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.dst_addr,
-            self.proto,
-            self.start_time,
-            self.last_time,
+            "src_addr={:?} dst_addr={:?} dst_ports={:?} start_time={:?} last_time={:?} proto={:?} triage_scores={:?}",
+            self.src_addr.to_string(),
+            self.dst_addr.to_string(),
+            vector_to_string(&self.dst_ports),
+            self.start_time.to_rfc3339(),
+            self.last_time.to_rfc3339(),
+            self.proto.to_string(),
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }
@@ -132,8 +139,13 @@ impl fmt::Display for MultiHostPortScanFields {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{},-,-,{},{},Multi Host Port Scan,3,{},{}",
-            self.src_addr, self.dst_port, self.proto, self.start_time, self.last_time,
+            "src_addr={:?} dst_addrs={:?} dst_port={:?} proto={:?} start_time={:?} last_time={:?}",
+            self.src_addr.to_string(),
+            vector_to_string(&self.dst_addrs),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.start_time.to_rfc3339(),
+            self.last_time.to_rfc3339()
         )
     }
 }
@@ -154,13 +166,14 @@ impl fmt::Display for MultiHostPortScan {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{},{},-,-,{},{},Multi Host Port Scan,{},{}",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.dst_port,
-            self.proto,
-            self.start_time,
-            self.last_time,
+            "src_addr={:?} dst_addrs={:?} dst_port={:?} proto={:?} start_time={:?} last_time={:?} triage_scores={:?}",
+            self.src_addr.to_string(),
+            vector_to_string(&self.dst_addrs),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.start_time.to_rfc3339(),
+            self.last_time.to_rfc3339(),
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }
@@ -240,8 +253,12 @@ impl fmt::Display for ExternalDdosFields {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "-,-,{},-,{},External DDos,3,{},{}",
-            self.dst_addr, self.proto, self.start_time, self.last_time,
+            "src_addrs={:?} dst_addr={:?} proto={:?} start_time={:?} last_time={:?}",
+            vector_to_string(&self.src_addrs),
+            self.dst_addr.to_string(),
+            self.proto.to_string(),
+            self.start_time.to_rfc3339(),
+            self.last_time.to_rfc3339()
         )
     }
 }
@@ -261,12 +278,13 @@ impl fmt::Display for ExternalDdos {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{},-,-,{},-,{},External DDos,{},{}",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.dst_addr,
-            self.proto,
-            self.start_time,
-            self.last_time,
+            "src_addrs={:?} dst_addr={:?} proto={:?} start_time={:?} last_time={:?} triage_scores={:?}",
+            vector_to_string(&self.src_addrs),
+            self.dst_addr.to_string(),
+            self.proto.to_string(),
+            self.start_time.to_rfc3339(),
+            self.last_time.to_rfc3339(),
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }
@@ -353,8 +371,20 @@ impl fmt::Display for BlockListConnFields {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},BlockListConn,3,{}",
-            self.src_addr, self.src_port, self.dst_addr, self.dst_port, self.proto, self.duration,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} conn_state={:?} duration={:?} service={:?} orig_bytes={:?} resp_bytes={:?} orig_pkts={:?} resp_pkts={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.conn_state,
+            self.duration.to_string(),
+            self.service,
+            self.orig_bytes.to_string(),
+            self.resp_bytes.to_string(),
+            self.orig_pkts.to_string(),
+            self.resp_pkts.to_string()
         )
     }
 }
@@ -382,14 +412,21 @@ impl fmt::Display for BlockListConn {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},BlockListConn,{}",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
-            self.duration,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} conn_state={:?} duration={:?} service={:?} orig_bytes={:?} resp_bytes={:?} orig_pkts={:?} resp_pkts={:?} triage_scores={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.conn_state,
+            self.duration.to_string(),
+            self.service,
+            self.orig_bytes.to_string(),
+            self.resp_bytes.to_string(),
+            self.orig_pkts.to_string(),
+            self.resp_pkts.to_string(),
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }

--- a/src/event/dcerpc.rs
+++ b/src/event/dcerpc.rs
@@ -1,9 +1,10 @@
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use crate::event::common::triage_scores_to_string;
 
 #[derive(Serialize, Deserialize)]
 pub struct BlockListDceRpcFields {
@@ -21,11 +22,21 @@ pub struct BlockListDceRpcFields {
 }
 
 impl fmt::Display for BlockListDceRpcFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},BlockListDceRpc,3",
-            self.src_addr, self.src_port, self.dst_addr, self.dst_port, self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} rtt={:?} named_pipe={:?} endpoint={:?} operation={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.rtt.to_string(),
+            self.named_pipe,
+            self.endpoint,
+            self.operation
         )
     }
 }
@@ -47,16 +58,22 @@ pub struct BlockListDceRpc {
 }
 
 impl fmt::Display for BlockListDceRpc {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},BlockListDceRpc",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} rtt={:?} named_pipe={:?} endpoint={:?} operation={:?} triage_scores={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.rtt.to_string(),
+            self.named_pipe,
+            self.endpoint,
+            self.operation,
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }

--- a/src/event/dns.rs
+++ b/src/event/dns.rs
@@ -1,10 +1,11 @@
 #![allow(clippy::module_name_repetitions, clippy::struct_excessive_bools)]
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
-use chrono::{serde::ts_nanoseconds, DateTime, Local, Utc};
+use chrono::{serde::ts_nanoseconds, DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, HIGH, MEDIUM};
+use crate::event::common::{triage_scores_to_string, vector_to_string};
 
 #[derive(Deserialize, Serialize)]
 pub struct DnsEventFields {
@@ -32,11 +33,30 @@ pub struct DnsEventFields {
 }
 
 impl fmt::Display for DnsEventFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},DNS covert channel,3,{}",
-            self.src_addr, self.src_port, self.dst_addr, self.dst_port, self.proto, self.query,
+            "source={:?} session_end_time={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} query={:?} answer={:?} trans_id={:?} rtt={:?} qclass={:?} qtype={:?} rcode={:?} aa_flag={:?} tc_flag={:?} rd_flag={:?} ra_flag={:?} ttl={:?} confidence={:?}",
+            self.source,
+            self.session_end_time.to_rfc3339(),
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.query,
+            self.answer.join(","),
+            self.trans_id.to_string(),
+            self.rtt.to_string(),
+            self.qclass.to_string(),
+            self.qtype.to_string(),
+            self.rcode.to_string(),
+            self.aa_flag.to_string(),
+            self.tc_flag.to_string(),
+            self.rd_flag.to_string(),
+            self.ra_flag.to_string(),
+            vector_to_string(&self.ttl),
+            self.confidence.to_string(),
         )
     }
 }
@@ -67,18 +87,31 @@ pub struct DnsCovertChannel {
 }
 
 impl fmt::Display for DnsCovertChannel {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},DNS covert channel,{},{}",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} session_end_time={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} query={:?} answer={:?} trans_id={:?} rtt={:?} qclass={:?} qtype={:?} rcode={:?} aa_flag={:?} tc_flag={:?} rd_flag={:?} ra_flag={:?} ttl={:?} confidence={:?} triage_scores={:?}",
+            self.source,
+            self.session_end_time.to_rfc3339(),
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
             self.query,
-            self.confidence
+            self.answer.join(","),
+            self.trans_id.to_string(),
+            self.rtt.to_string(),
+            self.qclass.to_string(),
+            self.qtype.to_string(),
+            self.rcode.to_string(),
+            self.aa_flag.to_string(),
+            self.tc_flag.to_string(),
+            self.rd_flag.to_string(),
+            self.ra_flag.to_string(),
+            vector_to_string(&self.ttl),
+            self.confidence.to_string(),
+            triage_scores_to_string(&self.triage_scores),
         )
     }
 }
@@ -186,18 +219,31 @@ pub struct LockyRansomware {
 }
 
 impl fmt::Display for LockyRansomware {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},Locky Ransomware,{},{}",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} session_end_time={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} query={:?} answer={:?} trans_id={:?} rtt={:?} qclass={:?} qtype={:?} rcode={:?} aa_flag={:?} tc_flag={:?} rd_flag={:?} ra_flag={:?} ttl={:?} confidence={:?} triage_scores={:?}",
+            self.source,
+            self.session_end_time.to_rfc3339(),
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
             self.query,
-            self.confidence
+            self.answer.join(","),
+            self.trans_id.to_string(),
+            self.rtt.to_string(),
+            self.qclass.to_string(),
+            self.qtype.to_string(),
+            self.rcode.to_string(),
+            self.aa_flag.to_string(),
+            self.tc_flag.to_string(),
+            self.rd_flag.to_string(),
+            self.ra_flag.to_string(),
+            vector_to_string(&self.ttl),
+            self.confidence.to_string(),
+            triage_scores_to_string(&self.triage_scores),
         )
     }
 }
@@ -304,11 +350,30 @@ pub struct CryptocurrencyMiningPoolFields {
 }
 
 impl fmt::Display for CryptocurrencyMiningPoolFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},Cryptocurrency Mining Pool,3,{}",
-            self.src_addr, self.src_port, self.dst_addr, self.dst_port, self.proto, self.query,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} session_end_time={:?} query={:?} answer={:?} trans_id={:?} rtt={:?} qclass={:?} qtype={:?} rcode={:?} aa_flag={:?} tc_flag={:?} rd_flag={:?} ra_flag={:?} ttl={:?} coins={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.session_end_time.to_rfc3339(),
+            self.query,
+            self.answer.join(","),
+            self.trans_id.to_string(),
+            self.rtt.to_string(),
+            self.qclass.to_string(),
+            self.qtype.to_string(),
+            self.rcode.to_string(),
+            self.aa_flag.to_string(),
+            self.tc_flag.to_string(),
+            self.rd_flag.to_string(),
+            self.ra_flag.to_string(),
+            vector_to_string(&self.ttl),
+            self.coins.join(","),
         )
     }
 }
@@ -339,17 +404,31 @@ pub struct CryptocurrencyMiningPool {
 }
 
 impl fmt::Display for CryptocurrencyMiningPool {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},Cryptocurrency Mining Pool,{}",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} session_end_time={:?} query={:?} answer={:?} trans_id={:?} rtt={:?} qclass={:?} qtype={:?} rcode={:?} aa_flag={:?} tc_flag={:?} rd_flag={:?} ra_flag={:?} ttl={:?} coins={:?} triage_scores={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.session_end_time.to_rfc3339(),
             self.query,
+            self.answer.join(","),
+            self.trans_id.to_string(),
+            self.rtt.to_string(),
+            self.qclass.to_string(),
+            self.qtype.to_string(),
+            self.rcode.to_string(),
+            self.aa_flag.to_string(),
+            self.tc_flag.to_string(),
+            self.rd_flag.to_string(),
+            self.ra_flag.to_string(),
+            vector_to_string(&self.ttl),
+            self.coins.join(","),
+            triage_scores_to_string(&self.triage_scores),
         )
     }
 }
@@ -454,11 +533,29 @@ pub struct BlockListDnsFields {
 }
 
 impl fmt::Display for BlockListDnsFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},BlockListDns,3,{}",
-            self.src_addr, self.src_port, self.dst_addr, self.dst_port, self.proto, self.query,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} query={:?} answer={:?} trans_id={:?} rtt={:?} qclass={:?} qtype={:?} rcode={:?} aa_flag={:?} tc_flag={:?} rd_flag={:?} ra_flag={:?} ttl={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.query,
+            self.answer.join(","),
+            self.trans_id.to_string(),
+            self.rtt.to_string(),
+            self.qclass.to_string(),
+            self.qtype.to_string(),
+            self.rcode.to_string(),
+            self.aa_flag.to_string(),
+            self.tc_flag.to_string(),
+            self.rd_flag.to_string(),
+            self.ra_flag.to_string(),
+            vector_to_string(&self.ttl),
         )
     }
 }
@@ -488,17 +585,30 @@ pub struct BlockListDns {
 }
 
 impl fmt::Display for BlockListDns {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},BlockListDns,{}",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} query={:?} answer={:?} trans_id={:?} rtt={:?} qclass={:?} qtype={:?} rcode={:?} aa_flag={:?} tc_flag={:?} rd_flag={:?} ra_flag={:?} ttl={:?} triage_scores={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
             self.query,
+            self.answer.join(","),
+            self.trans_id.to_string(),
+            self.rtt.to_string(),
+            self.qclass.to_string(),
+            self.qtype.to_string(),
+            self.rcode.to_string(),
+            self.aa_flag.to_string(),
+            self.tc_flag.to_string(),
+            self.rd_flag.to_string(),
+            self.ra_flag.to_string(),
+            vector_to_string(&self.ttl),
+            triage_scores_to_string(&self.triage_scores),
         )
     }
 }

--- a/src/event/ftp.rs
+++ b/src/event/ftp.rs
@@ -1,10 +1,11 @@
 #![allow(clippy::module_name_repetitions)]
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use crate::event::common::triage_scores_to_string;
 
 #[derive(Serialize, Deserialize)]
 pub struct FtpBruteForceFields {
@@ -19,17 +20,18 @@ pub struct FtpBruteForceFields {
 }
 
 impl fmt::Display for FtpBruteForceFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},-,{},{},{},FTP Brute Force,3,{},{},{}",
-            self.src_addr,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
-            self.start_time,
-            self.last_time,
-            self.is_internal,
+            "src_addr={:?} dst_addr={:?} dst_port={:?} proto={:?} user_list={:?} start_time={:?} last_time={:?} is_internal={:?}",
+            self.src_addr.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.user_list.join(","),
+            self.start_time.to_rfc3339(),
+            self.last_time.to_rfc3339(),
+            self.is_internal.to_string()
         )
     }
 }
@@ -48,18 +50,19 @@ pub struct FtpBruteForce {
 }
 
 impl fmt::Display for FtpBruteForce {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},-,{},{},{},FTP Brute Force,{},{},{}",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
-            self.start_time,
-            self.last_time,
-            self.is_internal
+            "src_addr={:?} dst_addr={:?} dst_port={:?} proto={:?} user_list={:?} start_time={:?} last_time={:?} is_internal={:?} triage_scores={:?}",
+            self.src_addr.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.user_list.join(","),
+            self.start_time.to_rfc3339(),
+            self.last_time.to_rfc3339(),
+            self.is_internal.to_string(),
+            triage_scores_to_string(&self.triage_scores),
         )
     }
 }
@@ -152,17 +155,29 @@ pub struct FtpPlainTextFields {
 }
 
 impl fmt::Display for FtpPlainTextFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},FTP Plain Text,3,{},{}",
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} user={:?} password={:?} command={:?} reply_code={:?} reply_msg={:?} data_passive={:?} data_orig_addr={:?} data_resp_addr={:?} data_resp_port={:?} file={:?} file_size={:?} file_id={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
             self.user,
             self.password,
+            self.command,
+            self.reply_code,
+            self.reply_msg,
+            self.data_passive.to_string(),
+            self.data_orig_addr.to_string(),
+            self.data_resp_addr.to_string(),
+            self.data_resp_port.to_string(),
+            self.file,
+            self.file_size.to_string(),
+            self.file_id,
         )
     }
 }
@@ -193,18 +208,30 @@ pub struct FtpPlainText {
 }
 
 impl fmt::Display for FtpPlainText {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},FTP Plain Text,{},{}",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} user={:?} password={:?} command={:?} reply_code={:?} reply_msg={:?} data_passive={:?} data_orig_addr={:?} data_resp_addr={:?} data_resp_port={:?} file={:?} file_size={:?} file_id={:?} triage_scores={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
             self.user,
             self.password,
+            self.command,
+            self.reply_code,
+            self.reply_msg,
+            self.data_passive.to_string(),
+            self.data_orig_addr.to_string(),
+            self.data_resp_addr.to_string(),
+            self.data_resp_port.to_string(),
+            self.file,
+            self.file_size.to_string(),
+            self.file_id,
+            triage_scores_to_string(&self.triage_scores),
         )
     }
 }
@@ -308,17 +335,29 @@ pub struct BlockListFtpFields {
 }
 
 impl fmt::Display for BlockListFtpFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},BlockListFtp,3,{},{}",
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} user={:?} password={:?} command={:?} reply_code={:?} reply_msg={:?} data_passive={:?} data_orig_addr={:?} data_resp_addr={:?} data_resp_port={:?} file={:?} file_size={:?} file_id={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
             self.user,
             self.password,
+            self.command,
+            self.reply_code,
+            self.reply_msg,
+            self.data_passive.to_string(),
+            self.data_orig_addr.to_string(),
+            self.data_resp_addr.to_string(),
+            self.data_resp_port.to_string(),
+            self.file,
+            self.file_size.to_string(),
+            self.file_id,
         )
     }
 }
@@ -349,18 +388,30 @@ pub struct BlockListFtp {
 }
 
 impl fmt::Display for BlockListFtp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},BlockListFtp,{},{}",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} user={:?} password={:?} command={:?} reply_code={:?} reply_msg={:?} data_passive={:?} data_orig_addr={:?} data_resp_addr={:?} data_resp_port={:?} file={:?} file_size={:?} file_id={:?} triage_scores={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
             self.user,
             self.password,
+            self.command,
+            self.reply_code,
+            self.reply_msg,
+            self.data_passive.to_string(),
+            self.data_orig_addr.to_string(),
+            self.data_resp_addr.to_string(),
+            self.data_resp_port.to_string(),
+            self.file,
+            self.file_size.to_string(),
+            self.file_id,
+            triage_scores_to_string(&self.triage_scores),
         )
     }
 }

--- a/src/event/kerberos.rs
+++ b/src/event/kerberos.rs
@@ -1,9 +1,10 @@
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use crate::event::common::triage_scores_to_string;
 
 #[derive(Serialize, Deserialize)]
 pub struct BlockListKerberosFields {
@@ -26,11 +27,26 @@ pub struct BlockListKerberosFields {
 }
 
 impl fmt::Display for BlockListKerberosFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},BlockListKerberos,3",
-            self.src_addr, self.src_port, self.dst_addr, self.dst_port, self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} client_time={:?} server_time={:?} error_code={:?} client_realm={:?} cname_type={:?} client_name={:?} realm={:?} sname_type={:?} service_name={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.client_time.to_string(),
+            self.server_time.to_string(),
+            self.error_code.to_string(),
+            self.client_realm,
+            self.cname_type.to_string(),
+            self.client_name.join(","),
+            self.realm,
+            self.sname_type.to_string(),
+            self.service_name.join(",")
         )
     }
 }
@@ -58,16 +74,27 @@ pub struct BlockListKerberos {
 }
 
 impl fmt::Display for BlockListKerberos {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},BlockListKerberos",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} client_time={:?} server_time={:?} error_code={:?} client_realm={:?} cname_type={:?} client_name={:?} realm={:?} sname_type={:?} service_name={:?} triage_scores={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.client_time.to_string(),
+            self.server_time.to_string(),
+            self.error_code.to_string(),
+            self.client_realm,
+            self.cname_type.to_string(),
+            self.client_name.join(","),
+            self.realm,
+            self.sname_type.to_string(),
+            self.service_name.join(","),
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }

--- a/src/event/log.rs
+++ b/src/event/log.rs
@@ -5,10 +5,11 @@ use std::{
     num::NonZeroU8,
 };
 
-use chrono::{serde::ts_nanoseconds, DateTime, Local, Utc};
+use chrono::{serde::ts_nanoseconds, DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use crate::event::common::triage_scores_to_string;
 
 #[derive(Serialize, Deserialize)]
 pub struct ExtraThreat {
@@ -25,21 +26,21 @@ pub struct ExtraThreat {
     pub confidence: f32,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
-
 impl fmt::Display for ExtraThreat {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "-,-,-,-,-,-,ExtraThreat,{},{},{},{},{},{},{},{},{}",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
+            "source={:?} service={:?} content={:?} db_name={:?} rule_id={:?} matched_to={:?} cluster_id={:?} attack_kind={:?} confidence={:?} triage_scores={:?}",
+            self.source,
             self.service,
             self.content,
             self.db_name,
-            self.rule_id,
+            self.rule_id.to_string(),
             self.matched_to,
-            self.cluster_id,
+            self.cluster_id.to_string(),
             self.attack_kind,
-            self.confidence,
+            self.confidence.to_string(),
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }

--- a/src/event/mqtt.rs
+++ b/src/event/mqtt.rs
@@ -1,9 +1,10 @@
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use crate::event::common::triage_scores_to_string;
 
 #[derive(Serialize, Deserialize)]
 pub struct BlockListMqttFields {
@@ -21,13 +22,24 @@ pub struct BlockListMqttFields {
     pub subscribe: Vec<String>,
     pub suback_reason: Vec<u8>,
 }
-
 impl fmt::Display for BlockListMqttFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},BlockListMqtt,3",
-            self.src_addr, self.src_port, self.dst_addr, self.dst_port, self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} protocol={:?} version={:?} client_id={:?} connack_reason={:?} subscribe={:?} suback_reason={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.protocol,
+            self.version.to_string(),
+            self.client_id,
+            self.connack_reason.to_string(),
+            self.subscribe.join(","),
+            String::from_utf8_lossy(&self.suback_reason)
         )
     }
 }
@@ -52,16 +64,24 @@ pub struct BlockListMqtt {
 }
 
 impl fmt::Display for BlockListMqtt {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},BlockListMqtt",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} protocol={:?} version={:?} client_id={:?} connack_reason={:?} subscribe={:?} suback_reason={:?} triage_scores={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.protocol,
+            self.version.to_string(),
+            self.client_id,
+            self.connack_reason.to_string(),
+            self.subscribe.join(","),
+            String::from_utf8_lossy(&self.suback_reason),
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }

--- a/src/event/network.rs
+++ b/src/event/network.rs
@@ -1,10 +1,11 @@
 #![allow(clippy::module_name_repetitions)]
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
-use chrono::{serde::ts_nanoseconds, DateTime, Local, Utc};
+use chrono::{serde::ts_nanoseconds, DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use crate::event::common::triage_scores_to_string;
 
 #[derive(Serialize, Deserialize)]
 pub struct NetworkThreat {
@@ -27,27 +28,27 @@ pub struct NetworkThreat {
     pub confidence: f32,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
-
 impl fmt::Display for NetworkThreat {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},NetworkThreat,{},{},{},{},{},{},{},{},{}",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.orig_addr,
-            self.orig_port,
-            self.resp_addr,
-            self.resp_port,
-            self.proto,
+            "source={:?} orig_addr={:?} orig_port={:?} resp_addr={:?} resp_port={:?} proto={:?} service={:?} last_time={:?} content={:?} db_name={:?} rule_id={:?} matched_to={:?} cluster_id={:?} attack_kind={:?} confidence={:?} triage_scores={:?}",
+            self.source,
+            self.orig_addr.to_string(),
+            self.orig_port.to_string(),
+            self.resp_addr.to_string(),
+            self.resp_port.to_string(),
+            self.proto.to_string(),
             self.service,
-            self.last_time,
+            self.last_time.to_string(),
             self.content,
             self.db_name,
-            self.rule_id,
+            self.rule_id.to_string(),
             self.matched_to,
-            self.cluster_id,
+            self.cluster_id.to_string(),
             self.attack_kind,
-            self.confidence,
+            self.confidence.to_string(),
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }

--- a/src/event/nfs.rs
+++ b/src/event/nfs.rs
@@ -1,9 +1,10 @@
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use crate::event::common::triage_scores_to_string;
 
 #[derive(Serialize, Deserialize)]
 pub struct BlockListNfsFields {
@@ -17,13 +18,20 @@ pub struct BlockListNfsFields {
     pub read_files: Vec<String>,
     pub write_files: Vec<String>,
 }
-
 impl fmt::Display for BlockListNfsFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},BlockListNfs,3",
-            self.src_addr, self.src_port, self.dst_addr, self.dst_port, self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} read_files={:?} write_files={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.read_files.join(","),
+            self.write_files.join(",")
         )
     }
 }
@@ -42,18 +50,21 @@ pub struct BlockListNfs {
     pub write_files: Vec<String>,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
-
 impl fmt::Display for BlockListNfs {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},BlockListNfs",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} read_files={:?} write_files={:?} triage_scores={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.read_files.join(","),
+            self.write_files.join(","),
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }

--- a/src/event/ntlm.rs
+++ b/src/event/ntlm.rs
@@ -1,9 +1,10 @@
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use crate::event::common::triage_scores_to_string;
 
 #[derive(Serialize, Deserialize)]
 pub struct BlockListNtlmFields {
@@ -20,17 +21,26 @@ pub struct BlockListNtlmFields {
     pub domainname: String,
     pub success: String,
 }
-
 impl fmt::Display for BlockListNtlmFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},BlockListNtlm,3",
-            self.src_addr, self.src_port, self.dst_addr, self.dst_port, self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} protocol={:?} username={:?} hostname={:?} domainname={:?} success={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.protocol,
+            self.username,
+            self.hostname,
+            self.domainname,
+            self.success
         )
     }
 }
-
 #[allow(clippy::module_name_repetitions)]
 pub struct BlockListNtlm {
     pub time: DateTime<Utc>,
@@ -48,22 +58,27 @@ pub struct BlockListNtlm {
     pub success: String,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
-
 impl fmt::Display for BlockListNtlm {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},BlockListNtlm",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} protocol={:?} username={:?} hostname={:?} domainname={:?} success={:?} triage_scores={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.protocol,
+            self.username,
+            self.hostname,
+            self.domainname,
+            self.success,
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }
-
 impl BlockListNtlm {
     pub(super) fn new(time: DateTime<Utc>, fields: BlockListNtlmFields) -> Self {
         Self {

--- a/src/event/rdp.rs
+++ b/src/event/rdp.rs
@@ -6,10 +6,14 @@ use std::{
     num::NonZeroU8,
 };
 
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use super::{
+    common::{vector_to_string, Match},
+    EventCategory, TriagePolicy, TriageScore, MEDIUM,
+};
+use crate::event::common::triage_scores_to_string;
 
 #[derive(Serialize, Deserialize)]
 pub struct RdpBruteForceFields {
@@ -19,17 +23,19 @@ pub struct RdpBruteForceFields {
     pub last_time: DateTime<Utc>,
     pub proto: u8,
 }
-
 impl fmt::Display for RdpBruteForceFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},-,-,-,{},RDP Brute Force,3,{},{}",
-            self.src_addr, self.proto, self.start_time, self.last_time,
+            "src_addr={:?} dst_addrs={:?} start_time={:?} last_time={:?} proto={:?}",
+            self.src_addr.to_string(),
+            vector_to_string(&self.dst_addrs),
+            self.start_time.to_rfc3339(),
+            self.last_time.to_rfc3339(),
+            self.proto.to_string()
         )
     }
 }
-
 pub struct RdpBruteForce {
     pub time: DateTime<Utc>,
     pub src_addr: IpAddr,
@@ -41,15 +47,16 @@ pub struct RdpBruteForce {
 }
 
 impl fmt::Display for RdpBruteForce {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},-,-,-,{},RDP Brute Force,{},{}",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.proto,
-            self.start_time,
-            self.last_time,
+            "src_addr={:?} dst_addrs={:?} start_time={:?} last_time={:?} proto={:?} triage_scores={:?}",
+            self.src_addr.to_string(),
+            vector_to_string(&self.dst_addrs),
+            self.start_time.to_rfc3339(),
+            self.last_time.to_rfc3339(),
+            self.proto.to_string(),
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }
@@ -126,17 +133,22 @@ pub struct BlockListRdpFields {
     pub last_time: i64,
     pub cookie: String,
 }
-
 impl fmt::Display for BlockListRdpFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},BlockListRdp,3",
-            self.src_addr, self.src_port, self.dst_addr, self.dst_port, self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} cookie={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.cookie
         )
     }
 }
-
 pub struct BlockListRdp {
     pub time: DateTime<Utc>,
     pub source: String,
@@ -149,18 +161,20 @@ pub struct BlockListRdp {
     pub cookie: String,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
-
 impl fmt::Display for BlockListRdp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},BlockListRdp",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} cookie={:?} triage_scores={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.cookie,
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }

--- a/src/event/smb.rs
+++ b/src/event/smb.rs
@@ -1,9 +1,10 @@
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use crate::event::common::triage_scores_to_string;
 
 #[derive(Serialize, Deserialize)]
 pub struct BlockListSmbFields {
@@ -26,13 +27,29 @@ pub struct BlockListSmbFields {
     pub write_time: i64,
     pub change_time: i64,
 }
-
 impl fmt::Display for BlockListSmbFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},BlockListSmb,3",
-            self.src_addr, self.src_port, self.dst_addr, self.dst_port, self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} command={:?} path={:?} service={:?} file_name={:?} file_size={:?} resource_type={:?} fid={:?} create_time={:?} access_time={:?} write_time={:?} change_time={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.command.to_string(),
+            self.path,
+            self.service,
+            self.file_name,
+            self.file_size.to_string(),
+            self.resource_type.to_string(),
+            self.fid.to_string(),
+            self.create_time.to_string(),
+            self.access_time.to_string(),
+            self.write_time.to_string(),
+            self.change_time.to_string()
         )
     }
 }
@@ -60,22 +77,33 @@ pub struct BlockListSmb {
     pub change_time: i64,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
-
 impl fmt::Display for BlockListSmb {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},BlockListSmb",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} command={:?} path={:?} service={:?} file_name={:?} file_size={:?} resource_type={:?} fid={:?} create_time={:?} access_time={:?} write_time={:?} change_time={:?} triage_scores={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.command.to_string(),
+            self.path,
+            self.service,
+            self.file_name,
+            self.file_size.to_string(),
+            self.resource_type.to_string(),
+            self.fid.to_string(),
+            self.create_time.to_string(),
+            self.access_time.to_string(),
+            self.write_time.to_string(),
+            self.change_time.to_string(),
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }
-
 impl BlockListSmb {
     pub(super) fn new(time: DateTime<Utc>, fields: BlockListSmbFields) -> Self {
         Self {

--- a/src/event/smtp.rs
+++ b/src/event/smtp.rs
@@ -1,9 +1,10 @@
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use crate::event::common::triage_scores_to_string;
 
 #[derive(Serialize, Deserialize)]
 pub struct BlockListSmtpFields {
@@ -24,11 +25,24 @@ pub struct BlockListSmtpFields {
 }
 
 impl fmt::Display for BlockListSmtpFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},BlockListSmtp,3",
-            self.src_addr, self.src_port, self.dst_addr, self.dst_port, self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} mailfrom={:?} date={:?} from={:?} to={:?} subject={:?} agent={:?} state={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.mailfrom,
+            self.date,
+            self.from,
+            self.to,
+            self.subject,
+            self.agent,
+            self.state
         )
     }
 }
@@ -52,18 +66,26 @@ pub struct BlockListSmtp {
     pub state: String,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
-
 impl fmt::Display for BlockListSmtp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},BlockListSmtp",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} mailfrom={:?} date={:?} from={:?} to={:?} subject={:?} agent={:?} state={:?} triage_scores={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.mailfrom,
+            self.date,
+            self.from,
+            self.to,
+            self.subject,
+            self.agent,
+            self.state,
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }

--- a/src/event/ssh.rs
+++ b/src/event/ssh.rs
@@ -1,9 +1,10 @@
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use crate::event::common::triage_scores_to_string;
 
 #[derive(Serialize, Deserialize)]
 pub struct BlockListSshFields {
@@ -28,13 +29,31 @@ pub struct BlockListSshFields {
     pub client_shka: String,
     pub server_shka: String,
 }
-
 impl fmt::Display for BlockListSshFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},BlockListSsh,3",
-            self.src_addr, self.src_port, self.dst_addr, self.dst_port, self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} client={:?} server={:?} cipher_alg={:?} mac_alg={:?} compression_alg={:?} kex_alg={:?} host_key_alg={:?} hassh_algorithms={:?} hassh={:?} hassh_server_algorithms={:?} hassh_server={:?} client_shka={:?} server_shka={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.client,
+            self.server,
+            self.cipher_alg,
+            self.mac_alg,
+            self.compression_alg,
+            self.kex_alg,
+            self.host_key_alg,
+            self.hassh_algorithms,
+            self.hassh,
+            self.hassh_server_algorithms,
+            self.hassh_server,
+            self.client_shka,
+            self.server_shka
         )
     }
 }
@@ -64,18 +83,32 @@ pub struct BlockListSsh {
     pub server_shka: String,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
-
 impl fmt::Display for BlockListSsh {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},BlockListSsh",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} client={:?} server={:?} cipher_alg={:?} mac_alg={:?} compression_alg={:?} kex_alg={:?} host_key_alg={:?} hassh_algorithms={:?} hassh={:?} hassh_server_algorithms={:?} hassh_server={:?} client_shka={:?} server_shka={:?} triage_scores={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.client,
+            self.server,
+            self.cipher_alg,
+            self.mac_alg,
+            self.compression_alg,
+            self.kex_alg,
+            self.host_key_alg,
+            self.hassh_algorithms,
+            self.hassh,
+            self.hassh_server_algorithms,
+            self.hassh_server,
+            self.client_shka,
+            self.server_shka,
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }

--- a/src/event/sysmon.rs
+++ b/src/event/sysmon.rs
@@ -5,10 +5,11 @@ use std::{
     num::NonZeroU8,
 };
 
-use chrono::{serde::ts_nanoseconds, DateTime, Local, Utc};
+use chrono::{serde::ts_nanoseconds, DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use crate::event::common::triage_scores_to_string;
 
 #[derive(Serialize, Deserialize)]
 pub struct WindowsThreat {
@@ -32,31 +33,31 @@ pub struct WindowsThreat {
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
+// image, user, content field enclosed with double quotes(\") instead of "{:?}" because they may contain escape characters
 impl fmt::Display for WindowsThreat {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "-,-,-,-,-,WindowsThreat,3,{},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
+            "source={:?} service={:?} agent_name={:?} agent_id={:?} process_guid={:?} process_id={:?} image=\"{}\" user=\"{}\" content=\"{}\" db_name={:?} rule_id={:?} matched_to={:?} cluster_id={:?} attack_kind={:?} confidence={:?} triage_scores={:?}",
             self.source,
             self.service,
             self.agent_name,
             self.agent_id,
             self.process_guid,
-            self.process_id,
+            self.process_id.to_string(),
             self.image,
             self.user,
             self.content,
             self.db_name,
-            self.rule_id,
+            self.rule_id.to_string(),
             self.matched_to,
-            self.cluster_id,
+            self.cluster_id.to_string(),
             self.attack_kind,
-            self.confidence,
+            self.confidence.to_string(),
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }
-
 // TODO: Make new Match trait for Windows threat events
 impl Match for WindowsThreat {
     fn source(&self) -> &str {

--- a/src/event/tls.rs
+++ b/src/event/tls.rs
@@ -1,9 +1,10 @@
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
-use chrono::{DateTime, Local, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use crate::event::common::{triage_scores_to_string, vector_to_string};
 
 #[derive(Serialize, Deserialize)]
 pub struct BlockListTlsFields {
@@ -36,13 +37,39 @@ pub struct BlockListTlsFields {
     pub issuer_common_name: String,
     pub last_alert: u8,
 }
-
 impl fmt::Display for BlockListTlsFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},BlockListTls,3",
-            self.src_addr, self.src_port, self.dst_addr, self.dst_port, self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} server_name={:?} alpn_protocol={:?} ja3={:?} version={:?} client_cipher_suites={:?} client_extensions={:?} cipher={:?} extensions={:?} ja3s={:?} serial={:?} subject_country={:?} subject_org_name={:?} subject_common_name={:?} validity_not_before={:?} validity_not_after={:?} subject_alt_name={:?} issuer_country={:?} issuer_org_name={:?} issuer_org_unit_name={:?} issuer_common_name={:?} last_alert={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.server_name,
+            self.alpn_protocol,
+            self.ja3,
+            self.version,
+            vector_to_string(&self.client_cipher_suites),
+            vector_to_string(&self.client_extensions),
+            self.cipher.to_string(),
+            vector_to_string(&self.extensions),
+            self.ja3s,
+            self.serial,
+            self.subject_country,
+            self.subject_org_name,
+            self.subject_common_name,
+            self.validity_not_before.to_string(),
+            self.validity_not_after.to_string(),
+            self.subject_alt_name,
+            self.issuer_country,
+            self.issuer_org_name,
+            self.issuer_org_unit_name,
+            self.issuer_common_name,
+            self.last_alert.to_string()
         )
     }
 }
@@ -80,18 +107,40 @@ pub struct BlockListTls {
     pub last_alert: u8,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
-
 impl fmt::Display for BlockListTls {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},BlockListTls",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} server_name={:?} alpn_protocol={:?} ja3={:?} version={:?} client_cipher_suites={:?} client_extensions={:?} cipher={:?} extensions={:?} ja3s={:?} serial={:?} subject_country={:?} subject_org_name={:?} subject_common_name={:?} validity_not_before={:?} validity_not_after={:?} subject_alt_name={:?} issuer_country={:?} issuer_org_name={:?} issuer_org_unit_name={:?} issuer_common_name={:?} last_alert={:?} triage_scores={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.server_name,
+            self.alpn_protocol,
+            self.ja3,
+            self.version,
+            vector_to_string(&self.client_cipher_suites),
+            vector_to_string(&self.client_extensions),
+            self.cipher.to_string(),
+            vector_to_string(&self.extensions),
+            self.ja3s,
+            self.serial,
+            self.subject_country,
+            self.subject_org_name,
+            self.subject_common_name,
+            self.validity_not_before.to_string(),
+            self.validity_not_after.to_string(),
+            self.subject_alt_name,
+            self.issuer_country,
+            self.issuer_org_name,
+            self.issuer_org_unit_name,
+            self.issuer_common_name,
+            self.last_alert.to_string(),
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }

--- a/src/event/tor.rs
+++ b/src/event/tor.rs
@@ -1,9 +1,10 @@
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
-use chrono::{serde::ts_nanoseconds, DateTime, Local, Utc};
+use chrono::{serde::ts_nanoseconds, DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use crate::event::common::triage_scores_to_string;
 
 #[derive(Deserialize, Serialize)]
 #[allow(clippy::module_name_repetitions)]
@@ -33,13 +34,34 @@ pub struct TorConnectionFields {
     pub content_type: String,
     pub cache_control: String,
 }
-
 impl fmt::Display for TorConnectionFields {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},Tor Exit Nodes,3",
-            self.src_addr, self.src_port, self.dst_addr, self.dst_port, self.proto
+            "source={:?} session_end_time={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} method={:?} host={:?} uri={:?} referrer={:?} version={:?} user_agent={:?} request_len={:?} response_len={:?} status_code={:?} status_msg={:?} username={:?} password={:?} cookie={:?} content_encoding={:?} content_type={:?} cache_control={:?}",
+            self.source,
+            self.session_end_time.to_rfc3339(),
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.method,
+            self.host,
+            self.uri,
+            self.referrer,
+            self.version,
+            self.user_agent,
+            self.request_len.to_string(),
+            self.response_len.to_string(),
+            self.status_code.to_string(),
+            self.status_msg,
+            self.username,
+            self.password,
+            self.cookie,
+            self.content_encoding,
+            self.content_type,
+            self.cache_control
         )
     }
 }
@@ -72,22 +94,38 @@ pub struct TorConnection {
     pub cache_control: String,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
-
 impl fmt::Display for TorConnection {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{},{},{},{},{},{},Tor Exit Nodes",
-            DateTime::<Local>::from(self.time).format("%Y-%m-%d %H:%M:%S"),
-            self.src_addr,
-            self.src_port,
-            self.dst_addr,
-            self.dst_port,
-            self.proto
+            "source={:?} session_end_time={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} method={:?} host={:?} uri={:?} referrer={:?} version={:?} user_agent={:?} request_len={:?} response_len={:?} status_code={:?} status_msg={:?} username={:?} password={:?} cookie={:?} content_encoding={:?} content_type={:?} cache_control={:?} triage_scores={:?}",
+            self.source,
+            self.session_end_time.to_rfc3339(),
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.method,
+            self.host,
+            self.uri,
+            self.referrer,
+            self.version,
+            self.user_agent,
+            self.request_len.to_string(),
+            self.response_len.to_string(),
+            self.status_code.to_string(),
+            self.status_msg,
+            self.username,
+            self.password,
+            self.cookie,
+            self.content_encoding,
+            self.content_type,
+            self.cache_control,
+            triage_scores_to_string(&self.triage_scores)
         )
     }
 }
-
 impl TorConnection {
     pub(super) fn new(time: DateTime<Utc>, fields: &TorConnectionFields) -> Self {
         TorConnection {


### PR DESCRIPTION
Close #274 

Modify the display message format of `Event` and `EventMessage` structure.
The modified messages will be sent to syslog according to RFC5424.