### PR TITLE
Copies trusted domains to redb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.30.0"
+version = "0.31.0-alpha.1"
 edition = "2021"
 
 [dependencies]
@@ -26,6 +26,8 @@ futures = "0.3"
 humantime-serde = "1"
 ip2location = "0.5"
 ipnet = { version = "2", features = ["serde"] }
+native_db = "0.7"
+native_model = "0.4"
 num-derive = "0.4"
 num-traits = "0.2"
 postgres-protocol = "0.6"

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,37 @@
+//! All the models stored in the database.
+
+use std::sync::LazyLock;
+
+use native_db::Models;
+
+pub(crate) static MODELS: LazyLock<Models> = LazyLock::new(|| models().expect("valid model"));
+
+pub type TrustedDomain = v1::TrustedDomain;
+
+pub(crate) fn models() -> anyhow::Result<Models> {
+    let mut models = Models::new();
+    models.define::<TrustedDomain>()?;
+    Ok(models)
+}
+
+pub(crate) mod v1 {
+    use native_db::{native_db, ToKey};
+    use native_model::{native_model, Model};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize)]
+    #[native_model(id = 1, version = 1)]
+    #[native_db]
+    pub struct TrustedDomain {
+        #[primary_key]
+        pub name: String,
+        pub remarks: String,
+    }
+}
+
+mod tests {
+    #[test]
+    fn validate_models() {
+        assert!(super::models().is_ok());
+    }
+}


### PR DESCRIPTION
The public API still uses the old trusted domains in RocksDB. The main purpose is to make sure the migration works correctly.