### PR TITLE
Remove unused structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   name to a numerical ID when migrating from a name-based key to a numerical
   key. It is no longer needed as we now use numerical keys for clusters.
 - `Database::get_top_clusters_by_score`: This method only returned an empty set
-  and did not provide any meaningful functionality.
+  and did not provide any meaningful functionality. `ClusterScore` and
+  `ClusterScoreSet`, which were used by this method, have also been removed.
 
 ### Fixed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,8 @@ pub use self::time_series::*;
 pub use self::time_series::{ColumnTimeSeries, TimeCount, TimeSeriesResult};
 pub use self::top_n::*;
 pub use self::top_n::{
-    ClusterScore, ClusterScoreSet, ClusterTrend, ElementCount, LineSegment, Regression,
-    StructuredColumnType, TopColumnsOfCluster, TopMultimaps, TopTrendsByColumn,
+    ClusterTrend, ElementCount, LineSegment, Regression, StructuredColumnType, TopColumnsOfCluster,
+    TopMultimaps, TopTrendsByColumn,
 };
 pub use self::types::{EventCategory, HostNetworkGroup, Qualifier, Status};
 

--- a/src/top_n.rs
+++ b/src/top_n.rs
@@ -68,17 +68,6 @@ impl From<(i32, i32)> for StructuredColumnType {
     }
 }
 
-pub struct ClusterScore {
-    pub cluster_id: i32,
-    pub cluster_name: String,
-    pub score: f64,
-}
-
-pub struct ClusterScoreSet {
-    pub top_n_sum: Vec<ClusterScore>,
-    pub top_n_rate: Vec<ClusterScore>,
-}
-
 #[derive(Clone, Deserialize)]
 pub struct ElementCount {
     pub value: String,


### PR DESCRIPTION
ClusterScoreSet and ClusterScore are not used anymore. They were used by `get_top_clusters_by_score` method, which was removed earlier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `review-migrate` tool for enhanced database migration management.
	- Updated the `update` method to include a `language` parameter for improved functionality.

- **Bug Fixes**
	- Resolved an issue with inserting statistical values in the `description_int` table.

- **Refactor**
	- Simplified the public API by removing `ClusterScore` and `ClusterScoreSet` structures.
	- Enhanced error handling in the `Database` struct's `new` method.

- **Security**
	- Upgraded `diesel-async` to address potential vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->