### PR TITLE
Add `theme` field in `Account` to represent user's screen color theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `Account::theme` field to represent user's selected screen color theme
+  on the user interface.
+
 ## [0.33.1] - 2024-12-20
 
 ### Fixed
@@ -752,6 +759,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Modified `FtpBruteForce` by adding an `is_internal` field which is a boolean
   indicating whether it is internal or not.
 
+[Unreleased]: https://github.com/petabi/review-database/compare/0.33.1...main
 [0.33.1]: https://github.com/petabi/review-database/compare/0.33.0...0.33.1
 [0.33.0]: https://github.com/petabi/review-database/compare/0.32.0...0.33.0
 [0.32.0]: https://github.com/petabi/review-database/compare/0.31.0...0.32.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.33.1"
+version = "0.34.0-alpha.1"
 edition = "2021"
 
 [dependencies]

--- a/src/account.rs
+++ b/src/account.rs
@@ -36,6 +36,7 @@ pub struct Account {
     pub name: String,
     pub department: String,
     pub language: Option<String>,
+    pub theme: Option<String>,
     pub(crate) creation_time: DateTime<Utc>,
     pub(crate) last_signin_time: Option<DateTime<Utc>>,
     pub allow_access_from: Option<Vec<IpAddr>>,
@@ -60,6 +61,7 @@ impl Account {
         name: String,
         department: String,
         language: Option<String>,
+        theme: Option<String>,
         allow_access_from: Option<Vec<IpAddr>>,
         max_parallel_sessions: Option<u32>,
     ) -> Result<Self> {
@@ -72,6 +74,7 @@ impl Account {
             role,
             name,
             department,
+            theme,
             language,
             creation_time: now,
             last_signin_time: None,
@@ -170,7 +173,7 @@ impl SaltedPassword {
     /// # Errors
     ///
     /// Returns an error if the salt cannot be generated.
-    fn new_with_hash_algorithm(
+    pub(crate) fn new_with_hash_algorithm(
         password: &str,
         hash_algorithm: &PasswordHashAlgorithm,
     ) -> Result<Self> {
@@ -292,6 +295,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert!(account.is_ok());
 
@@ -319,6 +323,7 @@ mod tests {
             department: String::new(),
             name: String::new(),
             language: None,
+            theme: None,
             creation_time: Utc::now(),
             last_signin_time: None,
             allow_access_from: None,

--- a/src/tables/accounts.rs
+++ b/src/tables/accounts.rs
@@ -77,6 +77,7 @@ impl<'d> Table<'d, Account> {
         name: &Option<(String, String)>,
         department: &Option<(String, String)>,
         language: &Option<(Option<String>, Option<String>)>,
+        theme: &Option<(Option<String>, Option<String>)>,
         allow_access_from: &Option<(Option<Vec<IpAddr>>, Option<Vec<IpAddr>>)>,
         max_parallel_sessions: &Option<(Option<u32>, Option<u32>)>,
     ) -> Result<(), anyhow::Error> {
@@ -116,6 +117,12 @@ impl<'d> Table<'d, Account> {
                         bail!("old value mismatch");
                     }
                     account.language.clone_from(new);
+                }
+                if let Some((old, new)) = theme {
+                    if account.theme != *old {
+                        bail!("old value mismatch");
+                    }
+                    account.theme.clone_from(new);
                 }
                 if let Some((old, new)) = &allow_access_from {
                     if account.allow_access_from != *old {
@@ -177,6 +184,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap();
         table.put(&acc1).unwrap();
@@ -188,6 +196,7 @@ mod tests {
             Role::SystemAdministrator,
             "User 2".to_string(),
             "Department 2".to_string(),
+            None,
             None,
             None,
             None,
@@ -221,6 +230,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap();
         table.put(&acc1).unwrap();
@@ -236,6 +246,7 @@ mod tests {
             Role::SystemAdministrator,
             "User 2".to_string(),
             "Department 2".to_string(),
+            None,
             None,
             None,
             None,


### PR DESCRIPTION
Closes: #374 

This is a PR that save the users' preferred screen color mode to the `Account` struct, when users select their preferred color mode on the UI screen. Also, I reflected the changed `Account` struct in the function that updates the account so that review-web could use and update the `Account`.(Since review-web is using the update function of review-database to modify contents of accounts)

I would appreciate it if you could review it. (cc. @sophie-cluml)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional field for user accounts to customize screen color themes.
	- Enhanced account update functionality to allow theme modifications.

- **Bug Fixes**
	- Improved migration logic to ensure compatibility with new account structures and error handling.

- **Documentation**
	- Updated changelog to reflect version changes and notable updates.

- **Chores**
	- Updated package version to indicate a pre-release state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->