### PR TITLE
Remove unnecessary `Cow` from `UniqueKey`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
     configuration settings from existing REview deployments to migrate databases
     using review-migrate.
 
+### Changed
+
+- Refactored the `UniqueKey` trait to remove the use of `Cow<[u8]>` as the
+  return type for `unique_key`. The return type is now specified by an
+  associated type `AsBytes<'a>`, allowing for more flexibliity in the
+  implementation of `unique_key`.
+
 ### Removed
 
 - `Database::cluster_id`: This method was previously used to convert a cluster

--- a/src/account.rs
+++ b/src/account.rs
@@ -122,8 +122,10 @@ impl Account {
 }
 
 impl UniqueKey for Account {
-    fn unique_key(&self) -> Cow<[u8]> {
-        Cow::Borrowed(self.username.as_bytes())
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> Self::AsBytes<'_> {
+        self.username.as_bytes()
     }
 }
 

--- a/src/batch_info.rs
+++ b/src/batch_info.rs
@@ -32,11 +32,12 @@ impl From<crate::types::ModelBatchInfo> for BatchInfo {
 }
 
 impl UniqueKey for BatchInfo {
-    fn unique_key(&self) -> Cow<[u8]> {
+    type AsBytes<'a> = Vec<u8> where Self: 'a;
+
+    fn unique_key(&self) -> Self::AsBytes<'_> {
         let mut key = self.model.to_be_bytes().to_vec();
         key.extend(self.inner.id.to_be_bytes());
-
-        Cow::Owned(key)
+        key
     }
 }
 

--- a/src/scores.rs
+++ b/src/scores.rs
@@ -21,12 +21,14 @@ impl Scores {
 }
 
 impl UniqueKey for Scores {
-    fn unique_key(&self) -> Cow<[u8]> {
+    type AsBytes<'a> = Vec<u8>;
+
+    fn unique_key(&self) -> Vec<u8> {
         use bincode::Options;
         let Ok(key) = bincode::DefaultOptions::new().serialize(&self.model) else {
             unreachable!("serialization into memory should never fail")
         };
-        Cow::Owned(key)
+        key
     }
 }
 

--- a/src/tables/agent.rs
+++ b/src/tables/agent.rs
@@ -141,10 +141,12 @@ impl FromKeyValue for Agent {
 }
 
 impl UniqueKey for Agent {
-    fn unique_key(&self) -> Cow<[u8]> {
+    type AsBytes<'a> = Vec<u8>;
+
+    fn unique_key(&self) -> Vec<u8> {
         let mut buf = self.node.to_be_bytes().to_vec();
         buf.extend(self.key.as_bytes());
-        Cow::Owned(buf)
+        buf
     }
 }
 

--- a/src/tables/allow_network.rs
+++ b/src/tables/allow_network.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use rocksdb::OptimisticTransactionDB;
 use serde::{Deserialize, Serialize};
 
+use super::UniqueKey;
 use crate::{
     types::FromKeyValue, HostNetworkGroup, Indexable, Indexed, IndexedMap, IndexedMapUpdate,
     IndexedTable,
@@ -22,6 +23,14 @@ pub struct AllowNetwork {
 impl FromKeyValue for AllowNetwork {
     fn from_key_value(_key: &[u8], value: &[u8]) -> anyhow::Result<Self> {
         super::deserialize(value)
+    }
+}
+
+impl UniqueKey for AllowNetwork {
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.name.as_bytes()
     }
 }
 

--- a/src/tables/block_network.rs
+++ b/src/tables/block_network.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use rocksdb::OptimisticTransactionDB;
 use serde::{Deserialize, Serialize};
 
+use super::UniqueKey;
 use crate::{
     types::FromKeyValue, HostNetworkGroup, Indexable, Indexed, IndexedMap, IndexedMapUpdate,
     IndexedTable,
@@ -22,6 +23,14 @@ pub struct BlockNetwork {
 impl FromKeyValue for BlockNetwork {
     fn from_key_value(_key: &[u8], value: &[u8]) -> anyhow::Result<Self> {
         super::deserialize(value)
+    }
+}
+
+impl UniqueKey for BlockNetwork {
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.name.as_bytes()
     }
 }
 

--- a/src/tables/category.rs
+++ b/src/tables/category.rs
@@ -2,6 +2,7 @@
 use anyhow::Result;
 use rocksdb::OptimisticTransactionDB;
 
+use super::UniqueKey;
 use crate::{category::Category, types::FromKeyValue, Indexed, IndexedMap, IndexedTable};
 
 const DEFAULT_ENTRIES: [(u32, &str); 2] = [(1, "Non-Specified Alert"), (2, "Irrelevant Alert")];
@@ -9,6 +10,14 @@ const DEFAULT_ENTRIES: [(u32, &str); 2] = [(1, "Non-Specified Alert"), (2, "Irre
 impl FromKeyValue for Category {
     fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
         super::deserialize(value)
+    }
+}
+
+impl UniqueKey for Category {
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.name.as_bytes()
     }
 }
 

--- a/src/tables/customer.rs
+++ b/src/tables/customer.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Utc};
 use rocksdb::OptimisticTransactionDB;
 use serde::{Deserialize, Serialize};
 
+use super::UniqueKey;
 use crate::{
     types::FromKeyValue, HostNetworkGroup, Indexable, Indexed, IndexedMap, IndexedMapUpdate,
     IndexedTable, NetworkType,
@@ -24,6 +25,14 @@ pub struct Customer {
 impl FromKeyValue for Customer {
     fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
         super::deserialize(value)
+    }
+}
+
+impl UniqueKey for Customer {
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.name.as_bytes()
     }
 }
 

--- a/src/tables/data_source.rs
+++ b/src/tables/data_source.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use rocksdb::OptimisticTransactionDB;
 use serde::{Deserialize, Serialize};
 
+use super::UniqueKey;
 use crate::{types::FromKeyValue, Indexable, Indexed, IndexedMap, IndexedMapUpdate, IndexedTable};
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -26,6 +27,14 @@ pub struct DataSource {
 impl FromKeyValue for DataSource {
     fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
         super::deserialize(value)
+    }
+}
+
+impl UniqueKey for DataSource {
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.name.as_bytes()
     }
 }
 

--- a/src/tables/network.rs
+++ b/src/tables/network.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Utc};
 use rocksdb::{Direction, OptimisticTransactionDB};
 use serde::{Deserialize, Serialize};
 
+use super::UniqueKey;
 use crate::{
     types::FromKeyValue, HostNetworkGroup, Indexable, Indexed, IndexedMap, IndexedMapUpdate,
     IndexedTable, Iterable,
@@ -84,6 +85,14 @@ impl FromKeyValue for Network {
             tag_ids: value.tag_ids,
             creation_time: value.creation_time,
         })
+    }
+}
+
+impl UniqueKey for Network {
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.name.as_bytes()
     }
 }
 

--- a/src/tables/node.rs
+++ b/src/tables/node.rs
@@ -42,8 +42,10 @@ pub struct Update {
 }
 
 impl UniqueKey for Node {
-    fn unique_key(&self) -> Cow<[u8]> {
-        Cow::from(self.name.as_bytes())
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.name.as_bytes()
     }
 }
 

--- a/src/tables/outlier_info.rs
+++ b/src/tables/outlier_info.rs
@@ -39,14 +39,16 @@ impl FromKeyValue for OutlierInfo {
 }
 
 impl UniqueKey for OutlierInfo {
-    fn unique_key(&self) -> Cow<[u8]> {
+    type AsBytes<'a> = Vec<u8>;
+
+    fn unique_key(&self) -> Vec<u8> {
         let mut buf = vec![];
         buf.extend(self.model_id.to_be_bytes());
         buf.extend(self.timestamp.to_be_bytes());
         buf.extend(self.rank.to_be_bytes());
         buf.extend(self.id.to_be_bytes());
         buf.extend(self.source.as_bytes());
-        Cow::Owned(buf)
+        buf
     }
 }
 
@@ -201,7 +203,7 @@ mod tests {
         let res = super::Key::from_be_bytes(&key);
         assert!(res.is_ok());
         let serialized_key = res.unwrap().to_bytes();
-        assert_eq!(&serialized_key, key.as_ref());
+        assert_eq!(serialized_key, key);
 
         let value = entry.value();
         let reassembled = OutlierInfo::from_key_value(&key, &value);

--- a/src/tables/qualifier.rs
+++ b/src/tables/qualifier.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use anyhow::Result;
 use rocksdb::OptimisticTransactionDB;
 
+use super::UniqueKey;
 use crate::{
     types::{FromKeyValue, Qualifier},
     Indexable, Indexed, IndexedMap, IndexedMapUpdate, IndexedTable,
@@ -20,6 +21,14 @@ const DEFAULT_ENTRIES: [(u32, &str); 4] = [
 impl FromKeyValue for Qualifier {
     fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
         super::deserialize(value)
+    }
+}
+
+impl UniqueKey for Qualifier {
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.description.as_bytes()
     }
 }
 

--- a/src/tables/sampling_policy.rs
+++ b/src/tables/sampling_policy.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Utc};
 use rocksdb::OptimisticTransactionDB;
 use serde::{Deserialize, Serialize};
 
+use super::UniqueKey;
 use crate::{types::FromKeyValue, Indexable, Indexed, IndexedMap, IndexedMapUpdate, IndexedTable};
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -28,6 +29,14 @@ pub struct SamplingPolicy {
 impl FromKeyValue for SamplingPolicy {
     fn from_key_value(_key: &[u8], value: &[u8]) -> anyhow::Result<Self> {
         super::deserialize(value)
+    }
+}
+
+impl UniqueKey for SamplingPolicy {
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.name.as_bytes()
     }
 }
 

--- a/src/tables/status.rs
+++ b/src/tables/status.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use anyhow::Result;
 use rocksdb::OptimisticTransactionDB;
 
+use super::UniqueKey;
 use crate::{
     types::{FromKeyValue, Status},
     Indexable, Indexed, IndexedMap, IndexedMapUpdate, IndexedTable,
@@ -15,6 +16,14 @@ const DEFAULT_ENTRIES: [(u32, &str); 3] = [(1, "reviewed"), (2, "pending review"
 impl FromKeyValue for Status {
     fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
         super::deserialize(value)
+    }
+}
+
+impl UniqueKey for Status {
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.description.as_bytes()
     }
 }
 

--- a/src/tables/template.rs
+++ b/src/tables/template.rs
@@ -1,7 +1,5 @@
 //! The `template` table.
 
-use std::borrow::Cow;
-
 use anyhow::Result;
 use rocksdb::OptimisticTransactionDB;
 use serde::{Deserialize, Serialize};
@@ -30,8 +28,10 @@ impl Template {
 }
 
 impl UniqueKey for Template {
-    fn unique_key(&self) -> Cow<[u8]> {
-        Cow::Borrowed(self.name().as_bytes())
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.name().as_bytes()
     }
 }
 

--- a/src/tables/tidb.rs
+++ b/src/tables/tidb.rs
@@ -83,8 +83,10 @@ pub enum Kind {
 }
 
 impl UniqueKey for Tidb {
-    fn unique_key(&self) -> std::borrow::Cow<[u8]> {
-        std::borrow::Cow::Borrowed(self.name.as_bytes())
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.name.as_bytes()
     }
 }
 

--- a/src/tables/tor_exit_node.rs
+++ b/src/tables/tor_exit_node.rs
@@ -21,8 +21,10 @@ impl TorExitNode {
 }
 
 impl UniqueKey for TorExitNode {
-    fn unique_key(&self) -> std::borrow::Cow<[u8]> {
-        std::borrow::Cow::Borrowed(self.ip_address.as_bytes())
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.ip_address.as_bytes()
     }
 }
 

--- a/src/tables/traffic_filter.rs
+++ b/src/tables/traffic_filter.rs
@@ -27,8 +27,10 @@ impl FromKeyValue for TrafficFilter {
 }
 
 impl UniqueKey for TrafficFilter {
-    fn unique_key(&self) -> Cow<[u8]> {
-        Cow::Borrowed(self.agent.as_bytes())
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.agent.as_bytes()
     }
 }
 

--- a/src/tables/triage_policy.rs
+++ b/src/tables/triage_policy.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Utc};
 use rocksdb::OptimisticTransactionDB;
 use serde::{Deserialize, Serialize};
 
+use super::UniqueKey;
 use crate::{
     types::{EventCategory, FromKeyValue},
     Indexable, Indexed, IndexedMap, IndexedMapUpdate, IndexedTable,
@@ -26,6 +27,14 @@ pub struct TriagePolicy {
 impl FromKeyValue for TriagePolicy {
     fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
         super::deserialize(value)
+    }
+}
+
+impl UniqueKey for TriagePolicy {
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.name.as_bytes()
     }
 }
 

--- a/src/tables/triage_response.rs
+++ b/src/tables/triage_response.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Utc};
 use rocksdb::{Direction, OptimisticTransactionDB};
 use serde::{Deserialize, Serialize};
 
+use super::UniqueKey;
 use crate::{
     types::FromKeyValue, Indexable, Indexed, IndexedMap, IndexedMapUpdate, IndexedTable, Iterable,
 };
@@ -70,6 +71,14 @@ impl TriageResponse {
 impl FromKeyValue for TriageResponse {
     fn from_key_value(_key: &[u8], value: &[u8]) -> Result<Self> {
         super::deserialize(value)
+    }
+}
+
+impl UniqueKey for TriageResponse {
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        &self.key
     }
 }
 

--- a/src/tables/trusted_domain.rs
+++ b/src/tables/trusted_domain.rs
@@ -25,8 +25,10 @@ impl FromKeyValue for TrustedDomain {
 }
 
 impl UniqueKey for TrustedDomain {
-    fn unique_key(&self) -> Cow<[u8]> {
-        Cow::Borrowed(self.name.as_bytes())
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.name.as_bytes()
     }
 }
 
@@ -53,7 +55,7 @@ impl<'d> Table<'d, TrustedDomain> {
     pub fn update(&self, old: &TrustedDomain, new: &TrustedDomain) -> Result<()> {
         let (ok, ov) = (old.unique_key(), old.value());
         let (nk, nv) = (new.unique_key(), new.value());
-        self.map.update((&ok, &ov), (&nk, &nv))
+        self.map.update((ok, &ov), (nk, &nv))
     }
 
     /// Removes a `TrustedDomain` with the given name.

--- a/src/tables/trusted_user_agent.rs
+++ b/src/tables/trusted_user_agent.rs
@@ -31,8 +31,10 @@ impl FromKeyValue for TrustedUserAgent {
 }
 
 impl UniqueKey for TrustedUserAgent {
-    fn unique_key(&self) -> Cow<[u8]> {
-        Cow::Borrowed(self.user_agent.as_bytes())
+    type AsBytes<'a> = &'a [u8];
+
+    fn unique_key(&self) -> &[u8] {
+        self.user_agent.as_bytes()
     }
 }
 
@@ -72,7 +74,7 @@ impl<'d> Table<'d, TrustedUserAgent> {
 
         self.map.update(
             (old.as_bytes(), value.as_ref()),
-            (&new.unique_key(), &new.value()),
+            (new.unique_key(), &new.value()),
         )
     }
 }


### PR DESCRIPTION
- Refactored the `UniqueKey` trait to remove the use of `Cow<[u8]>` for the `unique_key` method's return type.
- Introduced an associated type `AsBytes<'a>`, which allows implementations to define the return type of `unique_key` more flexibly.

This refactor leads to cleaner and more efficient implementations, especially when handling keys that don't require ownership transfer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced new implementations of the `UniqueKey` trait for multiple structs, enhancing their ability to provide unique keys based on their respective fields.

- **Improvements**
  - Simplified the return type of the `unique_key` method across various structs, transitioning from `Cow<[u8]>` to direct byte slice references (`&[u8]` or `Vec<u8>`), improving clarity and efficiency.

- **Documentation**
  - Updated method signatures and added associated types to the `UniqueKey` trait for better type handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->