### PR TITLE
Fix the ability to filtering event by ip address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Added `confidence` field to the `BlockListTlsFields`. This change affects the
   `BlockListTls` and `SuspiciousTlsTraffic` events.
 
+### Fixed
+
+- Fixed the ability to filtering detected events by ip address value to work
+  properly. This fix ensures that `ExternalDdos`, `MultiHostPortScan`, and
+  `RdpBruteForce` with multiple addresses are filtered correctly.
+  - Changed the return types of `src_addr` and `dst_addr` in the `Match` trait
+    from `IpAddr` to `&[IpAddr]` to support returning one or more IP addresses.
+  - Renamed the methods to `src_addrs` and `dst_addrs` to reflect the
+    updated functionality.
+
 ## [0.36.0] - 2025-03-18
 
 ### Changed

--- a/src/event.rs
+++ b/src/event.rs
@@ -81,11 +81,14 @@ use super::{
 };
 
 // event levels (currently unused ones commented out)
-// const VERY_LOW: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(1) };
-const LOW: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(2) };
-const MEDIUM: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(3) };
-const HIGH: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(4) };
-// const VERY_HIGH: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(5) };
+// const VERY_LOW: NonZeroU8 =NonZeroU8::new(1).expect("eThe constant holds the nonzero value 1, which is always valid");
+const LOW: NonZeroU8 =
+    NonZeroU8::new(2).expect("The constant holds the nonzero value 2, which is always valid");
+const MEDIUM: NonZeroU8 =
+    NonZeroU8::new(3).expect("The constant holds the nonzero value 3, which is always valid");
+const HIGH: NonZeroU8 =
+    NonZeroU8::new(4).expect("The constant holds the nonzero value 4, which is always valid");
+// const VERY_HIGH: NonZeroU8 =NonZeroU8::new(5).expect("The constant holds the nonzero value 5, which is always valid");
 
 // event kind
 const DNS_COVERT_CHANNEL: &str = "DNS Covert Channel";
@@ -4855,12 +4858,12 @@ mod tests {
         let suspicious_tls_traffic =
             SuspiciousTlsTraffic::new(Utc.with_ymd_and_hms(1970, 1, 1, 1, 1, 1).unwrap(), fields);
         assert_eq!(
-            suspicious_tls_traffic.src_addr(),
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))
+            suspicious_tls_traffic.src_addrs(),
+            &[IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]
         );
         assert_eq!(
-            suspicious_tls_traffic.dst_addr(),
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2))
+            suspicious_tls_traffic.dst_addrs(),
+            &[IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2))]
         );
         assert_eq!(suspicious_tls_traffic.category(), EventCategory::Unknown);
         assert_eq!(suspicious_tls_traffic.src_port(), 10000);

--- a/src/event/bootp.rs
+++ b/src/event/bootp.rs
@@ -136,16 +136,16 @@ impl BlockListBootp {
 }
 
 impl Match for BlockListBootp {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/conn.rs
+++ b/src/event/conn.rs
@@ -1,8 +1,4 @@
-use std::{
-    fmt,
-    net::{IpAddr, Ipv4Addr},
-    num::NonZeroU8,
-};
+use std::{fmt, net::IpAddr, num::NonZeroU8};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -82,16 +78,16 @@ impl PortScan {
 }
 
 impl Match for PortScan {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         0
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {
@@ -203,16 +199,16 @@ impl MultiHostPortScan {
 }
 
 impl Match for MultiHostPortScan {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         0
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+    fn dst_addrs(&self) -> &[IpAddr] {
+        &self.dst_addrs
     }
 
     fn dst_port(&self) -> u16 {
@@ -319,16 +315,16 @@ impl ExternalDdos {
 }
 
 impl Match for ExternalDdos {
-    fn src_addr(&self) -> IpAddr {
-        IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+    fn src_addrs(&self) -> &[IpAddr] {
+        &self.src_addrs
     }
 
     fn src_port(&self) -> u16 {
         0
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {
@@ -485,16 +481,16 @@ impl BlockListConn {
 }
 
 impl Match for BlockListConn {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/dcerpc.rs
+++ b/src/event/dcerpc.rs
@@ -102,16 +102,16 @@ impl BlockListDceRpc {
 }
 
 impl Match for BlockListDceRpc {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/dhcp.rs
+++ b/src/event/dhcp.rs
@@ -177,16 +177,16 @@ impl BlockListDhcp {
 }
 
 impl Match for BlockListDhcp {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/dns.rs
+++ b/src/event/dns.rs
@@ -151,16 +151,16 @@ impl DnsCovertChannel {
 }
 
 impl Match for DnsCovertChannel {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {
@@ -288,16 +288,16 @@ impl LockyRansomware {
 }
 
 impl Match for LockyRansomware {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {
@@ -479,16 +479,16 @@ impl CryptocurrencyMiningPool {
 }
 
 impl Match for CryptocurrencyMiningPool {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {
@@ -664,16 +664,16 @@ impl BlockListDns {
 }
 
 impl Match for BlockListDns {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/ftp.rs
+++ b/src/event/ftp.rs
@@ -88,16 +88,16 @@ impl FtpBruteForce {
 }
 
 impl Match for FtpBruteForce {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         0
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {
@@ -274,16 +274,16 @@ impl FtpPlainText {
 }
 
 impl Match for FtpPlainText {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {
@@ -408,16 +408,16 @@ impl BlockListFtp {
 }
 
 impl Match for BlockListFtp {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/http.rs
+++ b/src/event/http.rs
@@ -81,16 +81,16 @@ impl RepeatedHttpSessions {
 }
 
 impl Match for RepeatedHttpSessions {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {
@@ -368,16 +368,16 @@ impl HttpThreat {
 }
 
 impl Match for HttpThreat {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {
@@ -634,16 +634,16 @@ impl DomainGenerationAlgorithm {
 }
 
 impl Match for DomainGenerationAlgorithm {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {
@@ -798,16 +798,16 @@ impl NonBrowser {
 }
 
 impl Match for NonBrowser {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {
@@ -1035,16 +1035,16 @@ impl BlockListHttp {
 }
 
 impl Match for BlockListHttp {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/kerberos.rs
+++ b/src/event/kerberos.rs
@@ -128,16 +128,16 @@ impl BlockListKerberos {
 }
 
 impl Match for BlockListKerberos {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/ldap.rs
+++ b/src/event/ldap.rs
@@ -95,16 +95,16 @@ impl LdapBruteForce {
 }
 
 impl Match for LdapBruteForce {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         0
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {
@@ -256,16 +256,16 @@ impl LdapPlainText {
 }
 
 impl Match for LdapPlainText {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {
@@ -375,16 +375,16 @@ impl BlockListLdap {
 }
 
 impl Match for BlockListLdap {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/log.rs
+++ b/src/event/log.rs
@@ -48,16 +48,16 @@ impl fmt::Display for ExtraThreat {
 }
 
 impl Match for ExtraThreat {
-    fn src_addr(&self) -> IpAddr {
-        IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&IpAddr::V4(Ipv4Addr::UNSPECIFIED))
     }
 
     fn src_port(&self) -> u16 {
         0
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&IpAddr::V4(Ipv4Addr::UNSPECIFIED))
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/mqtt.rs
+++ b/src/event/mqtt.rs
@@ -112,16 +112,16 @@ impl BlockListMqtt {
 }
 
 impl Match for BlockListMqtt {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/network.rs
+++ b/src/event/network.rs
@@ -56,16 +56,16 @@ impl fmt::Display for NetworkThreat {
 }
 
 impl Match for NetworkThreat {
-    fn src_addr(&self) -> IpAddr {
-        self.orig_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.orig_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.orig_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.resp_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.resp_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/nfs.rs
+++ b/src/event/nfs.rs
@@ -91,16 +91,16 @@ impl BlockListNfs {
 }
 
 impl Match for BlockListNfs {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/ntlm.rs
+++ b/src/event/ntlm.rs
@@ -104,16 +104,16 @@ impl BlockListNtlm {
 }
 
 impl Match for BlockListNtlm {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/rdp.rs
+++ b/src/event/rdp.rs
@@ -1,10 +1,6 @@
 #![allow(clippy::module_name_repetitions)]
 
-use std::{
-    fmt,
-    net::{IpAddr, Ipv4Addr},
-    num::NonZeroU8,
-};
+use std::{fmt, net::IpAddr, num::NonZeroU8};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -81,16 +77,16 @@ impl RdpBruteForce {
 }
 
 impl Match for RdpBruteForce {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         0
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+    fn dst_addrs(&self) -> &[IpAddr] {
+        &self.dst_addrs
     }
 
     fn dst_port(&self) -> u16 {
@@ -209,16 +205,16 @@ impl BlockListRdp {
 }
 
 impl Match for BlockListRdp {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/smb.rs
+++ b/src/event/smb.rs
@@ -135,16 +135,16 @@ impl BlockListSmb {
 }
 
 impl Match for BlockListSmb {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/smtp.rs
+++ b/src/event/smtp.rs
@@ -117,16 +117,16 @@ impl BlockListSmtp {
 }
 
 impl Match for BlockListSmtp {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/ssh.rs
+++ b/src/event/ssh.rs
@@ -146,16 +146,16 @@ impl BlockListSsh {
 }
 
 impl Match for BlockListSsh {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/sysmon.rs
+++ b/src/event/sysmon.rs
@@ -66,16 +66,16 @@ impl Match for WindowsThreat {
         &self.sensor
     }
 
-    fn src_addr(&self) -> IpAddr {
-        IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&IpAddr::V4(Ipv4Addr::UNSPECIFIED))
     }
 
     fn src_port(&self) -> u16 {
         0
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&IpAddr::V4(Ipv4Addr::UNSPECIFIED))
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/tls.rs
+++ b/src/event/tls.rs
@@ -192,16 +192,16 @@ impl BlockListTls {
 }
 
 impl Match for BlockListTls {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {
@@ -355,16 +355,16 @@ impl SuspiciousTlsTraffic {
 }
 
 impl Match for SuspiciousTlsTraffic {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {

--- a/src/event/tor.rs
+++ b/src/event/tor.rs
@@ -195,16 +195,16 @@ impl TorConnection {
 }
 
 impl Match for TorConnection {
-    fn src_addr(&self) -> IpAddr {
-        self.src_addr
+    fn src_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.src_addr)
     }
 
     fn src_port(&self) -> u16 {
         self.src_port
     }
 
-    fn dst_addr(&self) -> IpAddr {
-        self.dst_addr
+    fn dst_addrs(&self) -> &[IpAddr] {
+        std::slice::from_ref(&self.dst_addr)
     }
 
     fn dst_port(&self) -> u16 {


### PR DESCRIPTION
- This fix ensures that `ExternalDdos`, `MultiHostPortScan`, and `RdpBruteForce` with multiple addresses are filtered correctly.
  - Change the return types of `src_addr` and `dst_addr` in the `Match` trait: `IpAddr` to `&[IpAddr]`.
  - Change the names of `src_addr` and `dst_addr` in the `Match` trait to plural: `src_addrs`, `dst_addrs`.

Close: #411