### PR TITLE
Insert values of min, max, mean, and s_deviation into description_int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - `Database::get_top_clusters_by_score`: This method only returned an empty set
   and did not provide any meaningful functionality.
 
+### Fixed
+
+- The values of the `min`, `max`, `mean`, and `s_deviation` columns in the
+  `description_int` table are not inserted.
+
 ## [0.30.0] - 2024-09-03
 
 ### Added

--- a/src/column_statistics/save/int.rs
+++ b/src/column_statistics/save/int.rs
@@ -13,6 +13,10 @@ use crate::{
 #[diesel(table_name = crate::schema::description_int)]
 struct DescriptionInt {
     description_id: i32,
+    min: Option<i64>,
+    max: Option<i64>,
+    mean: Option<f64>,
+    s_deviation: Option<f64>,
     mode: i64,
 }
 
@@ -30,8 +34,23 @@ pub(super) async fn insert_top_n(
     column_stats: &ColumnStatistics,
     mode: i64,
 ) -> Result<usize, Error> {
+    let min = if let Some(Element::Int(v)) = column_stats.description.min() {
+        Some(*v)
+    } else {
+        None
+    };
+    let max = if let Some(Element::Int(v)) = column_stats.description.max() {
+        Some(*v)
+    } else {
+        None
+    };
+
     let db = DescriptionInt {
         description_id,
+        min,
+        max,
+        mean: column_stats.description.mean(),
+        s_deviation: column_stats.description.std_deviation(),
         mode,
     };
     let _res = diesel::insert_into(desc_d::description_int)


### PR DESCRIPTION
The behavior has changed in [this PR](https://github.com/petabi/review-database/pull/31) but I believe this is a bug and the values of the `min`, `max`, `mean` and `s_deviation` columns should be inserted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `review-migrate` tool for enhanced database migration management.
	- Added new optional fields (`min`, `max`, `mean`, `s_deviation`) to the `DescriptionInt` struct for improved statistical data handling.

- **Bug Fixes**
	- Fixed insertion issues in the `description_int` table to ensure accurate population of statistical columns.
	- Updated the `NodeTable::update` method for accurate updates to agents.

- **Refactor**
	- Updated the `UniqueKey` trait for improved flexibility by changing return types and removing redundant methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->