### PR TITLE
Insert category field to TI db and TI rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Extended the `Table<'d, Account>::update` method signature to include the
   `language` parameter, enabling language updates alongside existing fields.
+- Added `category` field to TI db and TI rules.
 
 ## [0.29.1] - 2024-08-05
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.29.1"
+version = "0.30.0-alpha.1"
 edition = "2021"
 
 [dependencies]
@@ -32,7 +32,10 @@ postgres-protocol = "0.6"
 rand = "0.8"
 ring = { version = "0.17", features = ["std"] }
 rocksdb = "0.22"
-rustls = { version = "0.23", default-features = false, features = ["ring", "std"] } # should be the same version as what tokio-postgres-rustls depends on
+rustls = { version = "0.23", default-features = false, features = [
+  "ring",
+  "std",
+] } # should be the same version as what tokio-postgres-rustls depends on
 rustls-native-certs = "0.7"
 rustls-pemfile = "2"
 rustls-pki-types = "1"

--- a/src/tables/tidb.rs
+++ b/src/tables/tidb.rs
@@ -8,7 +8,7 @@ use flate2::read::GzDecoder;
 use rocksdb::{Direction, OptimisticTransactionDB};
 use serde::{Deserialize, Serialize};
 
-use crate::{types::FromKeyValue, Iterable, Map, Table, UniqueKey};
+use crate::{types::FromKeyValue, EventCategory, Iterable, Map, Table, UniqueKey};
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct Tidb {
@@ -16,6 +16,7 @@ pub struct Tidb {
     pub name: String,
     pub description: Option<String>,
     pub kind: Kind,
+    pub category: EventCategory,
     pub version: String,
     pub patterns: Vec<Rule>,
 }
@@ -64,6 +65,7 @@ impl Tidb {
 #[derive(Clone, Deserialize, Serialize)]
 pub struct Rule {
     pub rule_id: u32,
+    pub category: EventCategory,
     pub name: String,
     pub description: Option<String>,
     pub references: Option<Vec<String>>,
@@ -206,6 +208,10 @@ impl<'d> Table<'d, Tidb> {
     pub fn remove(&self, name: &str) -> Result<()> {
         self.map.delete(name.as_bytes())
     }
+
+    pub(crate) fn raw(&self) -> &Map<'_> {
+        &self.map
+    }
 }
 
 #[cfg(test)]
@@ -281,6 +287,7 @@ mod tests {
             name: name.to_string(),
             description: None,
             kind: super::Kind::Regex,
+            category: crate::EventCategory::Reconnaissance,
             version: "1".to_string(),
             patterns: vec![],
         }


### PR DESCRIPTION
Related #315 

I am dividing PR #316 into smaller pieces.
- Add `category` field to TI db and rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for language updates in account records.
  - Introduced a new `category` field to enhance data organization and management.

- **Improvements**
  - Enhanced migration capabilities for transitioning from older database structures.
  - Improved access to internal data structures for better data handling.

- **Versioning**
  - Updated package version to 0.30.0-alpha.1, reflecting a major version change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->