### PR TITLE
Take reference when ownership is not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Modified `Table::get_patterns` to take a reference to a slice of tuples
+  instead of taking ownership of a vector, making the function more flexible.
+
 ## [0.32.0] - 2024-11-07
 
 ### Changed
@@ -721,6 +728,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Modified `FtpBruteForce` by adding an `is_internal` field which is a boolean
   indicating whether it is internal or not.
 
+[Unreleased]: https://github.com/petabi/review-database/compare/0.32.0...main
 [0.32.0]: https://github.com/petabi/review-database/compare/0.31.0...0.32.0
 [0.31.0]: https://github.com/petabi/review-database/compare/0.30.0...0.31.0
 [0.30.0]: https://github.com/petabi/review-database/compare/0.29.1...0.30.0

--- a/src/tables/tidb.rs
+++ b/src/tables/tidb.rs
@@ -169,12 +169,15 @@ impl<'d> Table<'d, Tidb> {
     /// # Errors
     ///
     /// * Returns an error if it fails to decode TI database
-    pub fn get_patterns(&self, info: Vec<(String, String)>) -> Result<Vec<(String, Option<Tidb>)>> {
+    pub fn get_patterns<'a>(
+        &self,
+        info: &[(&'a str, &str)],
+    ) -> Result<Vec<(&'a str, Option<Tidb>)>> {
         //TODO: This job is too heavy if tidb is nothing changed.
         //      Tidb header and patterns should be stored separately.
         let mut ret = Vec::new();
-        for (db_name, db_version) in info {
-            let Some(mut tidb) = self.get(&db_name)? else {
+        for &(db_name, db_version) in info {
+            let Some(mut tidb) = self.get(db_name)? else {
                 return Ok(Vec::new());
             };
 


### PR DESCRIPTION
Instead of taking ownership of the `info` vector, `get_patterns` now takes a reference to a slice of tuples. This change makes the function more flexible and efficient, as it no longer requires the caller to transfer ownership of the data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated changelog to include an "Unreleased" section for documenting upcoming changes.
	- Enhanced `get_patterns` method to accept borrowed data, improving flexibility and performance.
  
- **Bug Fixes**
	- Retained previous version entries in the changelog for clarity on past modifications and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->