### PR TITLE
Seal `FromKeyValue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- `FromKeyValue` is sealed.
+
 ### Removed
 
 - `TrustedDomain` no longer implements `serde::Serialize` and

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -43,6 +43,7 @@ pub use self::data_source::{DataSource, DataType, Update as DataSourceUpdate};
 pub use self::filter::Filter;
 pub use self::model_indicator::ModelIndicator;
 pub use self::network::{Network, Update as NetworkUpdate};
+pub(crate) use self::node::Inner as InnerNode;
 pub use self::node::{
     Giganto, Node, Profile as NodeProfile, Table as NodeTable, Update as NodeUpdate,
 };

--- a/src/tables/node.rs
+++ b/src/tables/node.rs
@@ -312,7 +312,7 @@ pub struct Profile {
 }
 
 #[derive(Clone, Deserialize, Serialize)]
-struct Inner {
+pub(crate) struct Inner {
     id: u32,
     name: String,
     name_draft: Option<String>,
@@ -363,7 +363,7 @@ impl<'d> IndexedTable<'d, Inner> {
     /// # Errors
     ///
     /// Returns an error if the `id` is invalid or the database operation fails.
-    pub fn update(&mut self, id: u32, old: &InnerUpdate, new: &InnerUpdate) -> Result<()> {
+    fn update(&mut self, id: u32, old: &InnerUpdate, new: &InnerUpdate) -> Result<()> {
         self.indexed_map.update(id, old, new)
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,13 +11,46 @@ use strum_macros::Display;
 use super::TrafficDirection;
 pub use crate::account::{Account, Role};
 
-pub trait FromKeyValue: Sized {
+pub trait FromKeyValue: Sized + private::Sealed {
     /// Creates a new instance from the given key and value.
     ///
     /// # Errors
     ///
     /// Returns an error if the key or value cannot be deserialized.
     fn from_key_value(key: &[u8], value: &[u8]) -> Result<Self>;
+}
+
+mod private {
+    use crate::{tables, types};
+
+    pub trait Sealed {}
+
+    impl Sealed for tables::AccessToken {}
+    impl Sealed for types::Account {}
+    impl Sealed for tables::Agent {}
+    impl Sealed for tables::AllowNetwork {}
+    impl Sealed for crate::BatchInfo {}
+    impl Sealed for tables::BlockNetwork {}
+    impl Sealed for crate::Category {}
+    impl Sealed for tables::CsvColumnExtra {}
+    impl Sealed for tables::Customer {}
+    impl Sealed for tables::DataSource {}
+    impl Sealed for tables::Filter {}
+    impl Sealed for tables::InnerNode {}
+    impl Sealed for tables::ModelIndicator {}
+    impl Sealed for tables::Network {}
+    impl Sealed for tables::OutlierInfo {}
+    impl Sealed for types::Qualifier {}
+    impl Sealed for tables::SamplingPolicy {}
+    impl Sealed for types::Status {}
+    impl Sealed for tables::Template {}
+    impl Sealed for tables::Tidb {}
+    impl Sealed for tables::TorExitNode {}
+    impl Sealed for tables::TrafficFilter {}
+    impl Sealed for tables::TriagePolicy {}
+    impl Sealed for tables::TriageResponse {}
+    impl Sealed for tables::TrustedDomain {}
+    impl Sealed for tables::TrustedUserAgent {}
 }
 
 pub(crate) type Timestamp = i64;


### PR DESCRIPTION
`FromKeyValue` should be implemented for the types in this crate only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `review-migrate` tool for enhanced database migration management.
- **Bug Fixes**
	- Resolved an issue with incorrect insertion of statistical values in the `description_int` table.
- **Refactor**
	- Sealed the `FromKeyValue` trait to restrict its implementation.
	- Modified visibility for the `Inner` struct and adjusted the `update` method's accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->