### PR TITLE
Fix indexed map name for `SamplingPolicy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   `serde::Deserialize`. Its serialized form in the database is internal and
   should not be exposed to other modules.
 
+### Fixed
+
+- Fixed the indexed map name for `SamplingPolicy` in `IndexedTable`
+  implementation, changing it from `NETWORKS` to `SAMPLING_POLICY`.
+
 ## [0.31.0] - 2024-10-01
 
 ### Added

--- a/src/tables/sampling_policy.rs
+++ b/src/tables/sampling_policy.rs
@@ -95,7 +95,7 @@ impl<'d> IndexedTable<'d, SamplingPolicy> {
     ///
     /// Returns `None` if the table does not exist.
     pub(super) fn open(db: &'d OptimisticTransactionDB) -> Option<Self> {
-        IndexedMap::new(db, super::NETWORKS)
+        IndexedMap::new(db, super::SAMPLING_POLICY)
             .map(IndexedTable::new)
             .ok()
     }


### PR DESCRIPTION
~Related~ Closes: #367 

### Notes

~I think the issue may require further discussion, so I honestly think submitting a full PR might be premature. So I am opening this as a draft PR, just to visualize and initiate discussion on a minimal approach to address the issue.~

I changed this to a PR, as I now think this might resolve #367.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new tool, `review-migrate`, for managing database migrations, enhancing flexibility.
  
- **Bug Fixes**
	- Corrected the indexed map name for `SamplingPolicy` in the `IndexedTable` implementation.
	- Fixed insertion issues for statistical columns in the `description_int` table.

- **Refactor**
	- Updated the return type of the `unique_key` method in the `UniqueKey` trait for improved flexibility.
	- Sealed the `FromKeyValue` trait to prevent further implementations.
  
- **Documentation**
	- Updated the `CHANGELOG.md` to reflect recent changes and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->