### PR TITLE
Add `language` field in `Account` struct to represent user's language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   `Node::giganto`.
 - Added `Account::password_last_modified_at` field to track the timestamp of the
   last password modification.
+- Added `Account::language` field to represent user's selected language on the
+  user interface.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.29.0-alpha.7"
+version = "0.29.0-alpha.8"
 edition = "2021"
 
 [dependencies]

--- a/src/account.rs
+++ b/src/account.rs
@@ -35,6 +35,7 @@ pub struct Account {
     pub role: Role,
     pub name: String,
     pub department: String,
+    pub language: Option<String>,
     pub(crate) creation_time: DateTime<Utc>,
     pub(crate) last_signin_time: Option<DateTime<Utc>>,
     pub allow_access_from: Option<Vec<IpAddr>>,
@@ -51,12 +52,14 @@ impl Account {
     /// # Errors
     ///
     /// Returns an error if account creation fails.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         username: &str,
         password: &str,
         role: Role,
         name: String,
         department: String,
+        language: Option<String>,
         allow_access_from: Option<Vec<IpAddr>>,
         max_parallel_sessions: Option<u32>,
     ) -> Result<Self> {
@@ -69,6 +72,7 @@ impl Account {
             role,
             name,
             department,
+            language,
             creation_time: now,
             last_signin_time: None,
             allow_access_from,
@@ -283,6 +287,7 @@ mod tests {
             String::new(),
             None,
             None,
+            None,
         );
         assert!(account.is_ok());
 
@@ -298,7 +303,7 @@ mod tests {
     }
 
     #[test]
-    fn account_passowrd_update() {
+    fn account_password_update() {
         let mut account = Account {
             username: "test".to_string(),
             password: SaltedPassword::new_with_hash_algorithm(
@@ -309,6 +314,7 @@ mod tests {
             role: Role::SecurityAdministrator,
             department: String::new(),
             name: String::new(),
+            language: None,
             creation_time: Utc::now(),
             last_signin_time: None,
             allow_access_from: None,

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -38,7 +38,7 @@ use crate::{Agent, AgentStatus, Giganto, Indexed, IterableMap};
 /// // the database format won't be changed in the future alpha or beta versions.
 /// const COMPATIBLE_VERSION: &str = ">=0.5.0-alpha.2,<=0.5.0-alpha.4";
 /// ```
-const COMPATIBLE_VERSION_REQ: &str = ">=0.29.0-alpha.7,<=0.29.0-alpha.7";
+const COMPATIBLE_VERSION_REQ: &str = ">=0.29.0-alpha.8,<=0.29.0-alpha.8";
 
 /// Migrates data exists in `PostgresQL` to Rocksdb if necessary.
 ///
@@ -769,6 +769,7 @@ fn migrate_0_29_account(store: &super::Store) -> Result<()> {
                 role: input.role,
                 name: input.name,
                 department: input.department,
+                language: None,
                 creation_time: input.creation_time,
                 last_signin_time: input.last_signin_time,
                 allow_access_from: input.allow_access_from,
@@ -2225,6 +2226,7 @@ mod tests {
                     role: input.role,
                     name: input.name,
                     department: input.department,
+                    language: None,
                     creation_time: input.creation_time,
                     last_signin_time: input.last_signin_time,
                     allow_access_from: input.allow_access_from,
@@ -2262,6 +2264,7 @@ mod tests {
             Role::SecurityAdministrator,
             "name".to_string(),
             "department".to_string(),
+            None,
             None,
             None,
         )

--- a/src/tables/accounts.rs
+++ b/src/tables/accounts.rs
@@ -169,6 +169,7 @@ mod tests {
             "Department 1".to_string(),
             None,
             None,
+            None,
         )
         .unwrap();
         table.put(&acc1).unwrap();
@@ -180,6 +181,7 @@ mod tests {
             Role::SystemAdministrator,
             "User 2".to_string(),
             "Department 2".to_string(),
+            None,
             None,
             None,
         )
@@ -211,6 +213,7 @@ mod tests {
             "Department 1".to_string(),
             None,
             None,
+            None,
         )
         .unwrap();
         table.put(&acc1).unwrap();
@@ -226,6 +229,7 @@ mod tests {
             Role::SystemAdministrator,
             "User 2".to_string(),
             "Department 2".to_string(),
+            None,
             None,
             None,
         )


### PR DESCRIPTION
Resolve #308 

It's not related to this PR, but there's one line that I've corrected because I found a typo (`passowrd` -> `password`).
Please review if this is the right way to work on adding `language` field to `Account`. @sehkone @sophie-cluml 