### PR TITLE
Implement backup functionality for redb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.3"
 humantime-serde = "1"
 ip2location = "0.5"
 ipnet = { version = "2", features = ["serde"] }
-native_db = "0.7"
+native_db = { version = "0.7", default-features = false }
 native_model = "0.4"
 num-derive = "0.4"
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.30.1-alpha.1"
+version = "0.31.0-alpha.1"
 edition = "2021"
 
 [dependencies]
@@ -27,6 +27,8 @@ futures = "0.3"
 humantime-serde = "1"
 ip2location = "0.5"
 ipnet = { version = "2", features = ["serde"] }
+native_db = "0.7"
+native_model = "0.4"
 num-derive = "0.4"
 num-traits = "0.2"
 postgres-protocol = "0.6"

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,37 @@
+//! All the models stored in the database.
+
+use std::sync::LazyLock;
+
+use native_db::Models;
+
+pub(crate) static MODELS: LazyLock<Models> = LazyLock::new(|| models().expect("valid model"));
+
+pub type TrustedDomain = v1::TrustedDomain;
+
+pub(crate) fn models() -> anyhow::Result<Models> {
+    let mut models = Models::new();
+    models.define::<TrustedDomain>()?;
+    Ok(models)
+}
+
+pub(crate) mod v1 {
+    use native_db::{native_db, ToKey};
+    use native_model::{native_model, Model};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize)]
+    #[native_model(id = 1, version = 1)]
+    #[native_db]
+    pub struct TrustedDomain {
+        #[primary_key]
+        pub name: String,
+        pub remarks: String,
+    }
+}
+
+mod tests {
+    #[test]
+    fn validate_models() {
+        assert!(super::models().is_ok());
+    }
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -19,7 +19,7 @@ pub(crate) mod v1 {
     use native_model::{native_model, Model};
     use serde::{Deserialize, Serialize};
 
-    #[derive(Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     #[native_model(id = 1, version = 1)]
     #[native_db]
     pub struct TrustedDomain {

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -223,21 +223,11 @@ fn migrate_0_30_to_0_31(store: &super::Store) -> Result<()> {
 fn migrate_rocksdb_to_native_db(store: &super::Store) -> Result<()> {
     use crate::Iterable;
 
-    impl From<crate::tables::TrustedDomain> for crate::data::TrustedDomain {
-        fn from(input: crate::tables::TrustedDomain) -> Self {
-            Self {
-                name: input.name,
-                remarks: input.remarks,
-            }
-        }
-    }
-
     let table = store.trusted_domain_map();
     let db = &store.states;
     let rw = db.rw_transaction()?;
     for rec in table.iter(rocksdb::Direction::Forward, None) {
-        let old = rec?;
-        rw.insert(crate::data::TrustedDomain::from(old))?;
+        rw.insert(rec?)?;
     }
     rw.commit()?;
 

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -66,9 +66,9 @@ pub use self::triage_policy::{
     Update as TriagePolicyUpdate, ValueKind,
 };
 pub use self::triage_response::{TriageResponse, Update as TriageResponseUpdate};
-pub use self::trusted_domain::TrustedDomain;
 pub use self::trusted_user_agent::TrustedUserAgent;
 use super::{event, Indexed, IndexedMap, Map};
+pub use crate::data::TrustedDomain;
 use crate::{
     batch_info::BatchInfo,
     category::Category,

--- a/src/tables/trusted_domain.rs
+++ b/src/tables/trusted_domain.rs
@@ -4,16 +4,10 @@ use std::borrow::Cow;
 
 use anyhow::Result;
 use rocksdb::OptimisticTransactionDB;
-use serde::{Deserialize, Serialize};
 
 use super::Value;
+use crate::data::TrustedDomain;
 use crate::{types::FromKeyValue, Map, Table, UniqueKey};
-
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
-pub struct TrustedDomain {
-    pub name: String,
-    pub remarks: String,
-}
 
 impl FromKeyValue for TrustedDomain {
     fn from_key_value(key: &[u8], value: &[u8]) -> Result<Self, anyhow::Error> {
@@ -72,8 +66,9 @@ mod test {
 
     use rocksdb::Direction;
 
+    use super::TrustedDomain;
     use crate::types::FromKeyValue;
-    use crate::{Iterable, Store, TrustedDomain};
+    use crate::{Iterable, Store};
 
     #[test]
     fn operations() {


### PR DESCRIPTION
This change adds the ability to backup the redb database to a file. It also moves all backup-related methods of `Store` to the backup module, in order to keep the lib.rs file clean.