### PR TITLE
Remove unnecessary `Serialize`/`Deserialize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- `TrustedDomain` no longer implements `serde::Serialize` and
+  `serde::Deserialize`. Its serialized form in the database is internal and
+  should not be exposed to other modules.
+
 ## [0.31.0] - 2024-10-01
 
 ### Added
@@ -699,6 +707,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Modified `FtpBruteForce` by adding an `is_internal` field which is a boolean
   indicating whether it is internal or not.
 
+[Unreleased]: https://github.com/petabi/review-database/compare/0.31.0...main
 [0.31.0]: https://github.com/petabi/review-database/compare/0.30.0...0.31.0
 [0.30.0]: https://github.com/petabi/review-database/compare/0.29.1...0.30.0
 [0.29.1]: https://github.com/petabi/review-database/compare/0.29.0...0.29.1

--- a/src/tables/trusted_domain.rs
+++ b/src/tables/trusted_domain.rs
@@ -2,12 +2,11 @@
 
 use anyhow::Result;
 use rocksdb::OptimisticTransactionDB;
-use serde::{Deserialize, Serialize};
 
 use super::Value;
 use crate::{types::FromKeyValue, Map, Table, UniqueKey};
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TrustedDomain {
     pub name: String,
     pub remarks: String,


### PR DESCRIPTION
`TrustDomain`'s serialized form in the database is internal and should not be exposed to other modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the changelog to include an "Unreleased" section for better tracking of notable changes.
	- Added links to previous versions for easier navigation.

- **New Features**
	- Enhanced internal handling of the `TrustedDomain` type by removing serialization capabilities, focusing on internal data representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->