### PR TITLE
Add packet attribute triage function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Added `update_agent_status_by_hostname` public function to `Node` table. This
   function allows updating an agent’s status using the node’s hostname and the
   agent’s ID.
+- Added triage functionality for scoring with attributes of each raw event.
+  Previously, all detection events always returned a score of 0.0. It now
+  compares the values against the provided attribute correctly and returns a
+  score.
 
 ### Changed
 
@@ -22,6 +26,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   instead of Display trait.
 - `Filter::host_name` has been renamed to `Filter::hostname` to align with the
   naming convention used in other parts of the codebase.
+- Modified the `ValueKind` enum to support different types of input for packet
+  attribute triage.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 aho-corasick = "1"
 anyhow = "1"
 argon2 = { version = "0.5", features = ["std"] }
+attrievent = { git = "https://github.com/aicers/attrievent.git", tag = "0.2.1" }
 bb8-postgres = { version = "0.9", features = [
   "with-serde_json-1",
   "with-chrono-0_4",
@@ -26,6 +27,7 @@ futures = "0.3"
 humantime-serde = "1"
 ip2location = "0.5.4"
 ipnet = { version = "2", features = ["serde"] }
+memchr = "2"
 num-derive = "0.4"
 num-traits = "0.2"
 postgres-protocol = "0.6"

--- a/src/event.rs
+++ b/src/event.rs
@@ -3435,7 +3435,7 @@ mod tests {
             message: "message".to_string(),
             renewal_time: 100,
             rebinding_time: 200,
-            class_id: vec![4, 5, 6],
+            class_id: "MSFT 5.0".as_bytes().to_vec(),
             client_id_type: 1,
             client_id: vec![7, 8, 9],
             category: EventCategory::InitialAccess,
@@ -3456,7 +3456,7 @@ mod tests {
         let (_, _, syslog_message) = message.unwrap();
         assert_eq!(
             &syslog_message,
-            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlocklistDhcp" category="InitialAccess" sensor="collector1" src_addr="127.0.0.1" src_port="68" dst_addr="127.0.0.2" dst_port="67" proto="17" last_time="100" msg_type="1" ciaddr="127.0.0.5" yiaddr="127.0.0.6" siaddr="127.0.0.7" giaddr="127.0.0.8" subnet_mask="255.255.255.0" router="127.0.0.1" domain_name_server="127.0.0.1" req_ip_addr="127.0.0.100" lease_time="100" server_id="127.0.0.1" param_req_list="1,2,3" message="message" renewal_time="100" rebinding_time="200" class_id="04:05:06" client_id_type="1" client_id="07:08:09""#,
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlocklistDhcp" category="InitialAccess" sensor="collector1" src_addr="127.0.0.1" src_port="68" dst_addr="127.0.0.2" dst_port="67" proto="17" last_time="100" msg_type="1" ciaddr="127.0.0.5" yiaddr="127.0.0.6" siaddr="127.0.0.7" giaddr="127.0.0.8" subnet_mask="255.255.255.0" router="127.0.0.1" domain_name_server="127.0.0.1" req_ip_addr="127.0.0.100" lease_time="100" server_id="127.0.0.1" param_req_list="1,2,3" message="message" renewal_time="100" rebinding_time="200" class_id="MSFT 5.0" client_id_type="1" client_id="07:08:09""#,
         );
 
         let blocklist_dhcp = Event::Blocklist(RecordType::Dhcp(BlocklistDhcp::new(
@@ -3467,7 +3467,7 @@ mod tests {
 
         assert_eq!(
             &blocklist_dhcp,
-            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlocklistDhcp" category="InitialAccess" sensor="collector1" src_addr="127.0.0.1" src_port="68" dst_addr="127.0.0.2" dst_port="67" proto="17" last_time="100" msg_type="1" ciaddr="127.0.0.5" yiaddr="127.0.0.6" siaddr="127.0.0.7" giaddr="127.0.0.8" subnet_mask="255.255.255.0" router="127.0.0.1" domain_name_server="127.0.0.1" req_ip_addr="127.0.0.100" lease_time="100" server_id="127.0.0.1" param_req_list="1,2,3" message="message" renewal_time="100" rebinding_time="200" class_id="04:05:06" client_id_type="1" client_id="07:08:09" triage_scores="""#
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlocklistDhcp" category="InitialAccess" sensor="collector1" src_addr="127.0.0.1" src_port="68" dst_addr="127.0.0.2" dst_port="67" proto="17" last_time="100" msg_type="1" ciaddr="127.0.0.5" yiaddr="127.0.0.6" siaddr="127.0.0.7" giaddr="127.0.0.8" subnet_mask="255.255.255.0" router="127.0.0.1" domain_name_server="127.0.0.1" req_ip_addr="127.0.0.100" lease_time="100" server_id="127.0.0.1" param_req_list="1,2,3" message="message" renewal_time="100" rebinding_time="200" class_id="MSFT 5.0" client_id_type="1" client_id="07:08:09" triage_scores="""#
         );
     }
 

--- a/src/event/dcerpc.rs
+++ b/src/event/dcerpc.rs
@@ -1,10 +1,11 @@
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
+use attrievent::attribute::RawEventAttrKind;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use super::{EventCategory, LearningMethod, MEDIUM, TriagePolicy, TriageScore, common::Match};
-use crate::event::common::triage_scores_to_string;
+use super::{EventCategory, LearningMethod, MEDIUM, TriageScore, common::Match};
+use crate::event::common::{AttrValue, triage_scores_to_string};
 
 #[derive(Serialize, Deserialize)]
 pub struct BlocklistDceRpcFields {
@@ -147,7 +148,10 @@ impl Match for BlocklistDceRpc {
         LearningMethod::SemiSupervised
     }
 
-    fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        0.0
+    // Since `dcerpc` is not currently an event type collected by Feature Sensor, and as a result,
+    // the notation for each attribute of `dcerpc` has not been finalized. Therefore, we will
+    // proceed with this part after the collection and notation of dcerpc events is finalized.
+    fn find_attr_by_kind(&self, _raw_event_attr: RawEventAttrKind) -> Option<AttrValue> {
+        None
     }
 }

--- a/src/event/kerberos.rs
+++ b/src/event/kerberos.rs
@@ -1,10 +1,37 @@
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
+use attrievent::attribute::{KerberosAttr, RawEventAttrKind};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use super::{EventCategory, LearningMethod, MEDIUM, TriagePolicy, TriageScore, common::Match};
-use crate::event::common::triage_scores_to_string;
+use super::{EventCategory, LearningMethod, MEDIUM, TriageScore, common::Match};
+use crate::event::common::{AttrValue, triage_scores_to_string};
+
+macro_rules! find_kerberos_attr_by_kind {
+    ($event: expr, $raw_event_attr: expr) => {{
+        if let RawEventAttrKind::Kerberos(attr) = $raw_event_attr {
+            let target_value = match attr {
+                KerberosAttr::SrcAddr => AttrValue::Addr($event.src_addr),
+                KerberosAttr::SrcPort => AttrValue::UInt($event.src_port.into()),
+                KerberosAttr::DstAddr => AttrValue::Addr($event.dst_addr),
+                KerberosAttr::DstPort => AttrValue::UInt($event.dst_port.into()),
+                KerberosAttr::Proto => AttrValue::UInt($event.proto.into()),
+                KerberosAttr::ClientTime => AttrValue::SInt($event.client_time),
+                KerberosAttr::ServerTime => AttrValue::SInt($event.server_time),
+                KerberosAttr::ErrorCode => AttrValue::UInt($event.error_code.into()),
+                KerberosAttr::ClientRealm => AttrValue::String(&$event.client_realm),
+                KerberosAttr::CnameType => AttrValue::UInt($event.cname_type.into()),
+                KerberosAttr::ClientName => AttrValue::VecString(&$event.client_name),
+                KerberosAttr::Realm => AttrValue::String(&$event.realm),
+                KerberosAttr::SnameType => AttrValue::UInt($event.sname_type.into()),
+                KerberosAttr::ServiceName => AttrValue::VecString(&$event.service_name),
+            };
+            Some(target_value)
+        } else {
+            None
+        }
+    }};
+}
 
 #[derive(Serialize, Deserialize)]
 pub struct BlocklistKerberosFields {
@@ -173,7 +200,7 @@ impl Match for BlocklistKerberos {
         LearningMethod::SemiSupervised
     }
 
-    fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        0.0
+    fn find_attr_by_kind(&self, raw_event_attr: RawEventAttrKind) -> Option<AttrValue> {
+        find_kerberos_attr_by_kind!(self, raw_event_attr)
     }
 }

--- a/src/event/log.rs
+++ b/src/event/log.rs
@@ -5,11 +5,12 @@ use std::{
     num::NonZeroU8,
 };
 
+use attrievent::attribute::{LogAttr, RawEventAttrKind};
 use chrono::{DateTime, Utc, serde::ts_nanoseconds};
 use serde::{Deserialize, Serialize};
 
-use super::{EventCategory, LearningMethod, MEDIUM, TriagePolicy, TriageScore, common::Match};
-use crate::event::common::triage_scores_to_string;
+use super::{EventCategory, LearningMethod, MEDIUM, TriageScore, common::Match};
+use crate::event::common::{AttrValue, triage_scores_to_string};
 
 #[derive(Serialize, Deserialize)]
 pub struct ExtraThreat {
@@ -112,7 +113,10 @@ impl Match for ExtraThreat {
         LearningMethod::Unsupervised
     }
 
-    fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        0.0
+    fn find_attr_by_kind(&self, raw_event_attr: RawEventAttrKind) -> Option<AttrValue> {
+        if let RawEventAttrKind::Log(LogAttr::Content) = raw_event_attr {
+            return Some(AttrValue::String(&self.content));
+        }
+        None
     }
 }

--- a/src/event/tor.rs
+++ b/src/event/tor.rs
@@ -1,10 +1,14 @@
 use std::{fmt, net::IpAddr, num::NonZeroU8};
 
+use attrievent::attribute::{HttpAttr, RawEventAttrKind};
 use chrono::{DateTime, Utc, serde::ts_nanoseconds};
 use serde::{Deserialize, Serialize};
 
-use super::{EventCategory, LearningMethod, MEDIUM, TriagePolicy, TriageScore, common::Match};
-use crate::event::{common::triage_scores_to_string, http::get_post_body};
+use super::{EventCategory, LearningMethod, MEDIUM, TriageScore, common::Match};
+use crate::event::{
+    common::{AttrValue, triage_scores_to_string},
+    http::{find_http_attr_by_kind, get_post_body},
+};
 
 #[derive(Deserialize, Serialize)]
 #[allow(clippy::module_name_repetitions)]
@@ -240,7 +244,7 @@ impl Match for TorConnection {
         LearningMethod::SemiSupervised
     }
 
-    fn score_by_packet_attr(&self, _triage: &TriagePolicy) -> f64 {
-        0.0
+    fn find_attr_by_kind(&self, raw_event_attr: RawEventAttrKind) -> Option<AttrValue> {
+        find_http_attr_by_kind!(self, raw_event_attr)
     }
 }

--- a/src/tables/triage_policy.rs
+++ b/src/tables/triage_policy.rs
@@ -3,6 +3,7 @@
 use std::{borrow::Cow, cmp::Ordering};
 
 use anyhow::Result;
+use attrievent::attribute::RawEventKind;
 use chrono::{DateTime, Utc};
 use rocksdb::OptimisticTransactionDB;
 use serde::{Deserialize, Serialize};
@@ -68,8 +69,12 @@ pub enum TiCmpKind {
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
 pub enum ValueKind {
     String,
-    Integer,
+    Integer,  // range: i64::MAX
+    UInteger, // range: u64::MAX
+    Vector,
     Float,
+    IpAddr,
+    Bool,
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
@@ -135,6 +140,7 @@ impl Ord for Ti {
 
 #[derive(Clone, PartialEq, Deserialize, Serialize)]
 pub struct PacketAttr {
+    pub raw_event_kind: RawEventKind,
     pub attr_name: String,
     pub value_kind: ValueKind,
     pub cmp_kind: AttrCmpKind,


### PR DESCRIPTION
@sehkone 
Regarding the addition of packet attribute functionality, I have added this functionality to `DnsCovertChannel` as follows. I would appreciate any feedback on this modification.


closes #354 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functions for enhanced attribute comparison, supporting various data types and comparison scenarios.
  - Added dynamic scoring for DNS attributes, improving the accuracy of attribute evaluations.

- **Bug Fixes**
  - Updated method to log warnings for invalid DNS attribute fields, enhancing error handling.

- **Documentation**
  - Clarified method signatures for improved usability and understanding of the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->