### PR TITLE
Add category field to all the detected event structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Extended the `Table<'d, Account>::update` method signature to include the
   `language` parameter, enabling language updates alongside existing fields.
-- Added `category` field to TI db and TI rules.
+- Added `category` field to all the detected event structures.
+- Modified all the detected events to use its own category field value
+  instead of statically assigned values.
+- Added fields to some detected event structures
+  - `BlockListConn`: `orig_l2_bytes`, `resp_l2_bytes`
+  - `TorConnection`: `orig_filenames`, `orig_mime_types`, `resp_filenames`,
+    `resp_mime_types`, `post_body`, `state`
 - Added `update` method in `TrustedDomain`.
 
 ### Removed

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -103,6 +103,7 @@ mod tests {
             ra_flag: false,
             ttl: vec![1; 5],
             confidence: 0.8,
+            category: crate::EventCategory::CommandAndControl,
         };
         EventMessage {
             time: Utc::now(),

--- a/src/event/bootp.rs
+++ b/src/event/bootp.rs
@@ -4,10 +4,10 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
-use crate::event::common::triage_scores_to_string;
+use crate::event::common::{to_hardware_address, triage_scores_to_string};
 
 #[derive(Serialize, Deserialize)]
-pub struct BlockListNtlmFields {
+pub struct BlockListBootpFields {
     pub source: String,
     pub src_addr: IpAddr,
     pub src_port: u16,
@@ -15,18 +15,24 @@ pub struct BlockListNtlmFields {
     pub dst_port: u16,
     pub proto: u8,
     pub last_time: i64,
-    pub protocol: String,
-    pub username: String,
-    pub hostname: String,
-    pub domainname: String,
-    pub success: String,
+    pub op: u8,
+    pub htype: u8,
+    pub hops: u8,
+    pub xid: u32,
+    pub ciaddr: IpAddr,
+    pub yiaddr: IpAddr,
+    pub siaddr: IpAddr,
+    pub giaddr: IpAddr,
+    pub chaddr: Vec<u8>,
+    pub sname: String,
+    pub file: String,
     pub category: EventCategory,
 }
-impl fmt::Display for BlockListNtlmFields {
+impl fmt::Display for BlockListBootpFields {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} protocol={:?} username={:?} hostname={:?} domainname={:?} success={:?}",
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} op={:?} htype={:?} hops={:?} xid={:?} ciaddr={:?} yiaddr={:?} siaddr={:?} giaddr={:?} chaddr={:?} sname={:?} file={:?}",
             self.source,
             self.src_addr.to_string(),
             self.src_port.to_string(),
@@ -34,16 +40,23 @@ impl fmt::Display for BlockListNtlmFields {
             self.dst_port.to_string(),
             self.proto.to_string(),
             self.last_time.to_string(),
-            self.protocol,
-            self.username,
-            self.hostname,
-            self.domainname,
-            self.success
+            self.op.to_string(),
+            self.htype.to_string(),
+            self.hops.to_string(),
+            self.xid.to_string(),
+            self.ciaddr.to_string(),
+            self.yiaddr.to_string(),
+            self.siaddr.to_string(),
+            self.giaddr.to_string(),
+            to_hardware_address(&self.chaddr),
+            self.sname.to_string(),
+            self.file.to_string(),
         )
     }
 }
+
 #[allow(clippy::module_name_repetitions)]
-pub struct BlockListNtlm {
+pub struct BlockListBootp {
     pub time: DateTime<Utc>,
     pub source: String,
     pub src_addr: IpAddr,
@@ -52,19 +65,25 @@ pub struct BlockListNtlm {
     pub dst_port: u16,
     pub proto: u8,
     pub last_time: i64,
-    pub protocol: String,
-    pub username: String,
-    pub hostname: String,
-    pub domainname: String,
-    pub success: String,
+    pub op: u8,
+    pub htype: u8,
+    pub hops: u8,
+    pub xid: u32,
+    pub ciaddr: IpAddr,
+    pub yiaddr: IpAddr,
+    pub siaddr: IpAddr,
+    pub giaddr: IpAddr,
+    pub chaddr: Vec<u8>,
+    pub sname: String,
+    pub file: String,
     pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
-impl fmt::Display for BlockListNtlm {
+impl fmt::Display for BlockListBootp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} protocol={:?} username={:?} hostname={:?} domainname={:?} success={:?} triage_scores={:?}",
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} op={:?} htype={:?} hops={:?} xid={:?} ciaddr={:?} yiaddr={:?} siaddr={:?} giaddr={:?} chaddr={:?} sname={:?} file={:?} triage_scores={:?}",
             self.source,
             self.src_addr.to_string(),
             self.src_port.to_string(),
@@ -72,17 +91,24 @@ impl fmt::Display for BlockListNtlm {
             self.dst_port.to_string(),
             self.proto.to_string(),
             self.last_time.to_string(),
-            self.protocol,
-            self.username,
-            self.hostname,
-            self.domainname,
-            self.success,
+            self.op.to_string(),
+            self.htype.to_string(),
+            self.hops.to_string(),
+            self.xid.to_string(),
+            self.ciaddr.to_string(),
+            self.yiaddr.to_string(),
+            self.siaddr.to_string(),
+            self.giaddr.to_string(),
+            to_hardware_address(&self.chaddr),
+            self.sname.to_string(),
+            self.file.to_string(),
             triage_scores_to_string(&self.triage_scores)
         )
     }
 }
-impl BlockListNtlm {
-    pub(super) fn new(time: DateTime<Utc>, fields: BlockListNtlmFields) -> Self {
+
+impl BlockListBootp {
+    pub(super) fn new(time: DateTime<Utc>, fields: BlockListBootpFields) -> Self {
         Self {
             time,
             source: fields.source,
@@ -92,18 +118,24 @@ impl BlockListNtlm {
             dst_port: fields.dst_port,
             proto: fields.proto,
             last_time: fields.last_time,
-            protocol: fields.protocol,
-            username: fields.username,
-            hostname: fields.hostname,
-            domainname: fields.domainname,
-            success: fields.success,
+            op: fields.op,
+            htype: fields.htype,
+            hops: fields.hops,
+            xid: fields.xid,
+            ciaddr: fields.ciaddr,
+            yiaddr: fields.yiaddr,
+            siaddr: fields.siaddr,
+            giaddr: fields.giaddr,
+            chaddr: fields.chaddr,
+            sname: fields.sname,
+            file: fields.file,
             category: fields.category,
             triage_scores: None,
         }
     }
 }
 
-impl Match for BlockListNtlm {
+impl Match for BlockListBootp {
     fn src_addr(&self) -> IpAddr {
         self.src_addr
     }
@@ -133,7 +165,7 @@ impl Match for BlockListNtlm {
     }
 
     fn kind(&self) -> &str {
-        "block list ntlm"
+        "block list bootp"
     }
 
     fn source(&self) -> &str {

--- a/src/event/conn.rs
+++ b/src/event/conn.rs
@@ -18,6 +18,7 @@ pub struct PortScanFields {
     pub start_time: DateTime<Utc>,
     pub last_time: DateTime<Utc>,
     pub proto: u8,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for PortScanFields {
@@ -30,7 +31,7 @@ impl fmt::Display for PortScanFields {
             vector_to_string(&self.dst_ports),
             self.start_time.to_rfc3339(),
             self.last_time.to_rfc3339(),
-            self.proto.to_string()
+            self.proto.to_string(),
         )
     }
 }
@@ -44,6 +45,7 @@ pub struct PortScan {
     pub start_time: DateTime<Utc>,
     pub last_time: DateTime<Utc>,
     pub proto: u8,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -73,6 +75,7 @@ impl PortScan {
             proto: fields.proto,
             start_time: fields.start_time,
             last_time: fields.last_time,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -100,7 +103,7 @@ impl Match for PortScan {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::Reconnaissance
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -120,7 +123,6 @@ impl Match for PortScan {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }
@@ -133,6 +135,7 @@ pub struct MultiHostPortScanFields {
     pub proto: u8,
     pub start_time: DateTime<Utc>,
     pub last_time: DateTime<Utc>,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for MultiHostPortScanFields {
@@ -145,7 +148,7 @@ impl fmt::Display for MultiHostPortScanFields {
             self.dst_port.to_string(),
             self.proto.to_string(),
             self.start_time.to_rfc3339(),
-            self.last_time.to_rfc3339()
+            self.last_time.to_rfc3339(),
         )
     }
 }
@@ -159,6 +162,7 @@ pub struct MultiHostPortScan {
     pub proto: u8,
     pub start_time: DateTime<Utc>,
     pub last_time: DateTime<Utc>,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -188,6 +192,7 @@ impl MultiHostPortScan {
             proto: fields.proto,
             start_time: fields.start_time,
             last_time: fields.last_time,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -215,7 +220,7 @@ impl Match for MultiHostPortScan {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::Reconnaissance
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -235,7 +240,6 @@ impl Match for MultiHostPortScan {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }
@@ -247,6 +251,7 @@ pub struct ExternalDdosFields {
     pub proto: u8,
     pub start_time: DateTime<Utc>,
     pub last_time: DateTime<Utc>,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for ExternalDdosFields {
@@ -258,7 +263,7 @@ impl fmt::Display for ExternalDdosFields {
             self.dst_addr.to_string(),
             self.proto.to_string(),
             self.start_time.to_rfc3339(),
-            self.last_time.to_rfc3339()
+            self.last_time.to_rfc3339(),
         )
     }
 }
@@ -271,6 +276,7 @@ pub struct ExternalDdos {
     pub proto: u8,
     pub start_time: DateTime<Utc>,
     pub last_time: DateTime<Utc>,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -298,6 +304,7 @@ impl ExternalDdos {
             proto: fields.proto,
             start_time: fields.start_time,
             last_time: fields.last_time,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -325,7 +332,7 @@ impl Match for ExternalDdos {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::Impact
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -345,7 +352,6 @@ impl Match for ExternalDdos {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }
@@ -365,13 +371,16 @@ pub struct BlockListConnFields {
     pub resp_bytes: u64,
     pub orig_pkts: u64,
     pub resp_pkts: u64,
+    pub orig_l2_bytes: u64,
+    pub resp_l2_bytes: u64,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for BlockListConnFields {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} conn_state={:?} duration={:?} service={:?} orig_bytes={:?} resp_bytes={:?} orig_pkts={:?} resp_pkts={:?}",
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} conn_state={:?} duration={:?} service={:?} orig_bytes={:?} resp_bytes={:?} orig_pkts={:?} resp_pkts={:?} orig_l2_bytes={:?} resp_l2_bytes={:?}",
             self.source,
             self.src_addr.to_string(),
             self.src_port.to_string(),
@@ -384,7 +393,9 @@ impl fmt::Display for BlockListConnFields {
             self.orig_bytes.to_string(),
             self.resp_bytes.to_string(),
             self.orig_pkts.to_string(),
-            self.resp_pkts.to_string()
+            self.resp_pkts.to_string(),
+            self.orig_l2_bytes.to_string(),
+            self.resp_l2_bytes.to_string(),
         )
     }
 }
@@ -405,6 +416,9 @@ pub struct BlockListConn {
     pub resp_bytes: u64,
     pub orig_pkts: u64,
     pub resp_pkts: u64,
+    pub orig_l2_bytes: u64,
+    pub resp_l2_bytes: u64,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -412,7 +426,7 @@ impl fmt::Display for BlockListConn {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} conn_state={:?} duration={:?} service={:?} orig_bytes={:?} resp_bytes={:?} orig_pkts={:?} resp_pkts={:?} triage_scores={:?}",
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} conn_state={:?} duration={:?} service={:?} orig_bytes={:?} resp_bytes={:?} orig_pkts={:?} resp_pkts={:?} orig_l2_bytes={:?} resp_l2_bytes={:?} triage_scores={:?}",
             self.source,
             self.src_addr.to_string(),
             self.src_port.to_string(),
@@ -426,6 +440,8 @@ impl fmt::Display for BlockListConn {
             self.resp_bytes.to_string(),
             self.orig_pkts.to_string(),
             self.resp_pkts.to_string(),
+            self.orig_l2_bytes.to_string(),
+            self.resp_l2_bytes.to_string(),
             triage_scores_to_string(&self.triage_scores)
         )
     }
@@ -448,6 +464,9 @@ impl BlockListConn {
             resp_bytes: fields.resp_bytes,
             orig_pkts: fields.orig_pkts,
             resp_pkts: fields.resp_pkts,
+            orig_l2_bytes: fields.orig_l2_bytes,
+            resp_l2_bytes: fields.resp_l2_bytes,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -475,7 +494,7 @@ impl Match for BlockListConn {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::InitialAccess
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -495,7 +514,6 @@ impl Match for BlockListConn {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/event/dcerpc.rs
+++ b/src/event/dcerpc.rs
@@ -19,6 +19,7 @@ pub struct BlockListDceRpcFields {
     pub named_pipe: String,
     pub endpoint: String,
     pub operation: String,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for BlockListDceRpcFields {
@@ -54,6 +55,7 @@ pub struct BlockListDceRpc {
     pub named_pipe: String,
     pub endpoint: String,
     pub operation: String,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -93,6 +95,7 @@ impl BlockListDceRpc {
             named_pipe: fields.named_pipe,
             endpoint: fields.endpoint,
             operation: fields.operation,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -120,7 +123,7 @@ impl Match for BlockListDceRpc {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::InitialAccess
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -140,7 +143,6 @@ impl Match for BlockListDceRpc {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/event/dhcp.rs
+++ b/src/event/dhcp.rs
@@ -1,0 +1,223 @@
+use std::{fmt, net::IpAddr, num::NonZeroU8};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::{common::Match, EventCategory, TriagePolicy, TriageScore, MEDIUM};
+use crate::event::common::{to_hardware_address, triage_scores_to_string, vector_to_string};
+
+#[derive(Serialize, Deserialize)]
+pub struct BlockListDhcpFields {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub msg_type: u8,
+    pub ciaddr: IpAddr,
+    pub yiaddr: IpAddr,
+    pub siaddr: IpAddr,
+    pub giaddr: IpAddr,
+    pub subnet_mask: IpAddr,
+    pub router: Vec<IpAddr>,
+    pub domain_name_server: Vec<IpAddr>,
+    pub req_ip_addr: IpAddr,
+    pub lease_time: u32,
+    pub server_id: IpAddr,
+    pub param_req_list: Vec<u8>,
+    pub message: String,
+    pub renewal_time: u32,
+    pub rebinding_time: u32,
+    pub class_id: Vec<u8>,
+    pub client_id_type: u8,
+    pub client_id: Vec<u8>,
+    pub category: EventCategory,
+}
+
+// TODO: DHCP client identifier type.
+//  - 00: Ascii string (need to support)
+//  - 01: MAC address
+//  - XX: Hexdecimal number
+
+impl fmt::Display for BlockListDhcpFields {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} msg_type={:?} ciaddr={:?} yiaddr={:?} siaddr={:?} giaddr={:?} subnet_mask={:?} router={:?} domain_name_server={:?} req_ip_addr={:?} lease_time={:?} server_id={:?} param_req_list={:?} message={:?} renewal_time={:?} rebinding_time={:?} class_id={:?} client_id_type={:?} client_id={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.msg_type.to_string(),
+            self.ciaddr.to_string(),
+            self.yiaddr.to_string(),
+            self.siaddr.to_string(),
+            self.giaddr.to_string(),
+            self.subnet_mask.to_string(),
+            vector_to_string(&self.router),
+            vector_to_string(&self.domain_name_server),
+            self.req_ip_addr.to_string(),
+            self.lease_time.to_string(),
+            self.server_id.to_string(),
+            vector_to_string(&self.param_req_list),
+            self.message.to_string(),
+            self.renewal_time.to_string(),
+            self.rebinding_time.to_string(),
+            to_hardware_address(&self.class_id),
+            self.client_id_type.to_string(),
+            to_hardware_address(&self.client_id),
+        )
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct BlockListDhcp {
+    pub time: DateTime<Utc>,
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub msg_type: u8,
+    pub ciaddr: IpAddr,
+    pub yiaddr: IpAddr,
+    pub siaddr: IpAddr,
+    pub giaddr: IpAddr,
+    pub subnet_mask: IpAddr,
+    pub router: Vec<IpAddr>,
+    pub domain_name_server: Vec<IpAddr>,
+    pub req_ip_addr: IpAddr,
+    pub lease_time: u32,
+    pub server_id: IpAddr,
+    pub param_req_list: Vec<u8>,
+    pub message: String,
+    pub renewal_time: u32,
+    pub rebinding_time: u32,
+    pub class_id: Vec<u8>,
+    pub client_id_type: u8,
+    pub client_id: Vec<u8>,
+    pub category: EventCategory,
+    pub triage_scores: Option<Vec<TriageScore>>,
+}
+impl fmt::Display for BlockListDhcp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "source={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} msg_type={:?} ciaddr={:?} yiaddr={:?} siaddr={:?} giaddr={:?} subnet_mask={:?} router={:?} domain_name_server={:?} req_ip_addr={:?} lease_time={:?} server_id={:?} param_req_list={:?} message={:?} renewal_time={:?} rebinding_time={:?} class_id={:?} client_id_type={:?} client_id={:?} triage_scores={:?}",
+            self.source,
+            self.src_addr.to_string(),
+            self.src_port.to_string(),
+            self.dst_addr.to_string(),
+            self.dst_port.to_string(),
+            self.proto.to_string(),
+            self.last_time.to_string(),
+            self.msg_type.to_string(),
+            self.ciaddr.to_string(),
+            self.yiaddr.to_string(),
+            self.siaddr.to_string(),
+            self.giaddr.to_string(),
+            self.subnet_mask.to_string(),
+            vector_to_string(&self.router),
+            vector_to_string(&self.domain_name_server),
+            self.req_ip_addr.to_string(),
+            self.lease_time.to_string(),
+            self.server_id.to_string(),
+            vector_to_string(&self.param_req_list),
+            self.message.to_string(),
+            self.renewal_time.to_string(),
+            self.rebinding_time.to_string(),
+            to_hardware_address(&self.class_id),
+            self.client_id_type.to_string(),
+            to_hardware_address(&self.client_id),
+            triage_scores_to_string(&self.triage_scores)
+        )
+    }
+}
+
+impl BlockListDhcp {
+    pub(super) fn new(time: DateTime<Utc>, fields: BlockListDhcpFields) -> Self {
+        Self {
+            time,
+            source: fields.source,
+            src_addr: fields.src_addr,
+            src_port: fields.src_port,
+            dst_addr: fields.dst_addr,
+            dst_port: fields.dst_port,
+            proto: fields.proto,
+            last_time: fields.last_time,
+            msg_type: fields.msg_type,
+            ciaddr: fields.ciaddr,
+            yiaddr: fields.yiaddr,
+            siaddr: fields.siaddr,
+            giaddr: fields.giaddr,
+            subnet_mask: fields.subnet_mask,
+            router: fields.router,
+            domain_name_server: fields.domain_name_server,
+            req_ip_addr: fields.req_ip_addr,
+            lease_time: fields.lease_time,
+            server_id: fields.server_id,
+            param_req_list: fields.param_req_list,
+            message: fields.message,
+            renewal_time: fields.renewal_time,
+            rebinding_time: fields.rebinding_time,
+            class_id: fields.class_id,
+            client_id_type: fields.client_id_type,
+            client_id: fields.client_id,
+            category: fields.category,
+            triage_scores: None,
+        }
+    }
+}
+
+impl Match for BlockListDhcp {
+    fn src_addr(&self) -> IpAddr {
+        self.src_addr
+    }
+
+    fn src_port(&self) -> u16 {
+        self.src_port
+    }
+
+    fn dst_addr(&self) -> IpAddr {
+        self.dst_addr
+    }
+
+    fn dst_port(&self) -> u16 {
+        self.dst_port
+    }
+
+    fn proto(&self) -> u8 {
+        self.proto
+    }
+
+    fn category(&self) -> EventCategory {
+        self.category
+    }
+
+    fn level(&self) -> NonZeroU8 {
+        MEDIUM
+    }
+
+    fn kind(&self) -> &str {
+        "block list dhcp"
+    }
+
+    fn source(&self) -> &str {
+        self.source.as_str()
+    }
+
+    fn confidence(&self) -> Option<f32> {
+        None
+    }
+
+    fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
+        0.0
+    }
+}

--- a/src/event/dns.rs
+++ b/src/event/dns.rs
@@ -30,6 +30,7 @@ pub struct DnsEventFields {
     pub ra_flag: bool,
     pub ttl: Vec<i32>,
     pub confidence: f32,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for DnsEventFields {
@@ -83,6 +84,7 @@ pub struct DnsCovertChannel {
     pub ra_flag: bool,
     pub ttl: Vec<i32>,
     pub confidence: f32,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -140,6 +142,7 @@ impl DnsCovertChannel {
             ra_flag: fields.ra_flag,
             ttl: fields.ttl,
             confidence: fields.confidence,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -167,7 +170,7 @@ impl Match for DnsCovertChannel {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::CommandAndControl
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -187,12 +190,11 @@ impl Match for DnsCovertChannel {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }
 
-// TODO: Locky ransomware event uses same sruct with DnsCovertChannel. It should be merged.
+// TODO: Locky ransomware event uses same sruct with DnsCovertChannel. It can be merged.
 pub struct LockyRansomware {
     pub time: DateTime<Utc>,
     pub source: String,
@@ -215,6 +217,7 @@ pub struct LockyRansomware {
     pub ra_flag: bool,
     pub ttl: Vec<i32>,
     pub confidence: f32,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -272,6 +275,7 @@ impl LockyRansomware {
             ra_flag: fields.ra_flag,
             ttl: fields.ttl,
             confidence: fields.confidence,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -299,7 +303,7 @@ impl Match for LockyRansomware {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::Impact
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -319,7 +323,6 @@ impl Match for LockyRansomware {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }
@@ -347,6 +350,7 @@ pub struct CryptocurrencyMiningPoolFields {
     pub ra_flag: bool,
     pub ttl: Vec<i32>,
     pub coins: Vec<String>,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for CryptocurrencyMiningPoolFields {
@@ -400,6 +404,7 @@ pub struct CryptocurrencyMiningPool {
     pub ra_flag: bool,
     pub ttl: Vec<i32>,
     pub coins: Vec<String>,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -457,6 +462,7 @@ impl CryptocurrencyMiningPool {
             ra_flag: fields.ra_flag,
             ttl: fields.ttl,
             coins: fields.coins,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -484,7 +490,7 @@ impl Match for CryptocurrencyMiningPool {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::CommandAndControl
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -504,7 +510,6 @@ impl Match for CryptocurrencyMiningPool {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }
@@ -530,6 +535,7 @@ pub struct BlockListDnsFields {
     pub rd_flag: bool,
     pub ra_flag: bool,
     pub ttl: Vec<i32>,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for BlockListDnsFields {
@@ -581,6 +587,7 @@ pub struct BlockListDns {
     pub rd_flag: bool,
     pub ra_flag: bool,
     pub ttl: Vec<i32>,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -636,6 +643,7 @@ impl BlockListDns {
             rd_flag: fields.rd_flag,
             ra_flag: fields.ra_flag,
             ttl: fields.ttl,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -663,7 +671,7 @@ impl Match for BlockListDns {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::InitialAccess
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -683,7 +691,6 @@ impl Match for BlockListDns {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/event/ftp.rs
+++ b/src/event/ftp.rs
@@ -17,6 +17,7 @@ pub struct FtpBruteForceFields {
     pub start_time: DateTime<Utc>,
     pub last_time: DateTime<Utc>,
     pub is_internal: bool,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for FtpBruteForceFields {
@@ -46,6 +47,7 @@ pub struct FtpBruteForce {
     pub start_time: DateTime<Utc>,
     pub last_time: DateTime<Utc>,
     pub is_internal: bool,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -79,6 +81,7 @@ impl FtpBruteForce {
             start_time: fields.start_time,
             last_time: fields.last_time,
             is_internal: fields.is_internal,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -106,7 +109,7 @@ impl Match for FtpBruteForce {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::CredentialAccess
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -126,7 +129,6 @@ impl Match for FtpBruteForce {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }
@@ -152,6 +154,7 @@ pub struct FtpPlainTextFields {
     pub file: String,
     pub file_size: u64,
     pub file_id: String,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for FtpPlainTextFields {
@@ -204,6 +207,7 @@ pub struct FtpPlainText {
     pub file: String,
     pub file_size: u64,
     pub file_id: String,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -259,6 +263,7 @@ impl FtpPlainText {
             file: fields.file,
             file_size: fields.file_size,
             file_id: fields.file_id,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -286,7 +291,7 @@ impl Match for FtpPlainText {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::LateralMovement
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -306,11 +311,11 @@ impl Match for FtpPlainText {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }
 
+// TODO: Merge FtpPlainTextFields, BlockListFtpFields
 #[derive(Debug, Deserialize, Serialize)]
 pub struct BlockListFtpFields {
     pub source: String,
@@ -332,6 +337,7 @@ pub struct BlockListFtpFields {
     pub file: String,
     pub file_size: u64,
     pub file_id: String,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for BlockListFtpFields {
@@ -384,6 +390,7 @@ pub struct BlockListFtp {
     pub file: String,
     pub file_size: u64,
     pub file_id: String,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -439,6 +446,7 @@ impl BlockListFtp {
             file: fields.file,
             file_size: fields.file_size,
             file_id: fields.file_id,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -466,7 +474,7 @@ impl Match for BlockListFtp {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::InitialAccess
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -486,7 +494,6 @@ impl Match for BlockListFtp {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/event/http.rs
+++ b/src/event/http.rs
@@ -8,13 +8,14 @@ use super::{common::Match, EventCategory, EventFilter, TriagePolicy, TriageScore
 use crate::event::common::triage_scores_to_string;
 
 #[derive(Serialize, Deserialize)]
-pub(super) struct RepeatedHttpSessionsFields {
+pub struct RepeatedHttpSessionsFields {
     pub source: String,
     pub src_addr: IpAddr,
     pub src_port: u16,
     pub dst_addr: IpAddr,
     pub dst_port: u16,
     pub proto: u8,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for RepeatedHttpSessionsFields {
@@ -40,6 +41,7 @@ pub struct RepeatedHttpSessions {
     pub dst_addr: IpAddr,
     pub dst_port: u16,
     pub proto: u8,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -69,6 +71,7 @@ impl RepeatedHttpSessions {
             dst_addr: fields.dst_addr,
             dst_port: fields.dst_port,
             proto: fields.proto,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -96,7 +99,7 @@ impl Match for RepeatedHttpSessions {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::Exfiltration
+        self.category
     }
 
     fn level(&self) -> std::num::NonZeroU8 {
@@ -161,6 +164,7 @@ pub struct HttpThreatFields {
     pub cluster_id: usize,
     pub attack_kind: String,
     pub confidence: f32,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for HttpThreatFields {
@@ -209,7 +213,7 @@ impl fmt::Display for HttpThreatFields {
 
 // HTTP Request body has Vec<u8> type, and it's too large to print.
 const MAX_POST_BODY_LEN: usize = 10;
-fn get_post_body(post_body: &[u8]) -> String {
+pub(super) fn get_post_body(post_body: &[u8]) -> String {
     let post_body = String::from_utf8_lossy(post_body);
     if post_body.len() > MAX_POST_BODY_LEN {
         let mut trimmed = post_body
@@ -262,6 +266,7 @@ pub struct HttpThreat {
     pub cluster_id: usize,
     pub attack_kind: String,
     pub confidence: f32,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -349,6 +354,7 @@ impl HttpThreat {
             cluster_id: fields.cluster_id,
             attack_kind: fields.attack_kind,
             confidence: fields.confidence,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -376,7 +382,7 @@ impl Match for HttpThreat {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::Reconnaissance
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -396,7 +402,6 @@ impl Match for HttpThreat {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 
@@ -456,6 +461,7 @@ pub struct DgaFields {
     pub post_body: Vec<u8>,
     pub state: String,
     pub confidence: f32,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for DgaFields {
@@ -531,6 +537,7 @@ pub struct DomainGenerationAlgorithm {
     pub post_body: Vec<u8>,
     pub state: String,
     pub confidence: f32,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -608,6 +615,7 @@ impl DomainGenerationAlgorithm {
             post_body: fields.post_body,
             state: fields.state,
             confidence: fields.confidence,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -635,7 +643,7 @@ impl Match for DomainGenerationAlgorithm {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::CommandAndControl
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -655,11 +663,11 @@ impl Match for DomainGenerationAlgorithm {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }
 
+// TODO: Merge BlockListHttpFields, TorConnectionFields
 #[derive(Deserialize, Serialize)]
 #[allow(clippy::module_name_repetitions)]
 pub struct NonBrowserFields {
@@ -693,6 +701,7 @@ pub struct NonBrowserFields {
     pub resp_mime_types: Vec<String>,
     pub post_body: Vec<u8>,
     pub state: String,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for NonBrowserFields {
@@ -765,6 +774,7 @@ pub struct NonBrowser {
     pub resp_mime_types: Vec<String>,
     pub post_body: Vec<u8>,
     pub state: String,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -840,6 +850,7 @@ impl NonBrowser {
             resp_mime_types: fields.resp_mime_types.clone(),
             post_body: fields.post_body.clone(),
             state: fields.state.clone(),
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -867,7 +878,7 @@ impl Match for NonBrowser {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::CommandAndControl
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -887,7 +898,6 @@ impl Match for NonBrowser {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }
@@ -923,6 +933,7 @@ pub struct BlockListHttpFields {
     pub resp_mime_types: Vec<String>,
     pub post_body: Vec<u8>,
     pub state: String,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for BlockListHttpFields {
@@ -996,6 +1007,7 @@ pub struct BlockListHttp {
     pub resp_mime_types: Vec<String>,
     pub post_body: Vec<u8>,
     pub state: String,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -1071,6 +1083,7 @@ impl BlockListHttp {
             resp_mime_types: fields.resp_mime_types.clone(),
             post_body: fields.post_body.clone(),
             state: fields.state.clone(),
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -1098,7 +1111,7 @@ impl Match for BlockListHttp {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::InitialAccess
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -1118,7 +1131,6 @@ impl Match for BlockListHttp {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/event/kerberos.rs
+++ b/src/event/kerberos.rs
@@ -24,6 +24,7 @@ pub struct BlockListKerberosFields {
     pub realm: String,
     pub sname_type: u8,
     pub service_name: Vec<String>,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for BlockListKerberosFields {
@@ -70,6 +71,7 @@ pub struct BlockListKerberos {
     pub realm: String,
     pub sname_type: u8,
     pub service_name: Vec<String>,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -119,6 +121,7 @@ impl BlockListKerberos {
             realm: fields.realm,
             sname_type: fields.sname_type,
             service_name: fields.service_name,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -146,7 +149,7 @@ impl Match for BlockListKerberos {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::InitialAccess
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -166,7 +169,6 @@ impl Match for BlockListKerberos {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/event/ldap.rs
+++ b/src/event/ldap.rs
@@ -16,6 +16,7 @@ pub struct LdapBruteForceFields {
     pub user_pw_list: Vec<(String, String)>,
     pub start_time: DateTime<Utc>,
     pub last_time: DateTime<Utc>,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for LdapBruteForceFields {
@@ -55,6 +56,7 @@ pub struct LdapBruteForce {
     pub user_pw_list: Vec<(String, String)>,
     pub start_time: DateTime<Utc>,
     pub last_time: DateTime<Utc>,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -86,6 +88,7 @@ impl LdapBruteForce {
             user_pw_list: fields.user_pw_list.clone(),
             start_time: fields.start_time,
             last_time: fields.last_time,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -113,7 +116,7 @@ impl Match for LdapBruteForce {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::CredentialAccess
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -133,7 +136,6 @@ impl Match for LdapBruteForce {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }
@@ -154,6 +156,7 @@ pub struct LdapPlainTextFields {
     pub diagnostic_message: Vec<String>,
     pub object: Vec<String>,
     pub argument: Vec<String>,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for LdapPlainTextFields {
@@ -196,6 +199,7 @@ pub struct LdapPlainText {
     pub diagnostic_message: Vec<String>,
     pub object: Vec<String>,
     pub argument: Vec<String>,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -241,6 +245,7 @@ impl LdapPlainText {
             diagnostic_message: fields.diagnostic_message,
             object: fields.object,
             argument: fields.argument,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -268,7 +273,7 @@ impl Match for LdapPlainText {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::LateralMovement
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -288,11 +293,11 @@ impl Match for LdapPlainText {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }
 
+// TODO: Merge BlockListLdapFields and BlockListLdapFields
 #[derive(Debug, Deserialize, Serialize)]
 pub struct BlockListLdapFields {
     pub source: String,
@@ -309,7 +314,9 @@ pub struct BlockListLdapFields {
     pub diagnostic_message: Vec<String>,
     pub object: Vec<String>,
     pub argument: Vec<String>,
+    pub category: EventCategory,
 }
+
 impl fmt::Display for BlockListLdapFields {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -350,6 +357,7 @@ pub struct BlockListLdap {
     pub diagnostic_message: Vec<String>,
     pub object: Vec<String>,
     pub argument: Vec<String>,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -395,6 +403,7 @@ impl BlockListLdap {
             diagnostic_message: fields.diagnostic_message,
             object: fields.object,
             argument: fields.argument,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -422,7 +431,7 @@ impl Match for BlockListLdap {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::InitialAccess
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -442,7 +451,6 @@ impl Match for BlockListLdap {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/event/log.rs
+++ b/src/event/log.rs
@@ -24,6 +24,7 @@ pub struct ExtraThreat {
     pub cluster_id: usize,
     pub attack_kind: String,
     pub confidence: f32,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 impl fmt::Display for ExtraThreat {
@@ -67,7 +68,7 @@ impl Match for ExtraThreat {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::Reconnaissance
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -87,7 +88,6 @@ impl Match for ExtraThreat {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/event/mqtt.rs
+++ b/src/event/mqtt.rs
@@ -21,6 +21,7 @@ pub struct BlockListMqttFields {
     pub connack_reason: u8,
     pub subscribe: Vec<String>,
     pub suback_reason: Vec<u8>,
+    pub category: EventCategory,
 }
 impl fmt::Display for BlockListMqttFields {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -60,6 +61,7 @@ pub struct BlockListMqtt {
     pub connack_reason: u8,
     pub subscribe: Vec<String>,
     pub suback_reason: Vec<u8>,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -103,6 +105,7 @@ impl BlockListMqtt {
             connack_reason: fields.connack_reason,
             subscribe: fields.subscribe,
             suback_reason: fields.suback_reason,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -130,7 +133,7 @@ impl Match for BlockListMqtt {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::InitialAccess
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -150,7 +153,6 @@ impl Match for BlockListMqtt {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/event/network.rs
+++ b/src/event/network.rs
@@ -26,8 +26,10 @@ pub struct NetworkThreat {
     pub cluster_id: usize,
     pub attack_kind: String,
     pub confidence: f32,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
+
 impl fmt::Display for NetworkThreat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -75,7 +77,7 @@ impl Match for NetworkThreat {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::Reconnaissance
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -95,7 +97,6 @@ impl Match for NetworkThreat {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/event/nfs.rs
+++ b/src/event/nfs.rs
@@ -17,6 +17,7 @@ pub struct BlockListNfsFields {
     pub last_time: i64,
     pub read_files: Vec<String>,
     pub write_files: Vec<String>,
+    pub category: EventCategory,
 }
 impl fmt::Display for BlockListNfsFields {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -48,6 +49,7 @@ pub struct BlockListNfs {
     pub last_time: i64,
     pub read_files: Vec<String>,
     pub write_files: Vec<String>,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 impl fmt::Display for BlockListNfs {
@@ -82,6 +84,7 @@ impl BlockListNfs {
             last_time: fields.last_time,
             read_files: fields.read_files,
             write_files: fields.write_files,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -109,7 +112,7 @@ impl Match for BlockListNfs {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::InitialAccess
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -129,7 +132,6 @@ impl Match for BlockListNfs {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/event/rdp.rs
+++ b/src/event/rdp.rs
@@ -22,7 +22,9 @@ pub struct RdpBruteForceFields {
     pub start_time: DateTime<Utc>,
     pub last_time: DateTime<Utc>,
     pub proto: u8,
+    pub category: EventCategory,
 }
+
 impl fmt::Display for RdpBruteForceFields {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -36,6 +38,7 @@ impl fmt::Display for RdpBruteForceFields {
         )
     }
 }
+
 pub struct RdpBruteForce {
     pub time: DateTime<Utc>,
     pub src_addr: IpAddr,
@@ -43,6 +46,7 @@ pub struct RdpBruteForce {
     pub start_time: DateTime<Utc>,
     pub last_time: DateTime<Utc>,
     pub proto: u8,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -70,6 +74,7 @@ impl RdpBruteForce {
             start_time: fields.start_time,
             last_time: fields.last_time,
             proto: fields.proto,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -97,7 +102,7 @@ impl Match for RdpBruteForce {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::Discovery
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -117,7 +122,6 @@ impl Match for RdpBruteForce {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }
@@ -132,7 +136,9 @@ pub struct BlockListRdpFields {
     pub proto: u8,
     pub last_time: i64,
     pub cookie: String,
+    pub category: EventCategory,
 }
+
 impl fmt::Display for BlockListRdpFields {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -159,6 +165,7 @@ pub struct BlockListRdp {
     pub proto: u8,
     pub last_time: i64,
     pub cookie: String,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 impl fmt::Display for BlockListRdp {
@@ -191,6 +198,7 @@ impl BlockListRdp {
             proto: fields.proto,
             last_time: fields.last_time,
             cookie: fields.cookie,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -218,7 +226,7 @@ impl Match for BlockListRdp {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::InitialAccess
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -238,7 +246,6 @@ impl Match for BlockListRdp {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/event/smb.rs
+++ b/src/event/smb.rs
@@ -26,6 +26,7 @@ pub struct BlockListSmbFields {
     pub access_time: i64,
     pub write_time: i64,
     pub change_time: i64,
+    pub category: EventCategory,
 }
 impl fmt::Display for BlockListSmbFields {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -75,6 +76,7 @@ pub struct BlockListSmb {
     pub access_time: i64,
     pub write_time: i64,
     pub change_time: i64,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 impl fmt::Display for BlockListSmb {
@@ -126,6 +128,7 @@ impl BlockListSmb {
             access_time: fields.access_time,
             write_time: fields.write_time,
             change_time: fields.change_time,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -153,7 +156,7 @@ impl Match for BlockListSmb {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::InitialAccess
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -173,7 +176,6 @@ impl Match for BlockListSmb {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/event/smtp.rs
+++ b/src/event/smtp.rs
@@ -22,6 +22,7 @@ pub struct BlockListSmtpFields {
     pub subject: String,
     pub agent: String,
     pub state: String,
+    pub category: EventCategory,
 }
 
 impl fmt::Display for BlockListSmtpFields {
@@ -64,6 +65,7 @@ pub struct BlockListSmtp {
     pub subject: String,
     pub agent: String,
     pub state: String,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 impl fmt::Display for BlockListSmtp {
@@ -108,6 +110,7 @@ impl BlockListSmtp {
             subject: fields.subject,
             agent: fields.agent,
             state: fields.state,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -135,7 +138,7 @@ impl Match for BlockListSmtp {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::InitialAccess
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -155,7 +158,6 @@ impl Match for BlockListSmtp {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/event/ssh.rs
+++ b/src/event/ssh.rs
@@ -28,6 +28,7 @@ pub struct BlockListSshFields {
     pub hassh_server: String,
     pub client_shka: String,
     pub server_shka: String,
+    pub category: EventCategory,
 }
 impl fmt::Display for BlockListSshFields {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -81,6 +82,7 @@ pub struct BlockListSsh {
     pub hassh_server: String,
     pub client_shka: String,
     pub server_shka: String,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 impl fmt::Display for BlockListSsh {
@@ -137,6 +139,7 @@ impl BlockListSsh {
             hassh_server: fields.hassh_server,
             client_shka: fields.client_shka,
             server_shka: fields.server_shka,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -164,7 +167,7 @@ impl Match for BlockListSsh {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::InitialAccess
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -184,7 +187,6 @@ impl Match for BlockListSsh {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/event/sysmon.rs
+++ b/src/event/sysmon.rs
@@ -30,6 +30,7 @@ pub struct WindowsThreat {
     pub cluster_id: usize,
     pub attack_kind: String,
     pub confidence: f32,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
 
@@ -58,6 +59,7 @@ impl fmt::Display for WindowsThreat {
         )
     }
 }
+
 // TODO: Make new Match trait for Windows threat events
 impl Match for WindowsThreat {
     fn source(&self) -> &str {
@@ -84,9 +86,8 @@ impl Match for WindowsThreat {
         0
     }
 
-    // TODO: choose event category with service and attack_kind value
     fn category(&self) -> EventCategory {
-        EventCategory::Impact
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -102,7 +103,6 @@ impl Match for WindowsThreat {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/event/tls.rs
+++ b/src/event/tls.rs
@@ -36,6 +36,7 @@ pub struct BlockListTlsFields {
     pub issuer_org_unit_name: String,
     pub issuer_common_name: String,
     pub last_alert: u8,
+    pub category: EventCategory,
 }
 impl fmt::Display for BlockListTlsFields {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -69,7 +70,7 @@ impl fmt::Display for BlockListTlsFields {
             self.issuer_org_name,
             self.issuer_org_unit_name,
             self.issuer_common_name,
-            self.last_alert.to_string()
+            self.last_alert.to_string(),
         )
     }
 }
@@ -105,8 +106,10 @@ pub struct BlockListTls {
     pub issuer_org_unit_name: String,
     pub issuer_common_name: String,
     pub last_alert: u8,
+    pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
+
 impl fmt::Display for BlockListTls {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -177,6 +180,7 @@ impl BlockListTls {
             issuer_org_unit_name: fields.issuer_org_unit_name,
             issuer_common_name: fields.issuer_common_name,
             last_alert: fields.last_alert,
+            category: fields.category,
             triage_scores: None,
         }
     }
@@ -204,7 +208,7 @@ impl Match for BlockListTls {
     }
 
     fn category(&self) -> EventCategory {
-        EventCategory::InitialAccess
+        self.category
     }
 
     fn level(&self) -> NonZeroU8 {
@@ -224,7 +228,6 @@ impl Match for BlockListTls {
     }
 
     fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        // TODO: implement
         0.0
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,12 +53,16 @@ pub use self::event::{
     BlockListLdapFields, BlockListMqtt, BlockListMqttFields, BlockListNfs, BlockListNfsFields,
     BlockListNtlm, BlockListNtlmFields, BlockListRdp, BlockListRdpFields, BlockListSmb,
     BlockListSmbFields, BlockListSmtp, BlockListSmtpFields, BlockListSsh, BlockListSshFields,
-    BlockListTls, BlockListTlsFields, CryptocurrencyMiningPool, Direction, DnsCovertChannel,
-    DomainGenerationAlgorithm, Event, EventDb, EventFilter, EventIterator, EventMessage,
-    ExternalDdos, ExtraThreat, FilterEndpoint, FlowKind, FtpBruteForce, FtpPlainText, HttpThreat,
-    LdapBruteForce, LdapPlainText, LearningMethod, LockyRansomware, MultiHostPortScan,
-    NetworkThreat, NetworkType, NonBrowser, PortScan, RdpBruteForce, RecordType,
-    RepeatedHttpSessions, TorConnection, TrafficDirection, TriageScore, WindowsThreat,
+    BlockListTls, BlockListTlsFields, CryptocurrencyMiningPool, CryptocurrencyMiningPoolFields,
+    DgaFields, Direction, DnsCovertChannel, DnsEventFields, DomainGenerationAlgorithm, Event,
+    EventDb, EventFilter, EventIterator, EventMessage, ExternalDdos, ExternalDdosFields,
+    ExtraThreat, FilterEndpoint, FlowKind, FtpBruteForce, FtpBruteForceFields, FtpPlainText,
+    FtpPlainTextFields, HttpThreat, HttpThreatFields, LdapBruteForce, LdapBruteForceFields,
+    LdapPlainText, LdapPlainTextFields, LearningMethod, LockyRansomware, MultiHostPortScan,
+    MultiHostPortScanFields, NetworkThreat, NetworkType, NonBrowser, NonBrowserFields, PortScan,
+    PortScanFields, RdpBruteForce, RdpBruteForceFields, RecordType, RepeatedHttpSessions,
+    RepeatedHttpSessionsFields, TorConnection, TorConnectionFields, TrafficDirection, TriageScore,
+    WindowsThreat,
 };
 pub use self::migration::{migrate_backend, migrate_data_dir};
 pub use self::model::{Digest as ModelDigest, Model};

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -212,7 +212,8 @@ fn read_version_file(path: &Path) -> Result<Version> {
 }
 
 fn migrate_0_29_to_0_30_0(store: &super::Store) -> Result<()> {
-    migrate_0_30_tidb(store)
+    migrate_0_30_tidb(store)?;
+    migrate_0_30_event_struct(store)
 }
 
 fn migrate_0_30_tidb(store: &super::Store) -> Result<()> {
@@ -290,24 +291,29 @@ fn migrate_0_30_tidb(store: &super::Store) -> Result<()> {
     Ok(())
 }
 
-fn migrate_0_28_to_0_29_0(store: &super::Store) -> Result<()> {
-    migrate_event_struct(store)?;
-    migrate_0_29_node(store)?;
-    migrate_0_29_account(store)
-}
-
-fn migrate_event_struct(store: &super::Store) -> Result<()> {
+fn migrate_0_30_event_struct(store: &super::Store) -> Result<()> {
     use migration_structures::{
-        BlockListConnBeforeV29, BlockListHttpBeforeV29, BlockListNtlmBeforeV29,
-        BlockListSmtpBeforeV29, BlockListSshBeforeV29, BlockListTlsBeforeV29, DgaBeforeV29,
-        HttpThreatBeforeV29, NonBrowserBeforeV29,
+        BlockListConnBeforeV30, BlockListDnsBeforeV30, BlockListFtpBeforeV30,
+        BlockListHttpBeforeV30, BlockListKerberosBeforeV30, BlockListLdapBeforeV30,
+        BlockListNtlmBeforeV30, BlockListRdpBeforeV30, BlockListSmtpBeforeV30,
+        BlockListSshBeforeV30, BlockListTlsBeforeV30, CryptocurrencyMiningPoolBeforeV30,
+        DgaBeforeV30, DnsCovertChannelBeforeV30, ExternalDdosBeforeV30, FtpBruteForceBeforeV30,
+        FtpPlainTextBeforeV30, HttpThreatBeforeV30, LdapBruteForceBeforeV30,
+        LdapPlainTextBeforeV30, MultiHostPortScanBeforeV30, NetworkThreatBeforeV30,
+        NonBrowserBeforeV30, PortScanBeforeV30, RdpBruteForceBeforeV30,
+        RepeatedHttpSessionsBeforeV30, TorConnectionBeforeV30, WindowsThreatBeforeV30,
     };
     use num_traits::FromPrimitive;
 
     use crate::event::{
-        BlockListConnFields, BlockListHttpFields, BlockListNtlmFields, BlockListSmtpFields,
-        BlockListSshFields, BlockListTlsFields, DgaFields, EventKind, HttpThreatFields,
-        NonBrowserFields,
+        BlockListConnFields, BlockListDnsFields, BlockListFtpFields, BlockListHttpFields,
+        BlockListKerberosFields, BlockListLdapFields, BlockListNtlmFields, BlockListRdpFields,
+        BlockListSmtpFields, BlockListSshFields, BlockListTlsFields,
+        CryptocurrencyMiningPoolFields, DgaFields, DnsEventFields, EventKind, ExternalDdosFields,
+        FtpBruteForceFields, FtpPlainTextFields, HttpThreatFields, LdapBruteForceFields,
+        LdapPlainTextFields, MultiHostPortScanFields, NetworkThreat, NonBrowserFields,
+        PortScanFields, RdpBruteForceFields, RepeatedHttpSessionsFields, TorConnectionFields,
+        WindowsThreat,
     };
 
     let event_db = store.events();
@@ -327,45 +333,228 @@ fn migrate_event_struct(store: &super::Store) -> Result<()> {
 
         match event_kind {
             EventKind::HttpThreat => {
-                update_event_db_with_new_event::<HttpThreatBeforeV29, HttpThreatFields>(
+                update_event_db_with_new_event::<HttpThreatBeforeV30, HttpThreatFields>(
                     &k, &v, &event_db,
                 )?;
             }
             EventKind::DomainGenerationAlgorithm => {
-                update_event_db_with_new_event::<DgaBeforeV29, DgaFields>(&k, &v, &event_db)?;
+                update_event_db_with_new_event::<DgaBeforeV30, DgaFields>(&k, &v, &event_db)?;
             }
             EventKind::NonBrowser => {
-                update_event_db_with_new_event::<NonBrowserBeforeV29, NonBrowserFields>(
-                    &k, &v, &event_db,
-                )?;
-            }
-            EventKind::BlockListHttp => {
-                update_event_db_with_new_event::<BlockListHttpBeforeV29, BlockListHttpFields>(
+                update_event_db_with_new_event::<NonBrowserBeforeV30, NonBrowserFields>(
                     &k, &v, &event_db,
                 )?;
             }
             EventKind::BlockListConn => {
-                update_event_db_with_new_event::<BlockListConnBeforeV29, BlockListConnFields>(
+                update_event_db_with_new_event::<BlockListConnBeforeV30, BlockListConnFields>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::BlockListDns => {
+                update_event_db_with_new_event::<BlockListDnsBeforeV30, BlockListDnsFields>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::BlockListFtp => {
+                update_event_db_with_new_event::<BlockListFtpBeforeV30, BlockListFtpFields>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::BlockListHttp => {
+                update_event_db_with_new_event::<BlockListHttpBeforeV30, BlockListHttpFields>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::BlockListKerberos => {
+                update_event_db_with_new_event::<
+                    BlockListKerberosBeforeV30,
+                    BlockListKerberosFields,
+                >(&k, &v, &event_db)?;
+            }
+            EventKind::BlockListLdap => {
+                update_event_db_with_new_event::<BlockListLdapBeforeV30, BlockListLdapFields>(
                     &k, &v, &event_db,
                 )?;
             }
             EventKind::BlockListNtlm => {
-                update_event_db_with_new_event::<BlockListNtlmBeforeV29, BlockListNtlmFields>(
+                update_event_db_with_new_event::<BlockListNtlmBeforeV30, BlockListNtlmFields>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::BlockListRdp => {
+                update_event_db_with_new_event::<BlockListRdpBeforeV30, BlockListRdpFields>(
                     &k, &v, &event_db,
                 )?;
             }
             EventKind::BlockListSmtp => {
-                update_event_db_with_new_event::<BlockListSmtpBeforeV29, BlockListSmtpFields>(
+                update_event_db_with_new_event::<BlockListSmtpBeforeV30, BlockListSmtpFields>(
                     &k, &v, &event_db,
                 )?;
             }
             EventKind::BlockListSsh => {
-                update_event_db_with_new_event::<BlockListSshBeforeV29, BlockListSshFields>(
+                update_event_db_with_new_event::<BlockListSshBeforeV30, BlockListSshFields>(
                     &k, &v, &event_db,
                 )?;
             }
             EventKind::BlockListTls => {
-                update_event_db_with_new_event::<BlockListTlsBeforeV29, BlockListTlsFields>(
+                update_event_db_with_new_event::<BlockListTlsBeforeV30, BlockListTlsFields>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::CryptocurrencyMiningPool => {
+                update_event_db_with_new_event::<
+                    CryptocurrencyMiningPoolBeforeV30,
+                    CryptocurrencyMiningPoolFields,
+                >(&k, &v, &event_db)?;
+            }
+            EventKind::DnsCovertChannel => {
+                update_event_db_with_new_event::<DnsCovertChannelBeforeV30, DnsEventFields>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::ExternalDdos => {
+                update_event_db_with_new_event::<ExternalDdosBeforeV30, ExternalDdosFields>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::FtpBruteForce => {
+                update_event_db_with_new_event::<FtpBruteForceBeforeV30, FtpBruteForceFields>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::FtpPlainText => {
+                update_event_db_with_new_event::<FtpPlainTextBeforeV30, FtpPlainTextFields>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::LdapBruteForce => {
+                update_event_db_with_new_event::<LdapBruteForceBeforeV30, LdapBruteForceFields>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::LdapPlainText => {
+                update_event_db_with_new_event::<LdapPlainTextBeforeV30, LdapPlainTextFields>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::MultiHostPortScan => {
+                update_event_db_with_new_event::<
+                    MultiHostPortScanBeforeV30,
+                    MultiHostPortScanFields,
+                >(&k, &v, &event_db)?;
+            }
+            EventKind::NetworkThreat => {
+                update_event_db_with_new_event::<NetworkThreatBeforeV30, NetworkThreat>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::RdpBruteForce => {
+                update_event_db_with_new_event::<RdpBruteForceBeforeV30, RdpBruteForceFields>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::RepeatedHttpSessions => {
+                update_event_db_with_new_event::<
+                    RepeatedHttpSessionsBeforeV30,
+                    RepeatedHttpSessionsFields,
+                >(&k, &v, &event_db)?;
+            }
+            EventKind::PortScan => {
+                update_event_db_with_new_event::<PortScanBeforeV30, PortScanFields>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::TorConnection => {
+                update_event_db_with_new_event::<TorConnectionBeforeV30, TorConnectionFields>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::WindowsThreat => {
+                update_event_db_with_new_event::<WindowsThreatBeforeV30, WindowsThreat>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            _ => continue,
+        }
+    }
+    Ok(())
+}
+
+fn migrate_0_28_to_0_29_0(store: &super::Store) -> Result<()> {
+    migrate_event_struct(store)?;
+    migrate_0_29_node(store)?;
+    migrate_0_29_account(store)
+}
+
+fn migrate_event_struct(store: &super::Store) -> Result<()> {
+    use migration_structures::{
+        BlockListConnBeforeV29, BlockListConnBeforeV30, BlockListHttpBeforeV29,
+        BlockListHttpBeforeV30, BlockListNtlmBeforeV29, BlockListNtlmBeforeV30,
+        BlockListSmtpBeforeV29, BlockListSmtpBeforeV30, BlockListSshBeforeV29,
+        BlockListSshBeforeV30, BlockListTlsBeforeV29, BlockListTlsBeforeV30, DgaBeforeV29,
+        DgaBeforeV30, HttpThreatBeforeV29, HttpThreatBeforeV30, NonBrowserBeforeV29,
+        NonBrowserBeforeV30,
+    };
+    use num_traits::FromPrimitive;
+
+    use crate::event::EventKind;
+
+    let event_db = store.events();
+    let iter = event_db.raw_iter_forward();
+    for event in iter {
+        let (k, v) = event.map_err(|e| anyhow!("Failed to read events database: {e:?}"))?;
+        let key: [u8; 16] = if let Ok(key) = k.as_ref().try_into() {
+            key
+        } else {
+            return Err(anyhow!("Failed to migrate events: invalid event key"));
+        };
+        let key = i128::from_be_bytes(key);
+        let kind = (key & 0xffff_ffff_0000_0000) >> 32;
+        let Some(event_kind) = EventKind::from_i128(kind) else {
+            return Err(anyhow!("Failed to migrate events: invalid event kind"));
+        };
+
+        match event_kind {
+            EventKind::HttpThreat => {
+                update_event_db_with_new_event::<HttpThreatBeforeV29, HttpThreatBeforeV30>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::DomainGenerationAlgorithm => {
+                update_event_db_with_new_event::<DgaBeforeV29, DgaBeforeV30>(&k, &v, &event_db)?;
+            }
+            EventKind::NonBrowser => {
+                update_event_db_with_new_event::<NonBrowserBeforeV29, NonBrowserBeforeV30>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::BlockListHttp => {
+                update_event_db_with_new_event::<BlockListHttpBeforeV29, BlockListHttpBeforeV30>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::BlockListConn => {
+                update_event_db_with_new_event::<BlockListConnBeforeV29, BlockListConnBeforeV30>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::BlockListNtlm => {
+                update_event_db_with_new_event::<BlockListNtlmBeforeV29, BlockListNtlmBeforeV30>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::BlockListSmtp => {
+                update_event_db_with_new_event::<BlockListSmtpBeforeV29, BlockListSmtpBeforeV30>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::BlockListSsh => {
+                update_event_db_with_new_event::<BlockListSshBeforeV29, BlockListSshBeforeV30>(
+                    &k, &v, &event_db,
+                )?;
+            }
+            EventKind::BlockListTls => {
+                update_event_db_with_new_event::<BlockListTlsBeforeV29, BlockListTlsBeforeV30>(
                     &k, &v, &event_db,
                 )?;
             }
@@ -1637,19 +1826,10 @@ mod tests {
         assert_eq!(res.unwrap(), Some(time));
     }
 
-    #[test]
-    fn migrate_0_28_to_0_29_0_block_list_conn() {
+    fn block_list_conn_before_v29() -> super::migration_structures::BlockListConnBeforeV29 {
         use std::net::IpAddr;
 
-        use chrono::Utc;
-
-        use crate::{
-            migration::migration_structures::BlockListConnBeforeV29, EventKind, EventMessage,
-        };
-
-        let settings = TestSchema::new();
-        let time = Utc::now();
-        let value = BlockListConnBeforeV29 {
+        super::migration_structures::BlockListConnBeforeV29 {
             source: "source_1".to_string(),
             src_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
             src_port: 46378,
@@ -1662,10 +1842,18 @@ mod tests {
             resp_bytes: 295,
             orig_pkts: 397,
             resp_pkts: 511,
-        };
+        }
+    }
+
+    #[test]
+    fn migrate_0_28_to_0_29_block_list_conn() {
+        use crate::{EventKind, EventMessage};
+
+        let settings = TestSchema::new();
+        let value = block_list_conn_before_v29();
 
         let message = EventMessage {
-            time,
+            time: chrono::Utc::now(),
             kind: EventKind::BlockListConn,
             fields: bincode::serialize(&value).unwrap_or_default(),
         };
@@ -1680,19 +1868,83 @@ mod tests {
     }
 
     #[test]
-    fn migrate_0_28_to_0_29_0_http_threat() {
+    fn migrate_0_29_to_0_30_block_list_conn() {
+        use crate::{
+            migration::migration_structures::BlockListConnBeforeV30, EventKind, EventMessage,
+        };
+
+        let settings = TestSchema::new();
+        let value: BlockListConnBeforeV30 = block_list_conn_before_v29().into();
+
+        let message = EventMessage {
+            time: chrono::Utc::now(),
+            kind: EventKind::BlockListConn,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    #[test]
+    fn migrate_0_29_to_0_30_block_list_dns() {
         use std::net::IpAddr;
 
         use chrono::Utc;
 
         use crate::{
-            migration::migration_structures::HttpThreatBeforeV29, EventKind, EventMessage,
+            migration::migration_structures::BlockListDnsBeforeV30, EventKind, EventMessage,
         };
 
         let settings = TestSchema::new();
         let time = Utc::now();
-        let value = HttpThreatBeforeV29 {
+        let value = BlockListDnsBeforeV30 {
+            source: "source_1".to_string(),
+            src_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+            src_port: 46378,
+            dst_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+            dst_port: 80,
+            proto: 6,
+            last_time: 100,
+            query: "query".to_string(),
+            answer: vec!["answer".to_string()],
+            trans_id: 0,
+            rtt: 0,
+            qclass: 0,
+            qtype: 0,
+            rcode: 0,
+            aa_flag: true,
+            tc_flag: false,
+            rd_flag: false,
+            ra_flag: false,
+            ttl: vec![100],
+        };
+
+        let message = EventMessage {
             time,
+            kind: EventKind::BlockListDns,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    fn http_threat_before_v29() -> super::migration_structures::HttpThreatBeforeV29 {
+        use std::net::IpAddr;
+
+        super::migration_structures::HttpThreatBeforeV29 {
+            time: chrono::Utc::now(),
             source: "source_1".to_string(),
             src_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
             src_port: 46378,
@@ -1722,10 +1974,18 @@ mod tests {
             cluster_id: 200,
             attack_kind: "attack_kind".to_string(),
             confidence: 0.3,
-        };
+        }
+    }
+
+    #[test]
+    fn migrate_0_28_to_0_29_http_threat() {
+        use crate::{EventKind, EventMessage};
+
+        let settings = TestSchema::new();
+        let value = http_threat_before_v29();
 
         let message = EventMessage {
-            time,
+            time: value.time,
             kind: EventKind::HttpThreat,
             fields: bincode::serialize(&value).unwrap_or_default(),
         };
@@ -1740,16 +2000,32 @@ mod tests {
     }
 
     #[test]
-    fn migrate_0_28_to_0_29_0_dga() {
-        use std::net::IpAddr;
-
-        use chrono::Utc;
-
-        use crate::{migration::migration_structures::DgaBeforeV29, EventKind, EventMessage};
+    fn migrate_0_29_to_0_30_http_threat() {
+        use crate::{
+            migration::migration_structures::HttpThreatBeforeV30, EventKind, EventMessage,
+        };
 
         let settings = TestSchema::new();
-        let time = Utc::now();
-        let value = DgaBeforeV29 {
+        let value: HttpThreatBeforeV30 = http_threat_before_v29().into();
+        let message = EventMessage {
+            time: value.time,
+            kind: EventKind::HttpThreat,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    fn dga_before_v29() -> super::migration_structures::DgaBeforeV29 {
+        use std::net::IpAddr;
+
+        super::migration_structures::DgaBeforeV29 {
             source: "source_1".to_string(),
             src_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
             src_port: 46378,
@@ -1774,10 +2050,18 @@ mod tests {
             content_type: "content_type".to_string(),
             cache_control: "cache_control".to_string(),
             confidence: 0.3,
-        };
+        }
+    }
+
+    #[test]
+    fn migrate_0_28_to_0_29_dga() {
+        use crate::{EventKind, EventMessage};
+
+        let settings = TestSchema::new();
+        let value = dga_before_v29();
 
         let message = EventMessage {
-            time,
+            time: chrono::Utc::now(),
             kind: EventKind::DomainGenerationAlgorithm,
             fields: bincode::serialize(&value).unwrap_or_default(),
         };
@@ -1792,20 +2076,82 @@ mod tests {
     }
 
     #[test]
-    fn migrate_0_28_to_0_29_0_non_browser() {
+    fn migrate_0_29_to_0_30_dga() {
+        use crate::{migration::migration_structures::DgaBeforeV30, EventKind, EventMessage};
+
+        let settings = TestSchema::new();
+        let value: DgaBeforeV30 = dga_before_v29().into();
+
+        let message = EventMessage {
+            time: chrono::Utc::now(),
+            kind: EventKind::DomainGenerationAlgorithm,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    #[test]
+    fn migrate_0_29_to_0_30_block_list_ftp() {
         use std::net::IpAddr;
 
         use chrono::Utc;
 
         use crate::{
-            migration::migration_structures::NonBrowserBeforeV29, EventKind, EventMessage,
+            migration::migration_structures::BlockListFtpBeforeV30, EventKind, EventMessage,
         };
 
         let settings = TestSchema::new();
         let time = Utc::now();
-        let value = NonBrowserBeforeV29 {
+        let value = BlockListFtpBeforeV30 {
             source: "source_1".to_string(),
-            session_end_time: time,
+            src_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+            src_port: 46378,
+            dst_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+            dst_port: 80,
+            proto: 17,
+            last_time: 1,
+            user: "user".to_string(),
+            password: "password".to_string(),
+            reply_code: "Ok".to_string(),
+            reply_msg: "reply_msg".to_string(),
+            data_passive: false,
+            data_orig_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+            data_resp_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
+            data_resp_port: 80,
+            command: "command".to_string(),
+            file: "file".to_string(),
+            file_id: "file_id".to_string(),
+            file_size: 1000,
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::BlockListFtp,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    fn non_browser_before_v29() -> super::migration_structures::NonBrowserBeforeV29 {
+        use std::net::IpAddr;
+
+        super::migration_structures::NonBrowserBeforeV29 {
+            source: "source_1".to_string(),
+            session_end_time: chrono::Utc::now(),
             src_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
             src_port: 46378,
             dst_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
@@ -1827,10 +2173,18 @@ mod tests {
             content_encoding: "content_encoding".to_string(),
             content_type: "content_type".to_string(),
             cache_control: "cache_control".to_string(),
-        };
+        }
+    }
+
+    #[test]
+    fn migrate_0_28_to_0_29_non_browser() {
+        use crate::{EventKind, EventMessage};
+
+        let settings = TestSchema::new();
+        let value = non_browser_before_v29();
 
         let message = EventMessage {
-            time,
+            time: value.session_end_time,
             kind: EventKind::NonBrowser,
             fields: bincode::serialize(&value).unwrap_or_default(),
         };
@@ -1845,18 +2199,33 @@ mod tests {
     }
 
     #[test]
-    fn migrate_0_28_to_0_29_0_block_list_http() {
-        use std::net::IpAddr;
-
-        use chrono::Utc;
-
+    fn migrate_0_29_to_0_30_non_browser() {
         use crate::{
-            migration::migration_structures::BlockListHttpBeforeV29, EventKind, EventMessage,
+            migration::migration_structures::NonBrowserBeforeV30, EventKind, EventMessage,
         };
 
         let settings = TestSchema::new();
-        let time = Utc::now();
-        let value = BlockListHttpBeforeV29 {
+        let value: NonBrowserBeforeV30 = non_browser_before_v29().into();
+
+        let message = EventMessage {
+            time: value.session_end_time,
+            kind: EventKind::NonBrowser,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    fn block_list_http_before_v29() -> super::migration_structures::BlockListHttpBeforeV29 {
+        use std::net::IpAddr;
+
+        super::migration_structures::BlockListHttpBeforeV29 {
             source: "source_1".to_string(),
             src_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
             src_port: 46378,
@@ -1884,10 +2253,19 @@ mod tests {
             orig_mime_types: Vec::new(),
             resp_filenames: Vec::new(),
             resp_mime_types: Vec::new(),
-        };
+        }
+    }
+
+    #[test]
+    fn migrate_0_28_to_0_29_block_list_http() {
+        use crate::{EventKind, EventMessage};
+
+        let settings = TestSchema::new();
+        let value = block_list_http_before_v29();
 
         let message = EventMessage {
-            time,
+            time: chrono::Utc::now(),
+
             kind: EventKind::BlockListHttp,
             fields: bincode::serialize(&value).unwrap_or_default(),
         };
@@ -1902,18 +2280,164 @@ mod tests {
     }
 
     #[test]
-    fn migrate_0_28_to_0_29_0_block_list_ntlm() {
+    fn migrate_0_29_to_0_30_block_list_http() {
+        use crate::{
+            migration::migration_structures::BlockListHttpBeforeV30, EventKind, EventMessage,
+        };
+
+        let settings = TestSchema::new();
+        let value: BlockListHttpBeforeV30 = block_list_http_before_v29().into();
+
+        let message = EventMessage {
+            time: chrono::Utc::now(),
+            kind: EventKind::BlockListHttp,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    #[test]
+    fn migrate_0_29_to_0_30_0_block_list_kerberos() {
         use std::net::IpAddr;
+        use std::str::FromStr;
 
         use chrono::Utc;
 
         use crate::{
-            migration::migration_structures::BlockListNtlmBeforeV29, EventKind, EventMessage,
+            migration::migration_structures::BlockListKerberosBeforeV30, EventKind, EventMessage,
         };
 
         let settings = TestSchema::new();
         let time = Utc::now();
-        let value = BlockListNtlmBeforeV29 {
+        let value = BlockListKerberosBeforeV30 {
+            source: "source_1".to_string(),
+            src_addr: IpAddr::from_str("127.0.0.1").unwrap(),
+            src_port: 46378,
+            dst_addr: IpAddr::from_str("127.0.0.2").unwrap(),
+            dst_port: 80,
+            proto: 17,
+            last_time: 1,
+            client_time: 2,
+            server_time: 3,
+            error_code: 4,
+            client_realm: "client_realm".to_string(),
+            cname_type: 5,
+            client_name: vec!["client_name".to_string()],
+            realm: "realm".to_string(),
+            sname_type: 6,
+            service_name: vec!["service_name".to_string()],
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::BlockListKerberos,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    #[test]
+    fn migrate_0_29_to_0_30_0_block_list_ldap() {
+        use std::net::IpAddr;
+        use std::str::FromStr;
+
+        use chrono::Utc;
+
+        use crate::{
+            migration::migration_structures::BlockListLdapBeforeV30, EventKind, EventMessage,
+        };
+
+        let settings = TestSchema::new();
+        let time = Utc::now();
+        let value = BlockListLdapBeforeV30 {
+            source: "source_1".to_string(),
+            src_addr: IpAddr::from_str("127.0.0.1").unwrap(),
+            src_port: 46378,
+            dst_addr: IpAddr::from_str("127.0.0.2").unwrap(),
+            dst_port: 80,
+            proto: 17,
+            last_time: 1,
+            message_id: 2,
+            version: 3,
+            opcode: vec!["opcode".to_string()],
+            result: vec!["result".to_string()],
+            diagnostic_message: vec!["diagnostic_message".to_string()],
+            object: vec!["object".to_string()],
+            argument: vec!["argument".to_string()],
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::BlockListLdap,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    #[test]
+    fn migrate_0_29_to_0_30_0_block_list_rdp() {
+        use std::net::IpAddr;
+        use std::str::FromStr;
+
+        use chrono::Utc;
+
+        use crate::{
+            migration::migration_structures::BlockListRdpBeforeV30, EventKind, EventMessage,
+        };
+
+        let settings = TestSchema::new();
+        let time = Utc::now();
+        let value = BlockListRdpBeforeV30 {
+            source: "source_1".to_string(),
+            src_addr: IpAddr::from_str("127.0.0.1").unwrap(),
+            src_port: 46378,
+            dst_addr: IpAddr::from_str("127.0.0.2").unwrap(),
+            dst_port: 80,
+            proto: 17,
+            last_time: 1,
+            cookie: "cookie".to_string(),
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::BlockListRdp,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    fn block_list_ntlm_before_v29() -> super::migration_structures::BlockListNtlmBeforeV29 {
+        use std::net::IpAddr;
+
+        super::migration_structures::BlockListNtlmBeforeV29 {
             source: "source_1".to_string(),
             src_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
             src_port: 46378,
@@ -1928,10 +2452,18 @@ mod tests {
             server_dns_computer_name: "dns".to_string(),
             server_tree_name: "tree".to_string(),
             success: "tf".to_string(),
-        };
+        }
+    }
+
+    #[test]
+    fn migrate_0_28_to_0_29_block_list_ntlm() {
+        use crate::{EventKind, EventMessage};
+
+        let settings = TestSchema::new();
+        let value = block_list_ntlm_before_v29();
 
         let message = EventMessage {
-            time,
+            time: chrono::Utc::now(),
             kind: EventKind::BlockListNtlm,
             fields: bincode::serialize(&value).unwrap_or_default(),
         };
@@ -1946,18 +2478,33 @@ mod tests {
     }
 
     #[test]
-    fn migrate_0_28_to_0_29_0_block_list_smtp() {
-        use std::net::IpAddr;
-
-        use chrono::Utc;
-
+    fn migrate_0_29_to_0_30_block_list_ntlm() {
         use crate::{
-            migration::migration_structures::BlockListSmtpBeforeV29, EventKind, EventMessage,
+            migration::migration_structures::BlockListNtlmBeforeV30, EventKind, EventMessage,
         };
 
         let settings = TestSchema::new();
-        let time = Utc::now();
-        let value = BlockListSmtpBeforeV29 {
+        let value: BlockListNtlmBeforeV30 = block_list_ntlm_before_v29().into();
+
+        let message = EventMessage {
+            time: chrono::Utc::now(),
+            kind: EventKind::BlockListNtlm,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    fn block_list_smtp_before_v29() -> super::migration_structures::BlockListSmtpBeforeV29 {
+        use std::net::IpAddr;
+
+        super::migration_structures::BlockListSmtpBeforeV29 {
             source: "source_1".to_string(),
             src_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
             src_port: 46378,
@@ -1971,10 +2518,18 @@ mod tests {
             to: "to".to_string(),
             subject: "subject".to_string(),
             agent: "agent".to_string(),
-        };
+        }
+    }
+
+    #[test]
+    fn migrate_0_28_to_0_29_block_list_smtp() {
+        use crate::{EventKind, EventMessage};
+
+        let settings = TestSchema::new();
+        let value = block_list_smtp_before_v29();
 
         let message = EventMessage {
-            time,
+            time: chrono::Utc::now(),
             kind: EventKind::BlockListSmtp,
             fields: bincode::serialize(&value).unwrap_or_default(),
         };
@@ -1989,18 +2544,33 @@ mod tests {
     }
 
     #[test]
-    fn migrate_0_28_to_0_29_0_block_list_ssh() {
-        use std::net::IpAddr;
-
-        use chrono::Utc;
-
+    fn migrate_0_29_to_0_30_block_list_smtp() {
         use crate::{
-            migration::migration_structures::BlockListSshBeforeV29, EventKind, EventMessage,
+            migration::migration_structures::BlockListSmtpBeforeV30, EventKind, EventMessage,
         };
 
         let settings = TestSchema::new();
-        let time = Utc::now();
-        let value = BlockListSshBeforeV29 {
+        let value: BlockListSmtpBeforeV30 = block_list_smtp_before_v29().into();
+
+        let message = EventMessage {
+            time: chrono::Utc::now(),
+            kind: EventKind::BlockListSmtp,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    fn block_list_ssh_before_v29() -> super::migration_structures::BlockListSshBeforeV29 {
+        use std::net::IpAddr;
+
+        super::migration_structures::BlockListSshBeforeV29 {
             source: "source_1".to_string(),
             src_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
             src_port: 46378,
@@ -2020,10 +2590,18 @@ mod tests {
             kex_alg: "kex_alg".to_string(),
             host_key_alg: "host_key_alg".to_string(),
             host_key: "host_key".to_string(),
-        };
+        }
+    }
+
+    #[test]
+    fn migrate_0_28_to_0_29_block_list_ssh() {
+        use crate::{EventKind, EventMessage};
+
+        let settings = TestSchema::new();
+        let value = block_list_ssh_before_v29();
 
         let message = EventMessage {
-            time,
+            time: chrono::Utc::now(),
             kind: EventKind::BlockListSsh,
             fields: bincode::serialize(&value).unwrap_or_default(),
         };
@@ -2038,18 +2616,33 @@ mod tests {
     }
 
     #[test]
-    fn migrate_0_28_to_0_29_0_block_list_tls() {
-        use std::net::IpAddr;
-
-        use chrono::Utc;
-
+    fn migrate_0_29_to_0_30_block_list_ssh() {
         use crate::{
-            migration::migration_structures::BlockListTlsBeforeV29, EventKind, EventMessage,
+            migration::migration_structures::BlockListSshBeforeV30, EventKind, EventMessage,
         };
 
         let settings = TestSchema::new();
-        let time = Utc::now();
-        let value = BlockListTlsBeforeV29 {
+        let value: BlockListSshBeforeV30 = block_list_ssh_before_v29().into();
+
+        let message = EventMessage {
+            time: chrono::Utc::now(),
+            kind: EventKind::BlockListSsh,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    fn block_list_tls_before_v29() -> super::migration_structures::BlockListTlsBeforeV29 {
+        use std::net::IpAddr;
+
+        super::migration_structures::BlockListTlsBeforeV29 {
             source: "source_1".to_string(),
             src_addr: "192.168.4.76".parse::<IpAddr>().unwrap(),
             src_port: 46378,
@@ -2075,10 +2668,18 @@ mod tests {
             issuer_org_unit_name: "issuer_org_unit".to_string(),
             issuer_common_name: "issuer_comm".to_string(),
             last_alert: 13,
-        };
+        }
+    }
+
+    #[test]
+    fn migrate_0_28_to_0_29_block_list_tls() {
+        use crate::{EventKind, EventMessage};
+
+        let settings = TestSchema::new();
+        let value = block_list_tls_before_v29();
 
         let message = EventMessage {
-            time,
+            time: chrono::Utc::now(),
             kind: EventKind::BlockListTls,
             fields: bincode::serialize(&value).unwrap_or_default(),
         };
@@ -2090,6 +2691,569 @@ mod tests {
 
         let settings = TestSchema::new_with_dir(db_dir, backup_dir);
         assert!(super::migrate_0_28_to_0_29_0(&settings.store).is_ok());
+    }
+
+    #[test]
+    fn migrate_0_29_to_0_30_block_list_tls() {
+        use crate::{
+            migration::migration_structures::BlockListTlsBeforeV30, EventKind, EventMessage,
+        };
+
+        let settings = TestSchema::new();
+        let value: BlockListTlsBeforeV30 = block_list_tls_before_v29().into();
+
+        let message = EventMessage {
+            time: chrono::Utc::now(),
+            kind: EventKind::BlockListTls,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    #[test]
+    fn migrate_0_29_to_0_30_0_cryptocurrencyminingpool() {
+        use std::net::IpAddr;
+        use std::str::FromStr;
+
+        use chrono::Utc;
+
+        use crate::{
+            migration::migration_structures::CryptocurrencyMiningPoolBeforeV30, EventKind,
+            EventMessage,
+        };
+
+        let settings = TestSchema::new();
+        let time = Utc::now();
+        let value = CryptocurrencyMiningPoolBeforeV30 {
+            source: "source_1".to_string(),
+            src_addr: IpAddr::from_str("127.0.0.1").unwrap(),
+            src_port: 46378,
+            dst_addr: IpAddr::from_str("127.0.0.2").unwrap(),
+            dst_port: 80,
+            proto: 17,
+            session_end_time: time,
+            query: "example.com".to_string(),
+            answer: vec!["1.1.1.1".to_string()],
+            trans_id: 1001,
+            rtt: 100,
+            qclass: 1,
+            qtype: 2,
+            rcode: 3,
+            aa_flag: true,
+            tc_flag: true,
+            rd_flag: true,
+            ra_flag: true,
+            ttl: vec![100],
+            coins: vec!["bitcoin".to_string()],
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::CryptocurrencyMiningPool,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    #[test]
+    fn migrate_0_29_to_0_30_0_dnscovertchannel() {
+        use std::net::IpAddr;
+        use std::str::FromStr;
+
+        use chrono::Utc;
+
+        use crate::{
+            migration::migration_structures::DnsCovertChannelBeforeV30, EventKind, EventMessage,
+        };
+
+        let settings = TestSchema::new();
+        let time = Utc::now();
+        let value = DnsCovertChannelBeforeV30 {
+            source: "source_1".to_string(),
+            src_addr: IpAddr::from_str("127.0.0.1").unwrap(),
+            src_port: 46378,
+            dst_addr: IpAddr::from_str("127.0.0.2").unwrap(),
+            dst_port: 53,
+            proto: 17,
+            session_end_time: time,
+            query: "example.com".to_string(),
+            answer: vec!["1.1.1.1".to_string()],
+            trans_id: 1001,
+            rtt: 100,
+            qclass: 1,
+            qtype: 2,
+            rcode: 3,
+            aa_flag: true,
+            tc_flag: true,
+            rd_flag: true,
+            ra_flag: true,
+            ttl: vec![100],
+            confidence: 0.3,
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::DnsCovertChannel,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    #[test]
+    fn migrate_0_29_to_0_30_0_externalddos() {
+        use std::net::IpAddr;
+        use std::str::FromStr;
+
+        use chrono::Utc;
+
+        use crate::{
+            migration::migration_structures::ExternalDdosBeforeV30, EventKind, EventMessage,
+        };
+
+        let settings = TestSchema::new();
+        let time = Utc::now();
+        let value = ExternalDdosBeforeV30 {
+            src_addrs: vec![
+                IpAddr::from_str("127.0.0.1").unwrap(),
+                IpAddr::from_str("127.0.0.2").unwrap(),
+            ],
+            dst_addr: IpAddr::from_str("127.0.0.100").unwrap(),
+            proto: 6,
+            start_time: time,
+            last_time: time,
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::ExternalDdos,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    #[test]
+    fn migrate_0_29_to_0_30_0_ftpbruteforce() {
+        use std::net::IpAddr;
+        use std::str::FromStr;
+
+        use chrono::Utc;
+
+        use crate::{
+            migration::migration_structures::FtpBruteForceBeforeV30, EventKind, EventMessage,
+        };
+
+        let settings = TestSchema::new();
+        let time = Utc::now();
+        let value = FtpBruteForceBeforeV30 {
+            src_addr: IpAddr::from_str("127.0.0.1").unwrap(),
+            dst_addr: IpAddr::from_str("127.0.0.2").unwrap(),
+            dst_port: 21,
+            proto: 6,
+            user_list: vec!["user".to_string()],
+            start_time: time,
+            last_time: time,
+            is_internal: true,
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::FtpBruteForce,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    #[test]
+    fn migrate_0_29_to_0_30_0_ftpplaintext() {
+        use std::net::IpAddr;
+        use std::str::FromStr;
+
+        use chrono::Utc;
+
+        use crate::{
+            migration::migration_structures::FtpPlainTextBeforeV30, EventKind, EventMessage,
+        };
+
+        let settings = TestSchema::new();
+        let time = Utc::now();
+        let value = FtpPlainTextBeforeV30 {
+            source: "source_1".to_string(),
+            src_addr: IpAddr::from_str("127.0.0.1").unwrap(),
+            src_port: 46378,
+            dst_addr: IpAddr::from_str("127.0.0.2").unwrap(),
+            dst_port: 21,
+            proto: 6,
+            last_time: 1,
+            user: "user".to_string(),
+            password: "password".to_string(),
+            command: "command".to_string(),
+            reply_code: "200".to_string(),
+            reply_msg: "reply_msg".to_string(),
+            data_passive: true,
+            data_orig_addr: IpAddr::from_str("127.0.0.2").unwrap(),
+            data_resp_addr: IpAddr::from_str("127.0.0.1").unwrap(),
+            data_resp_port: 22,
+            file: "file".to_string(),
+            file_size: 100,
+            file_id: "md5".to_string(),
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::FtpPlainText,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    #[test]
+    fn migrate_0_29_to_0_30_0_ldapbruteforce_ldapplaintext() {
+        use std::net::IpAddr;
+        use std::str::FromStr;
+
+        use chrono::Utc;
+
+        use crate::{
+            migration::migration_structures::{LdapBruteForceBeforeV30, LdapPlainTextBeforeV30},
+            EventKind, EventMessage,
+        };
+
+        let settings = TestSchema::new();
+        let time = Utc::now();
+        let value = LdapBruteForceBeforeV30 {
+            src_addr: IpAddr::from_str("127.0.0.1").unwrap(),
+
+            dst_addr: IpAddr::from_str("127.0.0.2").unwrap(),
+            dst_port: 389,
+            proto: 6,
+            user_pw_list: vec![("user".to_string(), "password".to_string())],
+            start_time: time,
+            last_time: time,
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::LdapBruteForce,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let value = LdapPlainTextBeforeV30 {
+            source: "source_1".to_string(),
+            src_addr: IpAddr::from_str("127.0.0.1").unwrap(),
+            src_port: 46378,
+            dst_addr: IpAddr::from_str("127.0.0.2").unwrap(),
+            dst_port: 389,
+            proto: 6,
+            last_time: 1,
+            message_id: 2,
+            version: 3,
+            opcode: vec!["opcode".to_string()],
+            result: vec!["result".to_string()],
+            diagnostic_message: vec!["diagnostic_message".to_string()],
+            object: vec!["object".to_string()],
+            argument: vec!["argument".to_string()],
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::LdapPlainText,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    #[test]
+    fn migrate_0_29_to_0_30_0_multihostportscan_networkthreat_rdpbruteforce() {
+        use std::net::IpAddr;
+        use std::str::FromStr;
+
+        use chrono::Utc;
+
+        use crate::{
+            migration::migration_structures::{
+                MultiHostPortScanBeforeV30, NetworkThreatBeforeV30, RdpBruteForceBeforeV30,
+            },
+            EventKind, EventMessage,
+        };
+
+        let settings = TestSchema::new();
+        let time = Utc::now();
+        let value = MultiHostPortScanBeforeV30 {
+            src_addr: IpAddr::from_str("127.0.0.1").unwrap(),
+            dst_port: 80,
+            dst_addrs: vec![
+                IpAddr::from_str("127.0.0.2").unwrap(),
+                IpAddr::from_str("127.0.0.3").unwrap(),
+                IpAddr::from_str("127.0.0.4").unwrap(),
+            ],
+            proto: 6,
+            start_time: time,
+            last_time: time,
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::MultiHostPortScan,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let value = NetworkThreatBeforeV30 {
+            time,
+            source: "source_1".to_string(),
+            orig_addr: IpAddr::from_str("127.0.0.1").unwrap(),
+            orig_port: 46378,
+            resp_addr: IpAddr::from_str("127.0.0.2").unwrap(),
+            resp_port: 80,
+            proto: 6,
+            service: "service".to_string(),
+            last_time: 1,
+            content: "content".to_string(),
+            db_name: "db_name".to_string(),
+            rule_id: 200101,
+            matched_to: "matched_to".to_string(),
+            cluster_id: 11,
+            attack_kind: "attack_kind".to_string(),
+            confidence: 0.3,
+            triage_scores: None,
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::NetworkThreat,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let value = RdpBruteForceBeforeV30 {
+            src_addr: IpAddr::from_str("127.0.0.1").unwrap(),
+            dst_addrs: vec![
+                IpAddr::from_str("127.0.0.2").unwrap(),
+                IpAddr::from_str("127.0.0.3").unwrap(),
+            ],
+            start_time: time,
+            last_time: time,
+            proto: 6,
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::RdpBruteForce,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    #[test]
+    fn migrate_0_29_to_0_30_0_repeatedhttpsessions_portscan() {
+        use std::net::IpAddr;
+        use std::str::FromStr;
+
+        use chrono::Utc;
+
+        use crate::{
+            migration::migration_structures::{PortScanBeforeV30, RepeatedHttpSessionsBeforeV30},
+            EventKind, EventMessage,
+        };
+
+        let settings = TestSchema::new();
+        let time = Utc::now();
+        let value = RepeatedHttpSessionsBeforeV30 {
+            source: "source_1".to_string(),
+            src_addr: IpAddr::from_str("127.0.0.1").unwrap(),
+            src_port: 46378,
+            dst_addr: IpAddr::from_str("127.0.0.2").unwrap(),
+            dst_port: 80,
+            proto: 6,
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::RepeatedHttpSessions,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let value = PortScanBeforeV30 {
+            src_addr: IpAddr::from_str("127.0.0.1").unwrap(),
+            dst_addr: IpAddr::from_str("127.0.0.2").unwrap(),
+            dst_ports: vec![80, 81, 82, 84, 85],
+            start_time: time,
+            last_time: time,
+            proto: 6,
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::PortScan,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
+    }
+
+    #[test]
+    fn migrate_0_29_to_0_30_0_torconnection_windowsthreat() {
+        use std::net::IpAddr;
+        use std::str::FromStr;
+
+        use chrono::Utc;
+
+        use crate::{
+            migration::migration_structures::{TorConnectionBeforeV30, WindowsThreatBeforeV30},
+            EventKind, EventMessage, TriageScore,
+        };
+
+        let settings = TestSchema::new();
+        let time = Utc::now();
+        let value = TorConnectionBeforeV30 {
+            source: "source_1".to_string(),
+            src_addr: IpAddr::from_str("127.0.0.1").unwrap(),
+            src_port: 46378,
+            dst_addr: IpAddr::from_str("127.0.0.2").unwrap(),
+            dst_port: 80,
+            proto: 17,
+            session_end_time: time,
+            method: "GET".to_string(),
+            host: "cluml".to_string(),
+            uri: "/cluml.gif".to_string(),
+            referrer: "cluml.com".to_string(),
+            version: "version".to_string(),
+            user_agent: "review-database".to_string(),
+            request_len: 50,
+            response_len: 90,
+            status_code: 200,
+            status_msg: "status_msg".to_string(),
+            username: "username".to_string(),
+            password: "password".to_string(),
+            cookie: "cookie".to_string(),
+            content_encoding: "content_encoding".to_string(),
+            content_type: "content_type".to_string(),
+            cache_control: "cache_control".to_string(),
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::TorConnection,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let value = WindowsThreatBeforeV30 {
+            time,
+            source: "source_1".to_string(),
+            service: "service".to_string(),
+            agent_name: "agent_name".to_string(),
+            agent_id: "agent_id".to_string(),
+            process_guid: "process_guid".to_string(),
+            process_id: 1001,
+            image: "image".to_string(),
+            user: "user".to_string(),
+            content: "content".to_string(),
+            db_name: "db_name".to_string(),
+            rule_id: 200101,
+            matched_to: "matched_to".to_string(),
+            cluster_id: 10,
+            attack_kind: "attack_kind".to_string(),
+            confidence: 0.3,
+            triage_scores: Some(vec![
+                TriageScore {
+                    policy_id: 101,
+                    score: 0.1,
+                },
+                TriageScore {
+                    policy_id: 201,
+                    score: 0.3,
+                },
+            ]),
+        };
+
+        let message = EventMessage {
+            time,
+            kind: EventKind::WindowsThreat,
+            fields: bincode::serialize(&value).unwrap_or_default(),
+        };
+
+        let event_db = settings.store.events();
+        assert!(event_db.put(&message).is_ok());
+
+        let (db_dir, backup_dir) = settings.close();
+
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+        assert!(super::migrate_0_29_to_0_30_0(&settings.store).is_ok());
     }
 
     #[test]
@@ -2412,14 +3576,24 @@ mod tests {
             description: None,
             kind: TidbKind::Token,
             version: "1.0".to_string(),
-            patterns: vec![OldRule {
-                rule_id: 2010100,
-                name: "http_uri_threat".to_string(),
-                description: None,
-                references: None,
-                samples: None,
-                signatures: Some(vec!["sql,injection,attack".to_string()]),
-            }],
+            patterns: vec![
+                OldRule {
+                    rule_id: 2010100,
+                    name: "http_uri_threat".to_string(),
+                    description: None,
+                    references: None,
+                    samples: None,
+                    signatures: Some(vec!["sql,injection,attack".to_string()]),
+                },
+                OldRule {
+                    rule_id: 2010101,
+                    name: "http_uri_threat2".to_string(),
+                    description: None,
+                    references: None,
+                    samples: None,
+                    signatures: Some(vec!["etc,passwd".to_string()]),
+                },
+            ],
         };
         let value = bincode::DefaultOptions::new()
             .serialize(&old)

--- a/src/migration/migration_structures.rs
+++ b/src/migration/migration_structures.rs
@@ -8,9 +8,13 @@ use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 
 use crate::{
-    event::{DgaFields, HttpThreatFields, NonBrowserFields},
-    BlockListConnFields, BlockListHttpFields, BlockListNtlmFields, BlockListSmtpFields,
-    BlockListSshFields, BlockListTlsFields,
+    BlockListConnFields, BlockListDnsFields, BlockListFtpFields, BlockListHttpFields,
+    BlockListKerberosFields, BlockListLdapFields, BlockListNtlmFields, BlockListRdpFields,
+    BlockListSmtpFields, BlockListSshFields, BlockListTlsFields, CryptocurrencyMiningPoolFields,
+    DgaFields, DnsEventFields, EventCategory, ExternalDdosFields, FtpBruteForceFields,
+    FtpPlainTextFields, HttpThreatFields, LdapBruteForceFields, LdapPlainTextFields,
+    MultiHostPortScanFields, NetworkThreat, NonBrowserFields, PortScanFields, RdpBruteForceFields,
+    RepeatedHttpSessionsFields, TorConnectionFields, TriageScore, WindowsThreat,
 };
 
 #[derive(Deserialize, Serialize)]
@@ -29,7 +33,7 @@ pub struct BlockListConnBeforeV29 {
     pub resp_pkts: u64,
 }
 
-impl From<BlockListConnBeforeV29> for BlockListConnFields {
+impl From<BlockListConnBeforeV29> for BlockListConnBeforeV30 {
     fn from(input: BlockListConnBeforeV29) -> Self {
         Self {
             source: input.source,
@@ -45,6 +49,50 @@ impl From<BlockListConnBeforeV29> for BlockListConnFields {
             resp_bytes: input.resp_bytes,
             orig_pkts: input.orig_pkts,
             resp_pkts: input.resp_pkts,
+            orig_l2_bytes: 0,
+            resp_l2_bytes: 0,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct BlockListConnBeforeV30 {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub conn_state: String,
+    pub duration: i64,
+    pub service: String,
+    pub orig_bytes: u64,
+    pub resp_bytes: u64,
+    pub orig_pkts: u64,
+    pub resp_pkts: u64,
+    pub orig_l2_bytes: u64,
+    pub resp_l2_bytes: u64,
+}
+
+impl From<BlockListConnBeforeV30> for BlockListConnFields {
+    fn from(input: BlockListConnBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            conn_state: input.conn_state,
+            duration: input.duration,
+            service: input.service,
+            orig_bytes: input.orig_bytes,
+            resp_bytes: input.resp_bytes,
+            orig_pkts: input.orig_pkts,
+            resp_pkts: input.resp_pkts,
+            orig_l2_bytes: input.orig_l2_bytes,
+            resp_l2_bytes: input.resp_l2_bytes,
+            category: EventCategory::InitialAccess,
         }
     }
 }
@@ -85,7 +133,7 @@ pub struct HttpThreatBeforeV29 {
     pub confidence: f32,
 }
 
-impl From<HttpThreatBeforeV29> for HttpThreatFields {
+impl From<HttpThreatBeforeV29> for HttpThreatBeforeV30 {
     fn from(input: HttpThreatBeforeV29) -> Self {
         Self {
             time: input.time,
@@ -129,6 +177,92 @@ impl From<HttpThreatBeforeV29> for HttpThreatFields {
 }
 
 #[derive(Deserialize, Serialize)]
+#[allow(clippy::module_name_repetitions)]
+pub struct HttpThreatBeforeV30 {
+    #[serde(with = "ts_nanoseconds")]
+    pub time: DateTime<Utc>,
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub duration: i64,
+    pub method: String,
+    pub host: String,
+    pub uri: String,
+    pub referer: String,
+    pub version: String,
+    pub user_agent: String,
+    pub request_len: usize,
+    pub response_len: usize,
+    pub status_code: u16,
+    pub status_msg: String,
+    pub username: String,
+    pub password: String,
+    pub cookie: String,
+    pub content_encoding: String,
+    pub content_type: String,
+    pub cache_control: String,
+    pub orig_filenames: Vec<String>,
+    pub orig_mime_types: Vec<String>,
+    pub resp_filenames: Vec<String>,
+    pub resp_mime_types: Vec<String>,
+    pub post_body: Vec<u8>,
+    pub state: String,
+    pub db_name: String,
+    pub rule_id: u32,
+    pub matched_to: String,
+    pub cluster_id: usize,
+    pub attack_kind: String,
+    pub confidence: f32,
+}
+
+impl From<HttpThreatBeforeV30> for HttpThreatFields {
+    fn from(input: HttpThreatBeforeV30) -> Self {
+        Self {
+            time: input.time,
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            duration: input.duration,
+            method: input.method,
+            host: input.host,
+            uri: input.uri,
+            referer: input.referer,
+            version: input.version,
+            user_agent: input.user_agent,
+            request_len: input.request_len,
+            response_len: input.response_len,
+            status_code: input.status_code,
+            status_msg: input.status_msg,
+            username: input.username,
+            password: input.password,
+            cookie: input.cookie,
+            content_encoding: input.content_encoding,
+            content_type: input.content_type,
+            cache_control: input.cache_control,
+            orig_filenames: input.orig_filenames,
+            orig_mime_types: input.orig_mime_types,
+            resp_filenames: input.resp_filenames,
+            resp_mime_types: input.resp_mime_types,
+            post_body: input.post_body,
+            state: input.state,
+            db_name: input.db_name,
+            rule_id: input.rule_id,
+            matched_to: input.matched_to,
+            cluster_id: input.cluster_id,
+            attack_kind: input.attack_kind,
+            confidence: input.confidence,
+            category: EventCategory::Reconnaissance,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
 pub struct DgaBeforeV29 {
     pub source: String,
     pub src_addr: IpAddr,
@@ -156,7 +290,7 @@ pub struct DgaBeforeV29 {
     pub confidence: f32,
 }
 
-impl From<DgaBeforeV29> for DgaFields {
+impl From<DgaBeforeV29> for DgaBeforeV30 {
     fn from(input: DgaBeforeV29) -> Self {
         Self {
             source: input.source,
@@ -194,6 +328,78 @@ impl From<DgaBeforeV29> for DgaFields {
 }
 
 #[derive(Deserialize, Serialize)]
+pub struct DgaBeforeV30 {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub duration: i64,
+    pub method: String,
+    pub host: String,
+    pub uri: String,
+    pub referer: String,
+    pub version: String,
+    pub user_agent: String,
+    pub request_len: usize,
+    pub response_len: usize,
+    pub status_code: u16,
+    pub status_msg: String,
+    pub username: String,
+    pub password: String,
+    pub cookie: String,
+    pub content_encoding: String,
+    pub content_type: String,
+    pub cache_control: String,
+    pub orig_filenames: Vec<String>,
+    pub orig_mime_types: Vec<String>,
+    pub resp_filenames: Vec<String>,
+    pub resp_mime_types: Vec<String>,
+    pub post_body: Vec<u8>,
+    pub state: String,
+    pub confidence: f32,
+}
+
+impl From<DgaBeforeV30> for DgaFields {
+    fn from(input: DgaBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            duration: input.duration,
+            method: input.method,
+            host: input.host,
+            uri: input.uri,
+            referer: input.referer,
+            version: input.version,
+            user_agent: input.user_agent,
+            request_len: input.request_len,
+            response_len: input.response_len,
+            status_code: input.status_code,
+            status_msg: input.status_msg,
+            username: input.username,
+            password: input.password,
+            cookie: input.cookie,
+            content_encoding: input.content_encoding,
+            content_type: input.content_type,
+            cache_control: input.cache_control,
+            orig_filenames: input.orig_filenames,
+            orig_mime_types: input.orig_mime_types,
+            resp_filenames: input.resp_filenames,
+            resp_mime_types: input.resp_mime_types,
+            post_body: input.post_body,
+            state: input.state,
+            confidence: input.confidence,
+            category: EventCategory::CommandAndControl,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
 #[allow(clippy::module_name_repetitions)]
 pub struct NonBrowserBeforeV29 {
     pub source: String,
@@ -222,7 +428,7 @@ pub struct NonBrowserBeforeV29 {
     pub cache_control: String,
 }
 
-impl From<NonBrowserBeforeV29> for NonBrowserFields {
+impl From<NonBrowserBeforeV29> for NonBrowserBeforeV30 {
     fn from(input: NonBrowserBeforeV29) -> Self {
         Self {
             source: input.source,
@@ -258,7 +464,180 @@ impl From<NonBrowserBeforeV29> for NonBrowserFields {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[allow(clippy::module_name_repetitions)]
+pub struct NonBrowserBeforeV30 {
+    pub source: String,
+    #[serde(with = "ts_nanoseconds")]
+    pub session_end_time: DateTime<Utc>,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub method: String,
+    pub host: String,
+    pub uri: String,
+    pub referrer: String,
+    pub version: String,
+    pub user_agent: String,
+    pub request_len: usize,
+    pub response_len: usize,
+    pub status_code: u16,
+    pub status_msg: String,
+    pub username: String,
+    pub password: String,
+    pub cookie: String,
+    pub content_encoding: String,
+    pub content_type: String,
+    pub cache_control: String,
+    pub orig_filenames: Vec<String>,
+    pub orig_mime_types: Vec<String>,
+    pub resp_filenames: Vec<String>,
+    pub resp_mime_types: Vec<String>,
+    pub post_body: Vec<u8>,
+    pub state: String,
+}
+
+impl From<NonBrowserBeforeV30> for NonBrowserFields {
+    fn from(input: NonBrowserBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            session_end_time: input.session_end_time,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            method: input.method,
+            host: input.host,
+            uri: input.uri,
+            referrer: input.referrer,
+            version: input.version,
+            user_agent: input.user_agent,
+            request_len: input.request_len,
+            response_len: input.response_len,
+            status_code: input.status_code,
+            status_msg: input.status_msg,
+            username: input.username,
+            password: input.password,
+            cookie: input.cookie,
+            content_encoding: input.content_encoding,
+            content_type: input.content_type,
+            cache_control: input.cache_control,
+            orig_filenames: input.orig_filenames,
+            orig_mime_types: input.orig_mime_types,
+            resp_filenames: input.resp_filenames,
+            resp_mime_types: input.resp_mime_types,
+            post_body: input.post_body,
+            state: input.state,
+            category: EventCategory::CommandAndControl,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct BlockListDnsBeforeV30 {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub query: String,
+    pub answer: Vec<String>,
+    pub trans_id: u16,
+    pub rtt: i64,
+    pub qclass: u16,
+    pub qtype: u16,
+    pub rcode: u16,
+    pub aa_flag: bool,
+    pub tc_flag: bool,
+    pub rd_flag: bool,
+    pub ra_flag: bool,
+    pub ttl: Vec<i32>,
+}
+
+impl From<BlockListDnsBeforeV30> for BlockListDnsFields {
+    fn from(input: BlockListDnsBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            query: input.query,
+            answer: input.answer,
+            trans_id: input.trans_id,
+            rtt: input.rtt,
+            qclass: input.qclass,
+            qtype: input.qtype,
+            rcode: input.rcode,
+            aa_flag: input.aa_flag,
+            tc_flag: input.tc_flag,
+            rd_flag: input.rd_flag,
+            ra_flag: input.ra_flag,
+            ttl: input.ttl,
+            category: EventCategory::InitialAccess,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct BlockListFtpBeforeV30 {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub user: String,
+    pub password: String,
+    pub command: String,
+    pub reply_code: String,
+    pub reply_msg: String,
+    pub data_passive: bool,
+    pub data_orig_addr: IpAddr,
+    pub data_resp_addr: IpAddr,
+    pub data_resp_port: u16,
+    pub file: String,
+    pub file_size: u64,
+    pub file_id: String,
+}
+
+impl From<BlockListFtpBeforeV30> for BlockListFtpFields {
+    fn from(input: BlockListFtpBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            user: input.user,
+            password: input.password,
+            command: input.command,
+            reply_code: input.reply_code,
+            reply_msg: input.reply_msg,
+            data_passive: input.data_passive,
+            data_orig_addr: input.data_orig_addr,
+            data_resp_addr: input.data_resp_addr,
+            data_resp_port: input.data_resp_port,
+            file: input.file,
+            file_size: input.file_size,
+            file_id: input.file_id,
+            category: EventCategory::InitialAccess,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
 pub struct BlockListHttpBeforeV29 {
     pub source: String,
     pub src_addr: IpAddr,
@@ -289,7 +668,7 @@ pub struct BlockListHttpBeforeV29 {
     pub resp_mime_types: Vec<String>,
 }
 
-impl From<BlockListHttpBeforeV29> for BlockListHttpFields {
+impl From<BlockListHttpBeforeV29> for BlockListHttpBeforeV30 {
     fn from(input: BlockListHttpBeforeV29) -> Self {
         Self {
             source: input.source,
@@ -315,12 +694,166 @@ impl From<BlockListHttpBeforeV29> for BlockListHttpFields {
             content_encoding: input.content_encoding,
             content_type: input.content_type,
             cache_control: input.cache_control,
-            orig_filenames: Vec::new(),
-            orig_mime_types: Vec::new(),
-            resp_filenames: Vec::new(),
-            resp_mime_types: Vec::new(),
+            orig_filenames: input.orig_filenames,
+            orig_mime_types: input.orig_mime_types,
+            resp_filenames: input.resp_filenames,
+            resp_mime_types: input.resp_mime_types,
             post_body: Vec::new(),
             state: String::new(),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct BlockListHttpBeforeV30 {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub method: String,
+    pub host: String,
+    pub uri: String,
+    pub referrer: String,
+    pub version: String,
+    pub user_agent: String,
+    pub request_len: usize,
+    pub response_len: usize,
+    pub status_code: u16,
+    pub status_msg: String,
+    pub username: String,
+    pub password: String,
+    pub cookie: String,
+    pub content_encoding: String,
+    pub content_type: String,
+    pub cache_control: String,
+    pub orig_filenames: Vec<String>,
+    pub orig_mime_types: Vec<String>,
+    pub resp_filenames: Vec<String>,
+    pub resp_mime_types: Vec<String>,
+    pub post_body: Vec<u8>,
+    pub state: String,
+}
+
+impl From<BlockListHttpBeforeV30> for BlockListHttpFields {
+    fn from(input: BlockListHttpBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            method: input.method,
+            host: input.host,
+            uri: input.uri,
+            referrer: input.referrer,
+            version: input.version,
+            user_agent: input.user_agent,
+            request_len: input.request_len,
+            response_len: input.response_len,
+            status_code: input.status_code,
+            status_msg: input.status_msg,
+            username: input.username,
+            password: input.password,
+            cookie: input.cookie,
+            content_encoding: input.content_encoding,
+            content_type: input.content_type,
+            cache_control: input.cache_control,
+            orig_filenames: input.orig_filenames,
+            orig_mime_types: input.orig_mime_types,
+            resp_filenames: input.resp_filenames,
+            resp_mime_types: input.resp_mime_types,
+            post_body: input.post_body,
+            state: input.state,
+            category: EventCategory::InitialAccess,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct BlockListKerberosBeforeV30 {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub client_time: i64,
+    pub server_time: i64,
+    pub error_code: u32,
+    pub client_realm: String,
+    pub cname_type: u8,
+    pub client_name: Vec<String>,
+    pub realm: String,
+    pub sname_type: u8,
+    pub service_name: Vec<String>,
+}
+
+impl From<BlockListKerberosBeforeV30> for BlockListKerberosFields {
+    fn from(input: BlockListKerberosBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            client_time: input.client_time,
+            server_time: input.server_time,
+            error_code: input.error_code,
+            client_realm: input.client_realm,
+            cname_type: input.cname_type,
+            client_name: input.client_name,
+            realm: input.realm,
+            sname_type: input.sname_type,
+            service_name: input.service_name,
+            category: EventCategory::InitialAccess,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct BlockListLdapBeforeV30 {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub message_id: u32,
+    pub version: u8,
+    pub opcode: Vec<String>,
+    pub result: Vec<String>,
+    pub diagnostic_message: Vec<String>,
+    pub object: Vec<String>,
+    pub argument: Vec<String>,
+}
+
+impl From<BlockListLdapBeforeV30> for BlockListLdapFields {
+    fn from(input: BlockListLdapBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            message_id: input.message_id,
+            version: input.version,
+            opcode: input.opcode,
+            result: input.result,
+            diagnostic_message: input.diagnostic_message,
+            object: input.object,
+            argument: input.argument,
+            category: EventCategory::InitialAccess,
         }
     }
 }
@@ -343,7 +876,7 @@ pub struct BlockListNtlmBeforeV29 {
     pub success: String,
 }
 
-impl From<BlockListNtlmBeforeV29> for BlockListNtlmFields {
+impl From<BlockListNtlmBeforeV29> for BlockListNtlmBeforeV30 {
     fn from(input: BlockListNtlmBeforeV29) -> Self {
         Self {
             source: input.source,
@@ -358,6 +891,70 @@ impl From<BlockListNtlmBeforeV29> for BlockListNtlmFields {
             hostname: input.hostname,
             domainname: input.domainname,
             success: input.success,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct BlockListNtlmBeforeV30 {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub protocol: String,
+    pub username: String,
+    pub hostname: String,
+    pub domainname: String,
+    pub success: String,
+}
+
+impl From<BlockListNtlmBeforeV30> for BlockListNtlmFields {
+    fn from(input: BlockListNtlmBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            protocol: input.protocol,
+            username: input.username,
+            hostname: input.hostname,
+            domainname: input.domainname,
+            success: input.success,
+            category: EventCategory::InitialAccess,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct BlockListRdpBeforeV30 {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub cookie: String,
+}
+
+impl From<BlockListRdpBeforeV30> for BlockListRdpFields {
+    fn from(input: BlockListRdpBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            cookie: input.cookie,
+            category: EventCategory::InitialAccess,
         }
     }
 }
@@ -379,7 +976,7 @@ pub struct BlockListSmtpBeforeV29 {
     pub agent: String,
 }
 
-impl From<BlockListSmtpBeforeV29> for BlockListSmtpFields {
+impl From<BlockListSmtpBeforeV29> for BlockListSmtpBeforeV30 {
     fn from(input: BlockListSmtpBeforeV29) -> Self {
         Self {
             source: input.source,
@@ -396,6 +993,46 @@ impl From<BlockListSmtpBeforeV29> for BlockListSmtpFields {
             subject: input.subject,
             agent: input.agent,
             state: String::new(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct BlockListSmtpBeforeV30 {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub mailfrom: String,
+    pub date: String,
+    pub from: String,
+    pub to: String,
+    pub subject: String,
+    pub agent: String,
+    pub state: String,
+}
+
+impl From<BlockListSmtpBeforeV30> for BlockListSmtpFields {
+    fn from(input: BlockListSmtpBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            mailfrom: input.mailfrom,
+            date: input.date,
+            from: input.from,
+            to: input.to,
+            subject: input.subject,
+            agent: input.agent,
+            state: input.state,
+            category: EventCategory::InitialAccess,
         }
     }
 }
@@ -423,7 +1060,7 @@ pub struct BlockListSshBeforeV29 {
     pub host_key: String,
 }
 
-impl From<BlockListSshBeforeV29> for BlockListSshFields {
+impl From<BlockListSshBeforeV29> for BlockListSshBeforeV30 {
     fn from(input: BlockListSshBeforeV29) -> Self {
         Self {
             source: input.source,
@@ -446,6 +1083,58 @@ impl From<BlockListSshBeforeV29> for BlockListSshFields {
             hassh_server: String::new(),
             client_shka: String::new(),
             server_shka: String::new(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct BlockListSshBeforeV30 {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub client: String,
+    pub server: String,
+    pub cipher_alg: String,
+    pub mac_alg: String,
+    pub compression_alg: String,
+    pub kex_alg: String,
+    pub host_key_alg: String,
+    pub hassh_algorithms: String,
+    pub hassh: String,
+    pub hassh_server_algorithms: String,
+    pub hassh_server: String,
+    pub client_shka: String,
+    pub server_shka: String,
+}
+
+impl From<BlockListSshBeforeV30> for BlockListSshFields {
+    fn from(input: BlockListSshBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            client: input.client,
+            server: input.server,
+            cipher_alg: input.cipher_alg,
+            mac_alg: input.mac_alg,
+            compression_alg: input.compression_alg,
+            kex_alg: input.kex_alg,
+            host_key_alg: input.host_key_alg,
+            hassh_algorithms: input.hassh_algorithms,
+            hassh: input.hassh,
+            hassh_server_algorithms: input.hassh_server_algorithms,
+            hassh_server: input.hassh_server,
+            client_shka: input.client_shka,
+            server_shka: input.server_shka,
+            category: EventCategory::InitialAccess,
         }
     }
 }
@@ -479,7 +1168,7 @@ pub struct BlockListTlsBeforeV29 {
     pub last_alert: u8,
 }
 
-impl From<BlockListTlsBeforeV29> for BlockListTlsFields {
+impl From<BlockListTlsBeforeV29> for BlockListTlsBeforeV30 {
     fn from(input: BlockListTlsBeforeV29) -> Self {
         Self {
             source: input.source,
@@ -510,6 +1199,601 @@ impl From<BlockListTlsBeforeV29> for BlockListTlsFields {
             issuer_org_unit_name: input.issuer_org_unit_name,
             issuer_common_name: input.issuer_common_name,
             last_alert: input.last_alert,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct BlockListTlsBeforeV30 {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub server_name: String,
+    pub alpn_protocol: String,
+    pub ja3: String,
+    pub version: String,
+    pub client_cipher_suites: Vec<u16>,
+    pub client_extensions: Vec<u16>,
+    pub cipher: u16,
+    pub extensions: Vec<u16>,
+    pub ja3s: String,
+    pub serial: String,
+    pub subject_country: String,
+    pub subject_org_name: String,
+    pub subject_common_name: String,
+    pub validity_not_before: i64,
+    pub validity_not_after: i64,
+    pub subject_alt_name: String,
+    pub issuer_country: String,
+    pub issuer_org_name: String,
+    pub issuer_org_unit_name: String,
+    pub issuer_common_name: String,
+    pub last_alert: u8,
+}
+
+impl From<BlockListTlsBeforeV30> for BlockListTlsFields {
+    fn from(input: BlockListTlsBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            server_name: input.server_name,
+            alpn_protocol: input.alpn_protocol,
+            ja3: input.ja3,
+            version: input.version,
+            client_cipher_suites: input.client_cipher_suites,
+            client_extensions: input.client_extensions,
+            cipher: input.cipher,
+            extensions: input.extensions,
+            ja3s: input.ja3s,
+            serial: input.serial,
+            subject_country: input.subject_country,
+            subject_org_name: input.subject_org_name,
+            subject_common_name: input.subject_common_name,
+            validity_not_before: input.validity_not_before,
+            validity_not_after: input.validity_not_after,
+            subject_alt_name: input.subject_alt_name,
+            issuer_country: input.issuer_country,
+            issuer_org_name: input.issuer_org_name,
+            issuer_org_unit_name: input.issuer_org_unit_name,
+            issuer_common_name: input.issuer_common_name,
+            last_alert: input.last_alert,
+            category: EventCategory::InitialAccess,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct CryptocurrencyMiningPoolBeforeV30 {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    #[serde(with = "ts_nanoseconds")]
+    pub session_end_time: DateTime<Utc>,
+    pub query: String,
+    pub answer: Vec<String>,
+    pub trans_id: u16,
+    pub rtt: i64,
+    pub qclass: u16,
+    pub qtype: u16,
+    pub rcode: u16,
+    pub aa_flag: bool,
+    pub tc_flag: bool,
+    pub rd_flag: bool,
+    pub ra_flag: bool,
+    pub ttl: Vec<i32>,
+    pub coins: Vec<String>,
+}
+
+impl From<CryptocurrencyMiningPoolBeforeV30> for CryptocurrencyMiningPoolFields {
+    fn from(input: CryptocurrencyMiningPoolBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            session_end_time: input.session_end_time,
+            query: input.query,
+            answer: input.answer,
+            trans_id: input.trans_id,
+            rtt: input.rtt,
+            qclass: input.qclass,
+            qtype: input.qtype,
+            rcode: input.rcode,
+            aa_flag: input.aa_flag,
+            tc_flag: input.tc_flag,
+            rd_flag: input.rd_flag,
+            ra_flag: input.ra_flag,
+            ttl: input.ttl,
+            coins: input.coins,
+            category: EventCategory::CommandAndControl,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct DnsCovertChannelBeforeV30 {
+    pub source: String,
+    #[serde(with = "ts_nanoseconds")]
+    pub session_end_time: DateTime<Utc>,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub query: String,
+    pub answer: Vec<String>,
+    pub trans_id: u16,
+    pub rtt: i64,
+    pub qclass: u16,
+    pub qtype: u16,
+    pub rcode: u16,
+    pub aa_flag: bool,
+    pub tc_flag: bool,
+    pub rd_flag: bool,
+    pub ra_flag: bool,
+    pub ttl: Vec<i32>,
+    pub confidence: f32,
+}
+
+impl From<DnsCovertChannelBeforeV30> for DnsEventFields {
+    fn from(input: DnsCovertChannelBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            session_end_time: input.session_end_time,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            query: input.query,
+            answer: input.answer,
+            trans_id: input.trans_id,
+            rtt: input.rtt,
+            qclass: input.qclass,
+            qtype: input.qtype,
+            rcode: input.rcode,
+            aa_flag: input.aa_flag,
+            tc_flag: input.tc_flag,
+            rd_flag: input.rd_flag,
+            ra_flag: input.ra_flag,
+            ttl: input.ttl,
+            confidence: input.confidence,
+            category: EventCategory::CommandAndControl,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ExternalDdosBeforeV30 {
+    pub src_addrs: Vec<IpAddr>,
+    pub dst_addr: IpAddr,
+    pub proto: u8,
+    pub start_time: DateTime<Utc>,
+    pub last_time: DateTime<Utc>,
+}
+
+impl From<ExternalDdosBeforeV30> for ExternalDdosFields {
+    fn from(input: ExternalDdosBeforeV30) -> Self {
+        Self {
+            src_addrs: input.src_addrs,
+            dst_addr: input.dst_addr,
+            proto: input.proto,
+            start_time: input.start_time,
+            last_time: input.last_time,
+            category: EventCategory::Impact,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct FtpBruteForceBeforeV30 {
+    pub src_addr: IpAddr,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub user_list: Vec<String>,
+    pub start_time: DateTime<Utc>,
+    pub last_time: DateTime<Utc>,
+    pub is_internal: bool,
+}
+
+impl From<FtpBruteForceBeforeV30> for FtpBruteForceFields {
+    fn from(input: FtpBruteForceBeforeV30) -> Self {
+        Self {
+            src_addr: input.src_addr,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            user_list: input.user_list,
+            start_time: input.start_time,
+            last_time: input.last_time,
+            is_internal: input.is_internal,
+            category: EventCategory::CredentialAccess,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FtpPlainTextBeforeV30 {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub user: String,
+    pub password: String,
+    pub command: String,
+    pub reply_code: String,
+    pub reply_msg: String,
+    pub data_passive: bool,
+    pub data_orig_addr: IpAddr,
+    pub data_resp_addr: IpAddr,
+    pub data_resp_port: u16,
+    pub file: String,
+    pub file_size: u64,
+    pub file_id: String,
+}
+
+impl From<FtpPlainTextBeforeV30> for FtpPlainTextFields {
+    fn from(input: FtpPlainTextBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            user: input.user,
+            password: input.password,
+            command: input.command,
+            reply_code: input.reply_code,
+            reply_msg: input.reply_msg,
+            data_passive: input.data_passive,
+            data_orig_addr: input.data_orig_addr,
+            data_resp_addr: input.data_resp_addr,
+            data_resp_port: input.data_resp_port,
+            file: input.file,
+            file_size: input.file_size,
+            file_id: input.file_id,
+            category: EventCategory::LateralMovement,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct LdapBruteForceBeforeV30 {
+    pub src_addr: IpAddr,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub user_pw_list: Vec<(String, String)>,
+    pub start_time: DateTime<Utc>,
+    pub last_time: DateTime<Utc>,
+}
+
+impl From<LdapBruteForceBeforeV30> for LdapBruteForceFields {
+    fn from(input: LdapBruteForceBeforeV30) -> Self {
+        Self {
+            src_addr: input.src_addr,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            user_pw_list: input.user_pw_list,
+            start_time: input.start_time,
+            last_time: input.last_time,
+            category: EventCategory::CredentialAccess,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct LdapPlainTextBeforeV30 {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub message_id: u32,
+    pub version: u8,
+    pub opcode: Vec<String>,
+    pub result: Vec<String>,
+    pub diagnostic_message: Vec<String>,
+    pub object: Vec<String>,
+    pub argument: Vec<String>,
+}
+
+impl From<LdapPlainTextBeforeV30> for LdapPlainTextFields {
+    fn from(input: LdapPlainTextBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            message_id: input.message_id,
+            version: input.version,
+            opcode: input.opcode,
+            result: input.result,
+            diagnostic_message: input.diagnostic_message,
+            object: input.object,
+            argument: input.argument,
+            category: EventCategory::LateralMovement,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct MultiHostPortScanBeforeV30 {
+    pub src_addr: IpAddr,
+    pub dst_port: u16,
+    pub dst_addrs: Vec<IpAddr>,
+    pub proto: u8,
+    pub start_time: DateTime<Utc>,
+    pub last_time: DateTime<Utc>,
+}
+
+impl From<MultiHostPortScanBeforeV30> for MultiHostPortScanFields {
+    fn from(input: MultiHostPortScanBeforeV30) -> Self {
+        Self {
+            src_addr: input.src_addr,
+            dst_port: input.dst_port,
+            dst_addrs: input.dst_addrs,
+            proto: input.proto,
+            start_time: input.start_time,
+            last_time: input.last_time,
+            category: EventCategory::Reconnaissance,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct NetworkThreatBeforeV30 {
+    #[serde(with = "ts_nanoseconds")]
+    pub time: DateTime<Utc>,
+    pub source: String,
+    pub orig_addr: IpAddr,
+    pub orig_port: u16,
+    pub resp_addr: IpAddr,
+    pub resp_port: u16,
+    pub proto: u8,
+    pub service: String,
+    pub last_time: i64,
+    pub content: String,
+    pub db_name: String,
+    pub rule_id: u32,
+    pub matched_to: String,
+    pub cluster_id: usize,
+    pub attack_kind: String,
+    pub confidence: f32,
+    pub triage_scores: Option<Vec<TriageScore>>,
+}
+
+impl From<NetworkThreatBeforeV30> for NetworkThreat {
+    fn from(input: NetworkThreatBeforeV30) -> Self {
+        Self {
+            time: input.time,
+            source: input.source,
+            orig_addr: input.orig_addr,
+            orig_port: input.orig_port,
+            resp_addr: input.resp_addr,
+            resp_port: input.resp_port,
+            proto: input.proto,
+            service: input.service,
+            last_time: input.last_time,
+            content: input.content,
+            db_name: input.db_name,
+            rule_id: input.rule_id,
+            matched_to: input.matched_to,
+            cluster_id: input.cluster_id,
+            attack_kind: input.attack_kind,
+            confidence: input.confidence,
+            triage_scores: input.triage_scores,
+            category: EventCategory::Reconnaissance,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct RdpBruteForceBeforeV30 {
+    pub src_addr: IpAddr,
+    pub dst_addrs: Vec<IpAddr>,
+    pub start_time: DateTime<Utc>,
+    pub last_time: DateTime<Utc>,
+    pub proto: u8,
+}
+
+impl From<RdpBruteForceBeforeV30> for RdpBruteForceFields {
+    fn from(input: RdpBruteForceBeforeV30) -> Self {
+        Self {
+            src_addr: input.src_addr,
+            dst_addrs: input.dst_addrs,
+            start_time: input.start_time,
+            last_time: input.last_time,
+            proto: input.proto,
+            category: EventCategory::Discovery,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct RepeatedHttpSessionsBeforeV30 {
+    pub source: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+}
+
+impl From<RepeatedHttpSessionsBeforeV30> for RepeatedHttpSessionsFields {
+    fn from(input: RepeatedHttpSessionsBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            category: EventCategory::Exfiltration,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PortScanBeforeV30 {
+    pub src_addr: IpAddr,
+    pub dst_addr: IpAddr,
+    pub dst_ports: Vec<u16>,
+    pub start_time: DateTime<Utc>,
+    pub last_time: DateTime<Utc>,
+    pub proto: u8,
+}
+
+impl From<PortScanBeforeV30> for PortScanFields {
+    fn from(input: PortScanBeforeV30) -> Self {
+        Self {
+            src_addr: input.src_addr,
+            dst_addr: input.dst_addr,
+            dst_ports: input.dst_ports,
+            start_time: input.start_time,
+            last_time: input.last_time,
+            proto: input.proto,
+            category: EventCategory::Reconnaissance,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct TorConnectionBeforeV30 {
+    pub source: String,
+    #[serde(with = "ts_nanoseconds")]
+    pub session_end_time: DateTime<Utc>,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub method: String,
+    pub host: String,
+    pub uri: String,
+    pub referrer: String,
+    pub version: String,
+    pub user_agent: String,
+    pub request_len: usize,
+    pub response_len: usize,
+    pub status_code: u16,
+    pub status_msg: String,
+    pub username: String,
+    pub password: String,
+    pub cookie: String,
+    pub content_encoding: String,
+    pub content_type: String,
+    pub cache_control: String,
+}
+
+impl From<TorConnectionBeforeV30> for TorConnectionFields {
+    fn from(input: TorConnectionBeforeV30) -> Self {
+        Self {
+            source: input.source,
+            session_end_time: input.session_end_time,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            method: input.method,
+            host: input.host,
+            uri: input.uri,
+            referrer: input.referrer,
+            version: input.version,
+            user_agent: input.user_agent,
+            request_len: input.request_len,
+            response_len: input.response_len,
+            status_code: input.status_code,
+            status_msg: input.status_msg,
+            username: input.username,
+            password: input.password,
+            cookie: input.cookie,
+            content_encoding: input.content_encoding,
+            content_type: input.content_type,
+            cache_control: input.cache_control,
+            orig_filenames: Vec::new(),
+            orig_mime_types: Vec::new(),
+            resp_filenames: Vec::new(),
+            resp_mime_types: Vec::new(),
+            post_body: Vec::new(),
+            state: String::new(),
+            category: EventCategory::CommandAndControl,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct WindowsThreatBeforeV30 {
+    #[serde(with = "ts_nanoseconds")]
+    pub time: DateTime<Utc>,
+    pub source: String,
+    pub service: String,
+    pub agent_name: String,
+    pub agent_id: String,
+    pub process_guid: String,
+    pub process_id: u32,
+    pub image: String,
+    pub user: String,
+    pub content: String,
+    pub db_name: String,
+    pub rule_id: u32,
+    pub matched_to: String,
+    pub cluster_id: usize,
+    pub attack_kind: String,
+    pub confidence: f32,
+    pub triage_scores: Option<Vec<TriageScore>>,
+}
+
+impl From<WindowsThreatBeforeV30> for WindowsThreat {
+    fn from(input: WindowsThreatBeforeV30) -> Self {
+        Self {
+            time: input.time,
+            source: input.source,
+            service: input.service,
+            agent_name: input.agent_name,
+            agent_id: input.agent_id,
+            process_guid: input.process_guid,
+            process_id: input.process_id,
+            image: input.image,
+            user: input.user,
+            content: input.content,
+            db_name: input.db_name,
+            rule_id: input.rule_id,
+            matched_to: input.matched_to,
+            cluster_id: input.cluster_id,
+            attack_kind: input.attack_kind,
+            confidence: input.confidence,
+            triage_scores: input.triage_scores,
+            category: EventCategory::Impact,
         }
     }
 }


### PR DESCRIPTION
Related #315 

Add `category` field to all the detected event structures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added a `category` field to multiple event structures, enhancing event categorization and processing flexibility across various event types.
  - Introduced new fields such as `orig_l2_bytes`, `resp_l2_bytes`, and detailed fields for structures related to BOOTP, DHCP, and other events.

- **Modifications**
  - Updated the `category` methods in various event structures to return dynamic values rather than hardcoded defaults, improving accuracy in event classification.

- **Migration Enhancements**
  - Enhanced migration processes to accommodate new event structures and ensure robust data handling during version upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->