### PR TITLE
Bump version to 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.30.0] - 2024-09-03
 
 ### Added
 
@@ -656,7 +656,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Modified `FtpBruteForce` by adding an `is_internal` field which is a boolean
   indicating whether it is internal or not.
 
-[Unreleased]: https://github.com/petabi/review-database/compare/0.29.1...main
+[0.30.0]: https://github.com/petabi/review-database/compare/0.29.1...0.30.0
 [0.29.1]: https://github.com/petabi/review-database/compare/0.29.0...0.29.1
 [0.29.0]: https://github.com/petabi/review-database/compare/0.28.0...0.29.0
 [0.28.0]: https://github.com/petabi/review-database/compare/0.27.1...0.28.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.30.0-alpha.1"
+version = "0.30.0"
 edition = "2021"
 
 [dependencies]

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -38,7 +38,7 @@ use crate::{Agent, AgentStatus, Giganto, Indexed, IterableMap};
 /// // the database format won't be changed in the future alpha or beta versions.
 /// const COMPATIBLE_VERSION: &str = ">=0.5.0-alpha.2,<=0.5.0-alpha.4";
 /// ```
-const COMPATIBLE_VERSION_REQ: &str = ">0.29.1,<=0.30.0-alpha.1";
+const COMPATIBLE_VERSION_REQ: &str = ">=0.30.0,<0.31.0-alpha";
 
 /// Migrates data exists in `PostgresQL` to Rocksdb if necessary.
 ///
@@ -132,8 +132,8 @@ pub fn migrate_data_dir<P: AsRef<Path>>(data_dir: P, backup_dir: P) -> Result<()
             migrate_0_28_to_0_29_0,
         ),
         (
-            VersionReq::parse(">=0.29.1,<0.30.0-alpha.1")?,
-            Version::parse("0.30.0-alpha.1")?,
+            VersionReq::parse(">=0.29.0,<0.30.0")?,
+            Version::parse("0.30.0")?,
             migrate_0_29_to_0_30_0,
         ),
     ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new field `is_internal` to the `FtpBruteForce` entity for better instance classification.
  
- **Version Updates**
	- Updated the package version from "0.30.0-alpha.1" to "0.30.0," marking the transition to a stable release.

- **Compatibility Enhancements**
	- Broadened version compatibility requirements to support versions from `0.30.0` to just below `0.31.0-alpha`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->