### PR TITLE
Fix migration error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Corrected the migration failure issue. The previous version, 0.33.0, needs to
+  be yanked due to this issue.
+
 ## [0.33.0] - 2024-12-12
 
 ### Changed
@@ -740,6 +747,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Modified `FtpBruteForce` by adding an `is_internal` field which is a boolean
   indicating whether it is internal or not.
 
+[Unreleased]: https://github.com/petabi/review-database/compare/0.33.0...main
 [0.33.0]: https://github.com/petabi/review-database/compare/0.32.0...0.33.0
 [0.32.0]: https://github.com/petabi/review-database/compare/0.31.0...0.32.0
 [0.31.0]: https://github.com/petabi/review-database/compare/0.30.0...0.31.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.33.0"
+version = "0.33.1-alpha.1"
 edition = "2021"
 
 [dependencies]

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -38,7 +38,7 @@ use crate::{Agent, AgentStatus, Giganto, Indexed, IterableMap};
 /// // the database format won't be changed in the future alpha or beta versions.
 /// const COMPATIBLE_VERSION: &str = ">=0.5.0-alpha.2,<=0.5.0-alpha.4";
 /// ```
-const COMPATIBLE_VERSION_REQ: &str = ">=0.33.0,<0.34.0-alpha";
+const COMPATIBLE_VERSION_REQ: &str = ">=0.30.0,<0.34.0-alpha";
 
 /// Migrates data exists in `PostgresQL` to Rocksdb if necessary.
 ///


### PR DESCRIPTION
Close: #384 

-------

I modified the `version` in the Cargo.toml and `COMPATIBLE_VERSION_REQ` and `migrate_data_dir` in migration.rs, under the assumption that 0.33.0 will be yanked, and that 0.33.1 will be the next release, with this quick fix.

I did not mark the 0.33.0 as YANKED in this PR, because from my understanding so far, that should not be handled in this PR. But if I should mark it as YANKED in the CHANGELOG in this PR, please let me know.