### PR TITLE
Remove unnecessary `Cow` in `Value`

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, net::IpAddr, num::NonZeroU32};
+use std::{net::IpAddr, num::NonZeroU32};
 
 use anyhow::Result;
 use argon2::{
@@ -130,12 +130,14 @@ impl UniqueKey for Account {
 }
 
 impl Value for Account {
-    fn value(&self) -> Cow<[u8]> {
+    type AsBytes<'a> = Vec<u8>;
+
+    fn value(&self) -> Vec<u8> {
         use bincode::Options;
         let Ok(value) = bincode::DefaultOptions::new().serialize(&self) else {
             unreachable!("serialization into memory should never fail")
         };
-        Cow::Owned(value)
+        value
     }
 }
 

--- a/src/batch_info.rs
+++ b/src/batch_info.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use serde::{Deserialize, Serialize};
 
 use crate::{tables::Value, UniqueKey};
@@ -42,11 +40,13 @@ impl UniqueKey for BatchInfo {
 }
 
 impl Value for BatchInfo {
-    fn value(&self) -> Cow<[u8]> {
+    type AsBytes<'a> = Vec<u8>;
+
+    fn value(&self) -> Vec<u8> {
         use bincode::Options;
         let Ok(value) = bincode::DefaultOptions::new().serialize(&self.inner) else {
             unreachable!("serialization into memory should never fail")
         };
-        Cow::Owned(value)
+        value
     }
 }

--- a/src/scores.rs
+++ b/src/scores.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use serde::{Deserialize, Serialize};
 
 use crate::{tables::Value, UniqueKey};
@@ -33,11 +31,13 @@ impl UniqueKey for Scores {
 }
 
 impl Value for Scores {
-    fn value(&self) -> Cow<[u8]> {
+    type AsBytes<'a> = Vec<u8>;
+
+    fn value(&self) -> Vec<u8> {
         use bincode::Options;
         let Ok(value) = bincode::DefaultOptions::new().serialize(&self.inner) else {
             unreachable!("serialization into memory should never fail")
         };
-        Cow::Owned(value)
+        value
     }
 }

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -714,9 +714,8 @@ where
 ///
 /// The `UniqueKey` trait is designed to provide a standardized way to retrieve
 /// a unique, opaque key for instances of structs that implement this trait. The
-/// key is returned as a `Cow<[u8]>`, allowing for flexible ownership
-/// models—--either borrowing from an existing slice or owning the data
-/// outright.
+/// key is returned as a `AsRef<[u8]>`, allowing for flexible ownership
+/// models.
 ///
 /// Implementing this trait allows for unique identification of instances, which
 /// can be used for indexing, identification in collections, or any scenario
@@ -746,9 +745,8 @@ pub trait UniqueKey {
 
     /// Returns a unique, opaque key for the instance.
     ///
-    /// This method should return a byte slice that uniquely identifies the
-    /// instance of the struct. The returned `Cow<[u8]>` allows the key to be
-    /// either borrowed or owned, depending on the implementation's needs.
+    /// This method should return an object that implements `AsRef<[u8]>` and
+    /// uniquely identifies the instance of the struct.
     ///
     /// # Examples
     ///
@@ -772,8 +770,7 @@ pub trait UniqueKey {
     /// ```
     ///
     /// In this example, the `unique_key` method returns the user's `id` as a
-    /// byte array, converted into a `Vec<u8>` and then into a `Cow::Owned`,
-    /// providing a unique key for the user instance.
+    /// byte array, providing a unique key for the user instance.
     fn unique_key(&self) -> Self::AsBytes<'_>;
 }
 

--- a/src/tables/agent.rs
+++ b/src/tables/agent.rs
@@ -1,6 +1,6 @@
 //! The agent table.
 
-use std::{borrow::Cow, fmt::Display, mem::size_of};
+use std::{fmt::Display, mem::size_of};
 
 use anyhow::Result;
 use num_derive::{FromPrimitive, ToPrimitive};
@@ -151,14 +151,16 @@ impl UniqueKey for Agent {
 }
 
 impl ValueTrait for Agent {
-    fn value(&self) -> Cow<[u8]> {
+    type AsBytes<'a> = Vec<u8>;
+
+    fn value(&self) -> Vec<u8> {
         let value = Value {
             kind: self.kind,
             status: self.status,
             config: self.config.clone(),
             draft: self.draft.clone(),
         };
-        Cow::Owned(super::serialize(&value).expect("serializable"))
+        super::serialize(&value).expect("serializable")
     }
 }
 

--- a/src/tables/outlier_info.rs
+++ b/src/tables/outlier_info.rs
@@ -1,6 +1,6 @@
 //! The `outlier_info` map.
 
-use std::{borrow::Cow, mem::size_of};
+use std::mem::size_of;
 
 use anyhow::{bail, Result};
 use rocksdb::{Direction, OptimisticTransactionDB};
@@ -53,14 +53,14 @@ impl UniqueKey for OutlierInfo {
 }
 
 impl ValueTrait for OutlierInfo {
-    fn value(&self) -> Cow<[u8]> {
-        Cow::Owned(
-            super::serialize(&Value {
-                distance: self.distance,
-                is_saved: self.is_saved,
-            })
-            .expect("serializable"),
-        )
+    type AsBytes<'a> = Vec<u8>;
+
+    fn value(&self) -> Vec<u8> {
+        super::serialize(&Value {
+            distance: self.distance,
+            is_saved: self.is_saved,
+        })
+        .expect("serializable")
     }
 }
 

--- a/src/tables/traffic_filter.rs
+++ b/src/tables/traffic_filter.rs
@@ -1,6 +1,6 @@
 //! The `traffic_filter` map.
 
-use std::{borrow::Cow, collections::HashMap};
+use std::collections::HashMap;
 
 use anyhow::{bail, Result};
 use chrono::{DateTime, Utc};
@@ -35,8 +35,10 @@ impl UniqueKey for TrafficFilter {
 }
 
 impl Value for TrafficFilter {
-    fn value(&self) -> Cow<[u8]> {
-        Cow::Owned(super::serialize(self).expect("serializable"))
+    type AsBytes<'a> = Vec<u8>;
+
+    fn value(&self) -> Vec<u8> {
+        super::serialize(self).expect("serializable")
     }
 }
 

--- a/src/tables/trusted_domain.rs
+++ b/src/tables/trusted_domain.rs
@@ -1,7 +1,5 @@
 //! The `trusted_domain` table.
 
-use std::borrow::Cow;
-
 use anyhow::Result;
 use rocksdb::OptimisticTransactionDB;
 use serde::{Deserialize, Serialize};
@@ -33,8 +31,10 @@ impl UniqueKey for TrustedDomain {
 }
 
 impl Value for TrustedDomain {
-    fn value(&self) -> Cow<[u8]> {
-        Cow::Borrowed(self.remarks.as_bytes())
+    type AsBytes<'a> = &'a [u8];
+
+    fn value(&self) -> &[u8] {
+        self.remarks.as_bytes()
     }
 }
 
@@ -53,9 +53,10 @@ impl<'d> Table<'d, TrustedDomain> {
     ///
     /// Returns an error if the serialization fails or the database operation fails.
     pub fn update(&self, old: &TrustedDomain, new: &TrustedDomain) -> Result<()> {
-        let (ok, ov) = (old.unique_key(), old.value());
-        let (nk, nv) = (new.unique_key(), new.value());
-        self.map.update((ok, &ov), (nk, &nv))
+        self.map.update(
+            (old.unique_key(), old.value()),
+            (new.unique_key(), new.value()),
+        )
     }
 
     /// Removes a `TrustedDomain` with the given name.

--- a/src/tables/trusted_user_agent.rs
+++ b/src/tables/trusted_user_agent.rs
@@ -1,7 +1,5 @@
 //! The `trusted_user_agent` map.
 
-use std::borrow::Cow;
-
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use rocksdb::OptimisticTransactionDB;
@@ -39,8 +37,10 @@ impl UniqueKey for TrustedUserAgent {
 }
 
 impl Value for TrustedUserAgent {
-    fn value(&self) -> Cow<[u8]> {
-        Cow::Owned(self.updated_at.to_string().into_bytes())
+    type AsBytes<'a> = Vec<u8>;
+
+    fn value(&self) -> Vec<u8> {
+        self.updated_at.to_string().into_bytes()
     }
 }
 


### PR DESCRIPTION
- Refactored the `Value` trait to remove the use of `Cow<[u8]>` for the `value` method's return type.
- Introduced an associated type `AsBytes<'a>`, which allows implementations to define the return type of `unique_key` more flexibly.

This refactor leads to cleaner and more efficient implementations, especially when handling values that don't require ownership transfer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified return types for various `value` methods across multiple structs, now returning `Vec<u8>` instead of `Cow<[u8]>`.
	- Introduced new associated type `AsBytes` as `Vec<u8>` for several implementations.
	- Added a structured type alias `RuleList` for better representation of rules in the `TrafficFilter` struct.
  
- **Bug Fixes**
	- Enhanced clarity in the `update` method for the `TrustedDomain` struct.

- **Chores**
	- Removed unused `Cow` imports across multiple files to streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->