### PR TITLE
Remove get_max_event_id_num function

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -417,20 +417,6 @@ impl Database {
         Ok(dsl::model.count().get_result(&mut conn).await?)
     }
 
-    /// Returns the maximum number of outliers of the model with the given name.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the model does not exist or if a database operation fails.
-    pub async fn get_max_event_id_num(&self, model_name: &str) -> Result<i32, Error> {
-        let mut conn = self.pool.get_diesel_conn().await?;
-        Ok(dsl::model
-            .select(dsl::max_event_id_num)
-            .filter(dsl::name.eq(model_name))
-            .get_result(&mut conn)
-            .await?)
-    }
-
     /// Returns the model with the given ID.
     ///
     /// # Errors


### PR DESCRIPTION
It is no longer used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed an obsolete function that was causing confusion related to event ID retrieval.
  
- **Chores**
	- Updated documentation to reflect the removal of the function and its impact on existing code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->