### PR TITLE
Fix CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   `language` parameter, enabling language updates alongside existing fields.
 - Added `category` field to TI db and TI rules.
 
+### Removed
+
+- The outlier table has been removed from the PostgreSQL database.
+
 ## [0.29.1] - 2024-08-05
 
 ### Fixed
@@ -63,7 +67,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - Giganto-related settings from `Node::settings` are removed; those in
     `Node::settings_draft` are stored in `Node::giganto::draft` as
     TOML-formatted strings.
-- The outlier table has been removed from the PostgreSQL database.
 
 ### Fixed
 


### PR DESCRIPTION
[My previous PR](https://github.com/petabi/review-database/pull/324) incorrectly updated `CHANGELOG`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated configuration management for Giganto-related settings, transitioning to TOML-formatted strings for improved clarity and organization.

- **Removed Features**
	- Outlier table has been removed from the database, which may affect data processing and querying.

These changes enhance the application's performance and streamline configuration practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->