### PR TITLE
Fix `triage_policy` doc error

### DIFF
--- a/src/tables/triage_policy.rs
+++ b/src/tables/triage_policy.rs
@@ -247,7 +247,7 @@ impl Ord for Response {
 
 /// Functions for the `triage_policy` indexed map.
 impl<'d> IndexedTable<'d, TriagePolicy> {
-    /// Opens the `data_source` table in the database.
+    /// Opens the `triage_policy` table in the database.
     ///
     /// Returns `None` if the table does not exist.
     pub(super) fn open(db: &'d OptimisticTransactionDB) -> Option<Self> {


### PR DESCRIPTION
Resolves #378 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for the `open` method to accurately reflect that it opens the `triage_policy` table in the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->