### PR TITLE
Add a language update code into the account table update function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Modified codes related to the user's language settings to the account update
+  function
+
 ## [0.29.1] - 2024-08-05
 
 ### Fixed
@@ -611,6 +618,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Modified `FtpBruteForce` by adding an `is_internal` field which is a boolean
   indicating whether it is internal or not.
 
+[Unreleased]: https://github.com/petabi/review-database/compare/0.29.1...main
 [0.29.1]: https://github.com/petabi/review-database/compare/0.29.0...0.29.1
 [0.29.0]: https://github.com/petabi/review-database/compare/0.28.0...0.29.0
 [0.28.0]: https://github.com/petabi/review-database/compare/0.27.1...0.28.0

--- a/src/tables/accounts.rs
+++ b/src/tables/accounts.rs
@@ -76,6 +76,7 @@ impl<'d> Table<'d, Account> {
         role: Option<(Role, Role)>,
         name: &Option<(String, String)>,
         department: &Option<(String, String)>,
+        language: &Option<(Option<String>, Option<String>)>,
         allow_access_from: &Option<(Option<Vec<IpAddr>>, Option<Vec<IpAddr>>)>,
         max_parallel_sessions: &Option<(Option<u32>, Option<u32>)>,
     ) -> Result<(), anyhow::Error> {
@@ -109,6 +110,12 @@ impl<'d> Table<'d, Account> {
                         bail!("old value mismatch");
                     }
                     account.department.clone_from(new);
+                }
+                if let Some((old, new)) = language {
+                    if account.language != *old {
+                        bail!("old value mismatch");
+                    }
+                    account.language.clone_from(new);
                 }
                 if let Some((old, new)) = &allow_access_from {
                     if account.allow_access_from != *old {


### PR DESCRIPTION
Close: #318 

As I mentioned in the issue, a `language` field was added to the `Account` structure, but the function updating the account did not reflect this. To solve this problem, the following code modification was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new language preference setting for account management, allowing users to specify and manage their language preferences.
	- Enhanced validation ensures consistency when updating language settings for accounts.

- **Chores**
	- Updated versioning to indicate pre-release status (0.29.1-alpha) in the package management file.
	- Enhanced changelog to reflect new features and improve clarity for users and developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->