### PR TITLE
Update rustls-native-certs dependency to version 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - `TorConnection`: `orig_filenames`, `orig_mime_types`, `resp_filenames`,
     `resp_mime_types`, `post_body`, `state`
 - Added `update` method in `TrustedDomain`.
+- Improved platform certificate loading process to skip individual certificates
+  that fail to load, allowing the rest of the certificates to be loaded
+  successfully. Previously, the entire platform certificate loading process
+  would fail if any certificate failed to load.
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rustls = { version = "0.23", default-features = false, features = [
   "ring",
   "std",
 ] } # should be the same version as what tokio-postgres-rustls depends on
-rustls-native-certs = "0.7"
+rustls-native-certs = "0.8"
 rustls-pemfile = "2"
 rustls-pki-types = "1"
 semver = "1"

--- a/src/backends/postgres.rs
+++ b/src/backends/postgres.rs
@@ -192,13 +192,12 @@ impl ConnectionPoolType {
     ) -> Result<ClientConfig, rustls::Error> {
         let mut root_store = RootCertStore::empty();
         if with_platform_root {
-            match rustls_native_certs::load_native_certs() {
-                Ok(certs) => {
-                    for cert in certs {
-                        root_store.add(cert)?;
-                    }
-                }
-                Err(e) => tracing::error!("Could not load platform certificates: {:#}", e),
+            let certs = rustls_native_certs::load_native_certs();
+            for c in certs.certs {
+                root_store.add(c)?;
+            }
+            for e in certs.errors {
+                tracing::warn!("Could not load platform certificate: {:#}", e);
             }
         }
         for root in root_ca {


### PR DESCRIPTION
Improved the platform certificate loading process to skip individual certificates that fail to load, allowing the rest of the certificates to be loaded successfully. Previously, the entire platform certificate loading process would fail if any certificate failed to load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced certificate loading process to continue even if some certificates fail, improving system reliability.
  - Introduced a new method to the `TrustedDomain` class for better management.

- **Dependency Updates**
  - Updated the `rustls-native-certs` library to version 0.8, which may introduce new features and bug fixes.

- **Bug Fixes**
  - Simplified error handling during certificate loading, now logging warnings for errors encountered, ensuring valid certificates are still processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->