### PR TITLE
Add confidence field to BlockListTlsFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Added `confidence` field to the `BlockListTlsFields` structure to match Hog's
+  structure. This change affects the `BlockListTls` and `SuspiciousTlsTraffic` events.
+
 ## [0.36.0] - 2025-03-18
 
 ### Changed
@@ -829,6 +836,7 @@ AsRef<[u8]>`). This change accommodates scenarios where the information stored
 - Modified `FtpBruteForce` by adding an `is_internal` field which is a boolean
   indicating whether it is internal or not.
 
+[Unreleased]: https://github.com/petabi/review-database/compare/0.36.0...main
 [0.36.0]: https://github.com/petabi/review-database/compare/0.35.0...0.36.0
 [0.35.0]: https://github.com/petabi/review-database/compare/0.34.0...0.35.0
 [0.34.0]: https://github.com/petabi/review-database/compare/0.33.1...0.34.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.36.0"
+version = "0.37.0-alpha.1"
 edition = "2024"
 
 [dependencies]

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -171,7 +171,7 @@ impl<'a> Iterator for KeyIndexIterator<'a> {
                 let id = u32::try_from(self.i).expect("not exceeding u32::MAX");
                 self.i += 1;
                 return Some((id, key.as_slice()));
-            };
+            }
             self.i += 1;
         }
     }

--- a/src/collections/map.rs
+++ b/src/collections/map.rs
@@ -126,7 +126,7 @@ impl<'a> Map<'a> {
                 }
             } else {
                 bail!("no such entry");
-            };
+            }
 
             if old.0 != new.0 {
                 txn.delete_cf(self.cf, old.0)

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::too_many_lines)]
+#![allow(clippy::useless_nonzero_new_unchecked)]
 mod bootp;
 mod common;
 mod conn;
@@ -1196,7 +1197,7 @@ impl Event {
                     category = Some(event.category());
                 }
             }
-        };
+        }
 
         if let Some(category) = category {
             counter.entry(category).and_modify(|e| *e += 1).or_insert(1);
@@ -2133,7 +2134,7 @@ impl<'a> EventDb<'a> {
                 }
             } else {
                 bail!("no such entry");
-            };
+            }
 
             txn.put(new.0, new.1).context("failed to write new entry")?;
             if old.0 != new.0 {
@@ -4639,8 +4640,9 @@ mod tests {
             issuer_org_name: "org".to_string(),
             issuer_org_unit_name: "unit".to_string(),
             issuer_common_name: "common".to_string(),
-            category: EventCategory::InitialAccess,
             last_alert: 1,
+            confidence: 0.9,
+            category: EventCategory::InitialAccess,
         };
 
         let message = EventMessage {
@@ -4652,7 +4654,7 @@ mod tests {
         let syslog_message = message.to_string();
         assert_eq!(
             &syslog_message,
-            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListTls" category="InitialAccess" sensor="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="443" proto="6" last_time="100" server_name="server" alpn_protocol="alpn" ja3="ja3" version="version" client_cipher_suites="1,2,3" client_extensions="4,5,6" cipher="1" extensions="7,8,9" ja3s="ja3s" serial="serial" subject_country="country" subject_org_name="org" subject_common_name="common" validity_not_before="100" validity_not_after="200" subject_alt_name="alt" issuer_country="country" issuer_org_name="org" issuer_org_unit_name="unit" issuer_common_name="common" last_alert="1""#
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListTls" category="InitialAccess" sensor="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="443" proto="6" last_time="100" server_name="server" alpn_protocol="alpn" ja3="ja3" version="version" client_cipher_suites="1,2,3" client_extensions="4,5,6" cipher="1" extensions="7,8,9" ja3s="ja3s" serial="serial" subject_country="country" subject_org_name="org" subject_common_name="common" validity_not_before="100" validity_not_after="200" subject_alt_name="alt" issuer_country="country" issuer_org_name="org" issuer_org_unit_name="unit" issuer_common_name="common" last_alert="1" confidence="0.9""#
         );
 
         let block_list_tls = Event::BlockList(RecordType::Tls(crate::BlockListTls::new(
@@ -4663,7 +4665,7 @@ mod tests {
 
         assert_eq!(
             &block_list_tls,
-            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListTls" category="InitialAccess" sensor="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="443" proto="6" last_time="100" server_name="server" alpn_protocol="alpn" ja3="ja3" version="version" client_cipher_suites="1,2,3" client_extensions="4,5,6" cipher="1" extensions="7,8,9" ja3s="ja3s" serial="serial" subject_country="country" subject_org_name="org" subject_common_name="common" validity_not_before="100" validity_not_after="200" subject_alt_name="alt" issuer_country="country" issuer_org_name="org" issuer_org_unit_name="unit" issuer_common_name="common" last_alert="1" triage_scores="""#
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="BlockListTls" category="InitialAccess" sensor="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="443" proto="6" last_time="100" server_name="server" alpn_protocol="alpn" ja3="ja3" version="version" client_cipher_suites="1,2,3" client_extensions="4,5,6" cipher="1" extensions="7,8,9" ja3s="ja3s" serial="serial" subject_country="country" subject_org_name="org" subject_common_name="common" validity_not_before="100" validity_not_after="200" subject_alt_name="alt" issuer_country="country" issuer_org_name="org" issuer_org_unit_name="unit" issuer_common_name="common" last_alert="1" confidence="0.9" triage_scores="""#
         );
     }
 
@@ -4827,8 +4829,9 @@ mod tests {
             issuer_org_name: "org".to_string(),
             issuer_org_unit_name: "unit".to_string(),
             issuer_common_name: "common".to_string(),
-            category: EventCategory::Unknown,
             last_alert: 1,
+            confidence: 0.9,
+            category: EventCategory::Unknown,
         }
     }
 
@@ -4846,7 +4849,7 @@ mod tests {
         let syslog_message = message.to_string();
         assert_eq!(
             &syslog_message,
-            r#"time="1970-01-01T01:01:01+00:00" event_kind="SuspiciousTlsTraffic" category="Unknown" sensor="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="443" proto="6" last_time="100" server_name="server" alpn_protocol="alpn" ja3="ja3" version="version" client_cipher_suites="1,2,3" client_extensions="4,5,6" cipher="1" extensions="7,8,9" ja3s="ja3s" serial="serial" subject_country="country" subject_org_name="org" subject_common_name="common" validity_not_before="100" validity_not_after="200" subject_alt_name="alt" issuer_country="country" issuer_org_name="org" issuer_org_unit_name="unit" issuer_common_name="common" last_alert="1""#
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="SuspiciousTlsTraffic" category="Unknown" sensor="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="443" proto="6" last_time="100" server_name="server" alpn_protocol="alpn" ja3="ja3" version="version" client_cipher_suites="1,2,3" client_extensions="4,5,6" cipher="1" extensions="7,8,9" ja3s="ja3s" serial="serial" subject_country="country" subject_org_name="org" subject_common_name="common" validity_not_before="100" validity_not_after="200" subject_alt_name="alt" issuer_country="country" issuer_org_name="org" issuer_org_unit_name="unit" issuer_common_name="common" last_alert="1" confidence="0.9""#
         );
 
         let suspicious_tls_traffic =
@@ -4868,7 +4871,7 @@ mod tests {
 
         assert_eq!(
             &block_list_tls,
-            r#"time="1970-01-01T01:01:01+00:00" event_kind="SuspiciousTlsTraffic" category="Unknown" sensor="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="443" proto="6" last_time="100" server_name="server" alpn_protocol="alpn" ja3="ja3" version="version" client_cipher_suites="1,2,3" client_extensions="4,5,6" cipher="1" extensions="7,8,9" ja3s="ja3s" serial="serial" subject_country="country" subject_org_name="org" subject_common_name="common" validity_not_before="100" validity_not_after="200" subject_alt_name="alt" issuer_country="country" issuer_org_name="org" issuer_org_unit_name="unit" issuer_common_name="common" last_alert="1" triage_scores="""#
+            r#"time="1970-01-01T01:01:01+00:00" event_kind="SuspiciousTlsTraffic" category="Unknown" sensor="collector1" src_addr="127.0.0.1" src_port="10000" dst_addr="127.0.0.2" dst_port="443" proto="6" last_time="100" server_name="server" alpn_protocol="alpn" ja3="ja3" version="version" client_cipher_suites="1,2,3" client_extensions="4,5,6" cipher="1" extensions="7,8,9" ja3s="ja3s" serial="serial" subject_country="country" subject_org_name="org" subject_common_name="common" validity_not_before="100" validity_not_after="200" subject_alt_name="alt" issuer_country="country" issuer_org_name="org" issuer_org_unit_name="unit" issuer_common_name="common" last_alert="1" confidence="0.9" triage_scores="""#
         );
     }
 

--- a/src/event/common.rs
+++ b/src/event/common.rs
@@ -1,5 +1,5 @@
 use std::{
-    fmt::{self, Formatter},
+    fmt::{self, Formatter, Write},
     net::IpAddr,
     num::NonZeroU8,
 };
@@ -279,12 +279,11 @@ pub fn to_hardware_address(chaddr: &[u8]) -> String {
     iter.fold(
         {
             let mut addr = String::with_capacity(chaddr.len() * 3 - 1);
-            addr.push_str(&format!("{first:02x}"));
+            let _ = write!(addr, "{first:02x}");
             addr
         },
         |mut addr, byte| {
-            addr.push(':');
-            addr.push_str(&format!("{byte:02x}"));
+            let _ = write!(addr, ":{byte:02x}");
             addr
         },
     )
@@ -931,8 +930,9 @@ mod tests {
             issuer_org_name: "org".to_string(),
             issuer_org_unit_name: "unit".to_string(),
             issuer_common_name: "common".to_string(),
-            category: EventCategory::InitialAccess,
             last_alert: 1,
+            confidence: 0.6,
+            category: EventCategory::InitialAccess,
         }
     }
 

--- a/src/event/tls.rs
+++ b/src/event/tls.rs
@@ -36,13 +36,14 @@ pub struct BlockListTlsFields {
     pub issuer_org_unit_name: String,
     pub issuer_common_name: String,
     pub last_alert: u8,
+    pub confidence: f32,
     pub category: EventCategory,
 }
 impl fmt::Display for BlockListTlsFields {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "sensor={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} server_name={:?} alpn_protocol={:?} ja3={:?} version={:?} client_cipher_suites={:?} client_extensions={:?} cipher={:?} extensions={:?} ja3s={:?} serial={:?} subject_country={:?} subject_org_name={:?} subject_common_name={:?} validity_not_before={:?} validity_not_after={:?} subject_alt_name={:?} issuer_country={:?} issuer_org_name={:?} issuer_org_unit_name={:?} issuer_common_name={:?} last_alert={:?}",
+            "sensor={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} server_name={:?} alpn_protocol={:?} ja3={:?} version={:?} client_cipher_suites={:?} client_extensions={:?} cipher={:?} extensions={:?} ja3s={:?} serial={:?} subject_country={:?} subject_org_name={:?} subject_common_name={:?} validity_not_before={:?} validity_not_after={:?} subject_alt_name={:?} issuer_country={:?} issuer_org_name={:?} issuer_org_unit_name={:?} issuer_common_name={:?} last_alert={:?} confidence={:?}",
             self.sensor,
             self.src_addr.to_string(),
             self.src_port.to_string(),
@@ -71,6 +72,7 @@ impl fmt::Display for BlockListTlsFields {
             self.issuer_org_unit_name,
             self.issuer_common_name,
             self.last_alert.to_string(),
+            self.confidence.to_string(),
         )
     }
 }
@@ -106,6 +108,7 @@ pub struct BlockListTls {
     pub issuer_org_unit_name: String,
     pub issuer_common_name: String,
     pub last_alert: u8,
+    pub confidence: f32,
     pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
@@ -114,7 +117,7 @@ impl fmt::Display for BlockListTls {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "sensor={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} server_name={:?} alpn_protocol={:?} ja3={:?} version={:?} client_cipher_suites={:?} client_extensions={:?} cipher={:?} extensions={:?} ja3s={:?} serial={:?} subject_country={:?} subject_org_name={:?} subject_common_name={:?} validity_not_before={:?} validity_not_after={:?} subject_alt_name={:?} issuer_country={:?} issuer_org_name={:?} issuer_org_unit_name={:?} issuer_common_name={:?} last_alert={:?} triage_scores={:?}",
+            "sensor={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} server_name={:?} alpn_protocol={:?} ja3={:?} version={:?} client_cipher_suites={:?} client_extensions={:?} cipher={:?} extensions={:?} ja3s={:?} serial={:?} subject_country={:?} subject_org_name={:?} subject_common_name={:?} validity_not_before={:?} validity_not_after={:?} subject_alt_name={:?} issuer_country={:?} issuer_org_name={:?} issuer_org_unit_name={:?} issuer_common_name={:?} last_alert={:?} confidence={:?} triage_scores={:?}",
             self.sensor,
             self.src_addr.to_string(),
             self.src_port.to_string(),
@@ -143,6 +146,7 @@ impl fmt::Display for BlockListTls {
             self.issuer_org_unit_name,
             self.issuer_common_name,
             self.last_alert.to_string(),
+            self.confidence.to_string(),
             triage_scores_to_string(self.triage_scores.as_ref())
         )
     }
@@ -180,6 +184,7 @@ impl BlockListTls {
             issuer_org_unit_name: fields.issuer_org_unit_name,
             issuer_common_name: fields.issuer_common_name,
             last_alert: fields.last_alert,
+            confidence: fields.confidence,
             category: fields.category,
             triage_scores: None,
         }
@@ -224,7 +229,7 @@ impl Match for BlockListTls {
     }
 
     fn confidence(&self) -> Option<f32> {
-        None
+        Some(self.confidence)
     }
 
     fn learning_method(&self) -> LearningMethod {
@@ -266,6 +271,7 @@ pub struct SuspiciousTlsTraffic {
     pub issuer_org_unit_name: String,
     pub issuer_common_name: String,
     pub last_alert: u8,
+    pub confidence: f32,
     pub category: EventCategory,
     pub triage_scores: Option<Vec<TriageScore>>,
 }
@@ -274,7 +280,7 @@ impl fmt::Display for SuspiciousTlsTraffic {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "sensor={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} server_name={:?} alpn_protocol={:?} ja3={:?} version={:?} client_cipher_suites={:?} client_extensions={:?} cipher={:?} extensions={:?} ja3s={:?} serial={:?} subject_country={:?} subject_org_name={:?} subject_common_name={:?} validity_not_before={:?} validity_not_after={:?} subject_alt_name={:?} issuer_country={:?} issuer_org_name={:?} issuer_org_unit_name={:?} issuer_common_name={:?} last_alert={:?} triage_scores={:?}",
+            "sensor={:?} src_addr={:?} src_port={:?} dst_addr={:?} dst_port={:?} proto={:?} last_time={:?} server_name={:?} alpn_protocol={:?} ja3={:?} version={:?} client_cipher_suites={:?} client_extensions={:?} cipher={:?} extensions={:?} ja3s={:?} serial={:?} subject_country={:?} subject_org_name={:?} subject_common_name={:?} validity_not_before={:?} validity_not_after={:?} subject_alt_name={:?} issuer_country={:?} issuer_org_name={:?} issuer_org_unit_name={:?} issuer_common_name={:?} last_alert={:?} confidence={:?} triage_scores={:?}",
             self.sensor,
             self.src_addr.to_string(),
             self.src_port.to_string(),
@@ -303,6 +309,7 @@ impl fmt::Display for SuspiciousTlsTraffic {
             self.issuer_org_unit_name,
             self.issuer_common_name,
             self.last_alert.to_string(),
+            self.confidence.to_string(),
             triage_scores_to_string(self.triage_scores.as_ref())
         )
     }
@@ -340,6 +347,7 @@ impl SuspiciousTlsTraffic {
             issuer_org_unit_name: fields.issuer_org_unit_name,
             issuer_common_name: fields.issuer_common_name,
             last_alert: fields.last_alert,
+            confidence: fields.confidence,
             category: fields.category,
             triage_scores: None,
         }
@@ -384,7 +392,7 @@ impl Match for SuspiciousTlsTraffic {
     }
 
     fn confidence(&self) -> Option<f32> {
-        None
+        Some(self.confidence)
     }
 
     fn learning_method(&self) -> LearningMethod {

--- a/src/migration/migration_structures.rs
+++ b/src/migration/migration_structures.rs
@@ -1324,7 +1324,7 @@ pub struct BlockListTlsBeforeV30 {
     pub last_alert: u8,
 }
 
-impl From<BlockListTlsBeforeV30> for BlockListTlsFields {
+impl From<BlockListTlsBeforeV30> for BlockListTlsFieldsBeforeV37 {
     fn from(input: BlockListTlsBeforeV30) -> Self {
         Self {
             sensor: input.source,
@@ -1355,6 +1355,76 @@ impl From<BlockListTlsBeforeV30> for BlockListTlsFields {
             issuer_org_unit_name: input.issuer_org_unit_name,
             issuer_common_name: input.issuer_common_name,
             last_alert: input.last_alert,
+            category: EventCategory::InitialAccess,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct BlockListTlsFieldsBeforeV37 {
+    pub sensor: String,
+    pub src_addr: IpAddr,
+    pub src_port: u16,
+    pub dst_addr: IpAddr,
+    pub dst_port: u16,
+    pub proto: u8,
+    pub last_time: i64,
+    pub server_name: String,
+    pub alpn_protocol: String,
+    pub ja3: String,
+    pub version: String,
+    pub client_cipher_suites: Vec<u16>,
+    pub client_extensions: Vec<u16>,
+    pub cipher: u16,
+    pub extensions: Vec<u16>,
+    pub ja3s: String,
+    pub serial: String,
+    pub subject_country: String,
+    pub subject_org_name: String,
+    pub subject_common_name: String,
+    pub validity_not_before: i64,
+    pub validity_not_after: i64,
+    pub subject_alt_name: String,
+    pub issuer_country: String,
+    pub issuer_org_name: String,
+    pub issuer_org_unit_name: String,
+    pub issuer_common_name: String,
+    pub last_alert: u8,
+    pub category: EventCategory,
+}
+
+impl From<BlockListTlsFieldsBeforeV37> for BlockListTlsFields {
+    fn from(input: BlockListTlsFieldsBeforeV37) -> Self {
+        Self {
+            sensor: input.sensor,
+            src_addr: input.src_addr,
+            src_port: input.src_port,
+            dst_addr: input.dst_addr,
+            dst_port: input.dst_port,
+            proto: input.proto,
+            last_time: input.last_time,
+            server_name: input.server_name,
+            alpn_protocol: input.alpn_protocol,
+            ja3: input.ja3,
+            version: input.version,
+            client_cipher_suites: input.client_cipher_suites,
+            client_extensions: input.client_extensions,
+            cipher: input.cipher,
+            extensions: input.extensions,
+            ja3s: input.ja3s,
+            serial: input.serial,
+            subject_country: input.subject_country,
+            subject_org_name: input.subject_org_name,
+            subject_common_name: input.subject_common_name,
+            validity_not_before: input.validity_not_before,
+            validity_not_after: input.validity_not_after,
+            subject_alt_name: input.subject_alt_name,
+            issuer_country: input.issuer_country,
+            issuer_org_name: input.issuer_org_name,
+            issuer_org_unit_name: input.issuer_org_unit_name,
+            issuer_common_name: input.issuer_common_name,
+            last_alert: input.last_alert,
+            confidence: 0.0,
             category: EventCategory::InitialAccess,
         }
     }

--- a/src/tables/accounts.rs
+++ b/src/tables/accounts.rs
@@ -149,7 +149,7 @@ impl<'d> Table<'d, Account> {
                     .context("failed to write new entry")?;
             } else {
                 bail!("no such entry");
-            };
+            }
 
             match txn.commit() {
                 Ok(()) => break,

--- a/src/tables/network.rs
+++ b/src/tables/network.rs
@@ -350,7 +350,7 @@ mod test {
 
         let ids: Vec<_> = table
             .iter(Direction::Reverse, None)
-            .filter_map(|res| if let Ok(e) = res { Some(e) } else { None })
+            .filter_map(std::result::Result::ok)
             .map(|e| e.id)
             .collect();
 


### PR DESCRIPTION
Close #416 

* Add `confidence` field to `BlockListTlsFields` to match Semi-supervised engine's structure.
* Fix clippy error due to rust version update.