### PR TITLE
Modify `Node` structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   naming convention used in other parts of the codebase.
 - Modified the `ValueKind` enum to support different types of input for packet
   attribute triage.
+- Modified the `Node` structure to allow you to manage the configuration of all
+  remote servers that communicate with the REview.
+  - Introduced `Remote`, a new structure that stores only configuration drafts
+    for remote servers.
+  - Introduced `RemoteConfig`, `RemoteStatus`, and `RemoteKind` as internal
+    types used by the new `Remote` structure.
+  - Added a `remotes` field of type `Vec<Remote>` within the `Node` structure to
+    store the all remote server configuration.
+  - Added a `Datalake`, `TiContainer` field inside `node::kind`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
     as internal types used by the new `UnlinkedServer` structure.
   - Added a `unlinked_servers` field of type `Vec<UnlinkedServer>` within the `Node`
     structure to store all unlinked server configuration drafts.
-  - Added a `Datalake`, `TiContainer` field inside `node::kind`.
+  - Added `Datalake` and `TiContainer` variants inside `node::Kind`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,14 +28,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   naming convention used in other parts of the codebase.
 - Modified the `ValueKind` enum to support different types of input for packet
   attribute triage.
-- Modified the `Node` structure to allow you to manage the configuration of all
-  remote servers that communicate with the REview.
-  - Introduced `Remote`, a new structure that stores only configuration drafts
-    for remote servers.
-  - Introduced `RemoteConfig`, `RemoteStatus`, and `RemoteKind` as internal
-    types used by the new `Remote` structure.
-  - Added a `remotes` field of type `Vec<Remote>` within the `Node` structure to
-    store the all remote server configuration.
+- Modified the `Node` structure to allow you to manage the configuration drafts
+  of all unlinked servers.
+  - Introduced `UnlinkedServer`, a new structure that stores only configuration
+    drafts for unlinked servers.
+  - Introduced `UnlinkedServerConfig`, `UnlinkedServerStatus`, and `UnlinkedServerKind`
+    as internal types used by the new `UnlinkedServer` structure.
+  - Added a `unlinked_servers` field of type `Vec<UnlinkedServer>` within the `Node`
+    structure to store all unlinked server configuration drafts.
   - Added a `Datalake`, `TiContainer` field inside `node::kind`.
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "review-database"
-version = "0.37.0"
+version = "0.38.0-alpha.1"
 edition = "2024"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,14 +66,14 @@ pub use self::tables::{
     AccessToken, AccountPolicy, Agent, AgentConfig, AgentKind, AgentStatus, AllowNetwork,
     AllowNetworkUpdate, AttrCmpKind, BlockNetwork, BlockNetworkUpdate, Confidence,
     CsvColumnExtra as CsvColumnExtraConfig, Customer, CustomerNetwork, CustomerUpdate, DataSource,
-    DataSourceUpdate, DataType, Filter, Giganto, IndexedTable, Iterable, ModelIndicator, Network,
+    DataSourceUpdate, DataType, Filter, IndexedTable, Iterable, ModelIndicator, Network,
     NetworkUpdate, Node, NodeProfile, NodeTable, NodeUpdate, OutlierInfo, OutlierInfoKey,
-    OutlierInfoValue, PacketAttr, ProtocolPorts, Response, ResponseKind, SamplingInterval,
-    SamplingKind, SamplingPeriod, SamplingPolicy, SamplingPolicyUpdate, Structured,
-    StructuredClusteringAlgorithm, Table, Template, Ti, TiCmpKind, Tidb, TidbKind, TidbRule,
-    TorExitNode, TrafficFilter, TriagePolicy, TriagePolicyUpdate, TriageResponse,
-    TriageResponseUpdate, TrustedDomain, TrustedUserAgent, UniqueKey, Unstructured,
-    UnstructuredClusteringAlgorithm, ValueKind,
+    OutlierInfoValue, PacketAttr, ProtocolPorts, Remote, RemoteConfig, RemoteKind, RemoteStatus,
+    Response, ResponseKind, SamplingInterval, SamplingKind, SamplingPeriod, SamplingPolicy,
+    SamplingPolicyUpdate, Structured, StructuredClusteringAlgorithm, Table, Template, Ti,
+    TiCmpKind, Tidb, TidbKind, TidbRule, TorExitNode, TrafficFilter, TriagePolicy,
+    TriagePolicyUpdate, TriageResponse, TriageResponseUpdate, TrustedDomain, TrustedUserAgent,
+    UniqueKey, Unstructured, UnstructuredClusteringAlgorithm, ValueKind,
 };
 pub use self::time_series::*;
 pub use self::time_series::{ColumnTimeSeries, TimeCount, TimeSeriesResult};
@@ -260,6 +260,12 @@ impl Store {
     #[allow(clippy::missing_panics_doc)]
     pub fn outlier_map(&self) -> Table<OutlierInfo> {
         self.states.outlier_infos()
+    }
+
+    #[must_use]
+    #[allow(clippy::missing_panics_doc)]
+    pub fn remotes_map(&self) -> Table<Remote> {
+        self.states.remotes()
     }
 
     #[must_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,12 +68,13 @@ pub use self::tables::{
     CsvColumnExtra as CsvColumnExtraConfig, Customer, CustomerNetwork, CustomerUpdate, DataSource,
     DataSourceUpdate, DataType, Filter, IndexedTable, Iterable, ModelIndicator, Network,
     NetworkUpdate, Node, NodeProfile, NodeTable, NodeUpdate, OutlierInfo, OutlierInfoKey,
-    OutlierInfoValue, PacketAttr, ProtocolPorts, Remote, RemoteConfig, RemoteKind, RemoteStatus,
-    Response, ResponseKind, SamplingInterval, SamplingKind, SamplingPeriod, SamplingPolicy,
-    SamplingPolicyUpdate, Structured, StructuredClusteringAlgorithm, Table, Template, Ti,
-    TiCmpKind, Tidb, TidbKind, TidbRule, TorExitNode, TrafficFilter, TriagePolicy,
-    TriagePolicyUpdate, TriageResponse, TriageResponseUpdate, TrustedDomain, TrustedUserAgent,
-    UniqueKey, Unstructured, UnstructuredClusteringAlgorithm, ValueKind,
+    OutlierInfoValue, PacketAttr, ProtocolPorts, Response, ResponseKind, SamplingInterval,
+    SamplingKind, SamplingPeriod, SamplingPolicy, SamplingPolicyUpdate, Structured,
+    StructuredClusteringAlgorithm, Table, Template, Ti, TiCmpKind, Tidb, TidbKind, TidbRule,
+    TorExitNode, TrafficFilter, TriagePolicy, TriagePolicyUpdate, TriageResponse,
+    TriageResponseUpdate, TrustedDomain, TrustedUserAgent, UniqueKey, UnlinkedServer,
+    UnlinkedServerConfig, UnlinkedServerKind, UnlinkedServerStatus, Unstructured,
+    UnstructuredClusteringAlgorithm, ValueKind,
 };
 pub use self::time_series::*;
 pub use self::time_series::{ColumnTimeSeries, TimeCount, TimeSeriesResult};
@@ -264,12 +265,6 @@ impl Store {
 
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
-    pub fn remotes_map(&self) -> Table<Remote> {
-        self.states.remotes()
-    }
-
-    #[must_use]
-    #[allow(clippy::missing_panics_doc)]
     pub fn sampling_policy_map(&self) -> IndexedTable<SamplingPolicy> {
         self.states.sampling_policies()
     }
@@ -338,6 +333,12 @@ impl Store {
     #[allow(clippy::missing_panics_doc)]
     pub fn traffic_filter_map(&self) -> Table<TrafficFilter> {
         self.states.traffic_filters()
+    }
+
+    #[must_use]
+    #[allow(clippy::missing_panics_doc)]
+    pub fn unlinked_servers_map(&self) -> Table<UnlinkedServer> {
+        self.states.unlinked_servers()
     }
 
     /// Returns the tag set for workflow.

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -16,7 +16,7 @@ use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
-use crate::{Agent, AgentStatus, Giganto, Indexed, IterableMap};
+use crate::{Agent, Indexed, IterableMap, Remote};
 
 /// The range of versions that use the current database format.
 ///
@@ -99,7 +99,7 @@ use crate::{Agent, AgentStatus, Giganto, Indexed, IterableMap};
 /// // release that involves database format change) to 3.5.0, including
 /// // all alpha changes finalized in 3.5.0.
 /// ```
-const COMPATIBLE_VERSION_REQ: &str = ">=0.37.0,<0.38.0-alpha";
+const COMPATIBLE_VERSION_REQ: &str = ">=0.38.0-alpha.1,<0.38.0-alpha.2";
 
 /// Migrates data exists in `PostgresQL` to Rocksdb if necessary.
 ///
@@ -208,9 +208,14 @@ pub fn migrate_data_dir<P: AsRef<Path>>(data_dir: P, backup_dir: P) -> Result<()
             migrate_0_34_0_to_0_36,
         ),
         (
-            VersionReq::parse(">=0.36.0,<0.37.0-alpha")?,
+            VersionReq::parse(">=0.36.0,<0.37.0")?,
             Version::parse("0.37.0")?,
             migrate_0_36_0_to_0_37,
+        ),
+        (
+            VersionReq::parse(">=0.37.0,<0.38.0-alpha.1")?,
+            Version::parse("0.38.0-alpha.1")?,
+            migrate_0_37_to_0_38_0,
         ),
     ];
 
@@ -285,6 +290,42 @@ fn read_version_file(path: &Path) -> Result<Version> {
         .read_to_string(&mut ver)
         .context("cannot read VERSION")?;
     Version::parse(&ver).context("cannot parse VERSION")
+}
+
+fn migrate_0_37_to_0_38_0(store: &super::Store) -> Result<()> {
+    migrate_0_38_node(store)
+}
+
+fn migrate_0_38_node(store: &super::Store) -> Result<()> {
+    use bincode::Options;
+    use migration_structures::OldInnerFromV29BeforeV37;
+
+    use crate::{
+        IterableMap,
+        tables::{InnerNode, UniqueKey, Value},
+    };
+
+    let map = store.node_map();
+    let node_raw = map.raw();
+    let remote_raw = map.remote_raw();
+    for (_key, old_value) in node_raw.iter_forward()? {
+        let old_inner_node = bincode::DefaultOptions::new()
+            .deserialize::<OldInnerFromV29BeforeV37>(&old_value)
+            .context("Failed to migrate node database: invalid node value")?;
+        if let Some(ref config) = old_inner_node.giganto {
+            let remote = Remote {
+                node: old_inner_node.id,
+                key: "giganto".to_string(),
+                kind: crate::RemoteKind::Datalake,
+                status: config.status,
+                draft: config.draft.clone(),
+            };
+            remote_raw.insert(remote.unique_key().as_ref(), remote.value().as_ref())?;
+        }
+        let new_inner_node: InnerNode = old_inner_node.into();
+        node_raw.overwrite(&new_inner_node)?;
+    }
+    Ok(())
 }
 
 fn migrate_0_36_0_to_0_37(store: &super::Store) -> Result<()> {
@@ -815,14 +856,17 @@ fn migrate_0_29_node(store: &super::Store) -> Result<()> {
 
     use bincode::Options;
     use chrono::{DateTime, Utc};
+    use migration_structures::{Giganto, OldInnerFromV29BeforeV37, OldNodeFromV29BeforeV37};
 
-    use crate::IterableMap;
-    use crate::{Node, NodeProfile};
+    use crate::{
+        tables::{UniqueKey, Value},
+        {IterableMap, NodeProfile, collections::Indexed},
+    };
 
     type PortNumber = u16;
 
     #[derive(Clone, Deserialize, Serialize)]
-    pub struct OldNode {
+    pub struct OldNodeBeforeV29 {
         pub id: u32,
         pub name: String,
         pub name_draft: Option<String>,
@@ -894,10 +938,10 @@ fn migrate_0_29_node(store: &super::Store) -> Result<()> {
         }
     }
 
-    impl TryFrom<OldNode> for Node {
+    impl TryFrom<OldNodeBeforeV29> for OldNodeFromV29BeforeV37 {
         type Error = anyhow::Error;
 
-        fn try_from(input: OldNode) -> Result<Self, Self::Error> {
+        fn try_from(input: OldNodeBeforeV29) -> Result<Self, Self::Error> {
             use migration_structures::{
                 DumpHttpContentType, DumpItem, GigantoConfig, HogConfig, PigletConfig,
                 ProtocolForHog,
@@ -905,7 +949,9 @@ fn migrate_0_29_node(store: &super::Store) -> Result<()> {
 
             let mut giganto = None;
             let mut agents = vec![None, None, None];
-            let status = crate::AgentStatus::Enabled;
+            let agent_status = crate::AgentStatus::Enabled;
+            let remote_status = crate::RemoteStatus::Enabled;
+
             if let Some(s) = input.settings.as_ref() {
                 if s.hog {
                     let config = HogConfig {
@@ -944,7 +990,7 @@ fn migrate_0_29_node(store: &super::Store) -> Result<()> {
                         kind: crate::AgentKind::SemiSupervised,
                         config: Some(config),
                         draft: None,
-                        status,
+                        status: agent_status,
                     };
                     agents[0] = Some(agent);
                 }
@@ -1017,7 +1063,7 @@ fn migrate_0_29_node(store: &super::Store) -> Result<()> {
                         kind: crate::AgentKind::Sensor,
                         config: Some(config),
                         draft: None,
-                        status,
+                        status: agent_status,
                     };
                     agents[1] = Some(agent);
                 }
@@ -1030,14 +1076,14 @@ fn migrate_0_29_node(store: &super::Store) -> Result<()> {
                         kind: crate::AgentKind::Unsupervised,
                         config: Some(config),
                         draft: None,
-                        status,
+                        status: agent_status,
                     };
                     agents[2] = Some(agent);
                 }
 
                 if s.giganto {
                     giganto = Some(Giganto {
-                        status: AgentStatus::Enabled,
+                        status: remote_status,
                         draft: None,
                     });
                 }
@@ -1083,7 +1129,7 @@ fn migrate_0_29_node(store: &super::Store) -> Result<()> {
                             kind: crate::AgentKind::SemiSupervised,
                             config: None,
                             draft: Some(draft),
-                            status,
+                            status: agent_status,
                         });
                     }
                 }
@@ -1159,7 +1205,7 @@ fn migrate_0_29_node(store: &super::Store) -> Result<()> {
                             kind: crate::AgentKind::Sensor,
                             config: None,
                             draft: Some(draft),
-                            status,
+                            status: agent_status,
                         });
                     }
                 }
@@ -1175,7 +1221,7 @@ fn migrate_0_29_node(store: &super::Store) -> Result<()> {
                             kind: crate::AgentKind::Unsupervised,
                             config: None,
                             draft: Some(draft),
-                            status,
+                            status: agent_status,
                         });
                     }
                 }
@@ -1217,7 +1263,7 @@ fn migrate_0_29_node(store: &super::Store) -> Result<()> {
                     };
                     let draft = Some(toml::to_string(&draft)?.try_into()?);
                     giganto = Some(Giganto {
-                        status: AgentStatus::Enabled,
+                        status: remote_status,
                         draft,
                     });
                 }
@@ -1236,26 +1282,26 @@ fn migrate_0_29_node(store: &super::Store) -> Result<()> {
     }
 
     let map = store.node_map();
-    let raw = map.raw();
-    let mut nodes = vec![];
-    for (_key, old_value) in raw.iter_forward()? {
+    let node_raw = map.raw();
+    let agent_raw = map.agent_raw();
+    for (_key, old_value) in node_raw.iter_forward()? {
         let old_node = bincode::DefaultOptions::new()
-            .deserialize::<OldNode>(&old_value)
+            .deserialize::<OldNodeBeforeV29>(&old_value)
             .context("Failed to migrate node database: invalid node value")?;
-        match TryInto::<Node>::try_into(old_node) {
+        match TryInto::<OldNodeFromV29BeforeV37>::try_into(old_node) {
             Ok(new_node) => {
-                raw.deactivate(new_node.id)?;
-                nodes.push(new_node);
+                for agent in &new_node.agents {
+                    agent_raw.insert(agent.unique_key().as_ref(), agent.value().as_ref())?;
+                }
+                let inner: OldInnerFromV29BeforeV37 = new_node.into();
+                node_raw.overwrite(&inner)?;
             }
             Err(e) => {
                 warn!("Skip the migration for an item: {e}");
             }
         }
     }
-    raw.clear_inactive()?;
-    for node in nodes {
-        let _ = map.put(node)?;
-    }
+
     Ok(())
 }
 
@@ -3525,11 +3571,16 @@ mod tests {
         use serde::{Deserialize, Serialize};
 
         use crate::{
-            Indexable, collections::Indexed, migration::migration_structures::PigletConfig,
+            Agent, Indexable,
+            collections::Indexed,
+            migration::migration_structures::{
+                OldInnerFromV29BeforeV37, OldNodeFromV29BeforeV37, PigletConfig,
+            },
+            types::FromKeyValue,
         };
 
         #[derive(Clone, Deserialize, Serialize)]
-        pub struct OldNode {
+        pub struct OldNodeBeforeV29 {
             pub id: u32,
             pub name: String,
             pub name_draft: Option<String>,
@@ -3591,7 +3642,7 @@ mod tests {
             pub sensor_list: HashMap<String, bool>,
         }
 
-        impl Indexable for OldNode {
+        impl Indexable for OldNodeBeforeV29 {
             fn key(&self) -> Cow<[u8]> {
                 Cow::from(self.name.as_bytes())
             }
@@ -3619,7 +3670,7 @@ mod tests {
         let map = settings.store.node_map();
         let node_db = map.raw();
 
-        let old_node = OldNode {
+        let old_node = OldNodeBeforeV29 {
             id: 0,
             name: "name".to_string(),
             name_draft: None,
@@ -3671,19 +3722,42 @@ mod tests {
             }),
         };
 
-        let res = node_db.insert(old_node.clone());
-        assert!(res.is_ok());
-        let id = res.unwrap();
+        assert!(node_db.insert(old_node.clone()).is_ok());
         let (db_dir, backup_dir) = settings.close();
         let settings = TestSchema::new_with_dir(db_dir, backup_dir);
 
         assert!(super::migrate_0_29_node(&settings.store).is_ok());
 
         let map = settings.store.node_map();
-        let (new_node, invalid_agent) = map.get_by_id(id).unwrap().unwrap();
+        let node_db = map.raw();
+        let agent_db = map.agent_raw();
+        let raw_data = node_db.get_by_key("name".as_bytes()).unwrap().unwrap();
+        let new_inner_node: OldInnerFromV29BeforeV37 = bincode::DefaultOptions::new()
+            .deserialize(raw_data.as_ref())
+            .expect("deserializable");
 
-        assert!(invalid_agent.is_empty());
-        assert_eq!(new_node.id, id);
+        let mut agents = vec![];
+        for aid in new_inner_node.agents {
+            let mut key = new_inner_node.id.to_be_bytes().to_vec();
+            key.extend(aid.as_bytes());
+            if let Ok(Some(value)) = agent_db.get(&key) {
+                if let Ok(agent) = Agent::from_key_value(&key, value.as_ref()) {
+                    agents.push(agent);
+                }
+            }
+        }
+        let new_node = OldNodeFromV29BeforeV37 {
+            id: new_inner_node.id,
+            name: new_inner_node.name,
+            name_draft: new_inner_node.name_draft,
+            profile: new_inner_node.profile,
+            profile_draft: new_inner_node.profile_draft,
+            agents,
+            giganto: new_inner_node.giganto,
+            creation_time: new_inner_node.creation_time,
+        };
+
+        assert_eq!(new_node.id, 0);
         assert_eq!(new_node.name, "name");
         assert_eq!(new_node.agents.len(), 2);
         assert_eq!(new_node.agents[0].key, "hog");
@@ -4326,5 +4400,163 @@ mod tests {
                 _ => {}
             }
         }
+    }
+
+    #[test]
+    fn migrate_0_37_to_0_38_node() {
+        use std::{
+            net::{IpAddr, SocketAddr},
+            str::FromStr,
+        };
+
+        use chrono::Utc;
+
+        use super::migration_structures::{
+            DumpItem, OldInnerFromV29BeforeV37, OldNodeFromV29BeforeV37,
+        };
+        use crate::{
+            Agent, NodeProfile,
+            collections::Indexed,
+            migration::migration_structures::{Giganto, GigantoConfig, HogConfig, PigletConfig},
+            tables::{UniqueKey, Value},
+        };
+        let agent_status = crate::AgentStatus::Enabled;
+        let remote_status = crate::RemoteStatus::Enabled;
+
+        let hog_config = HogConfig {
+            active_protocols: Some(Vec::new()),
+            active_sources: Some(Vec::new()),
+            giganto_publish_srv_addr: Some(SocketAddr::new(
+                IpAddr::from_str("1.1.1.1").unwrap(),
+                3050,
+            )),
+            cryptocurrency_mining_pool: String::new(),
+            log_dir: String::new(),
+            export_dir: String::new(),
+            services_path: String::new(),
+        };
+
+        let hog_agent = Agent {
+            node: 0,
+            key: "hog".to_string(),
+            kind: crate::AgentKind::SemiSupervised,
+            status: agent_status,
+            config: None,
+            draft: Some(toml::to_string(&hog_config).unwrap().try_into().unwrap()),
+        };
+
+        let piglet_config = PigletConfig {
+            dpdk_args: String::new(),
+            dpdk_input: Vec::new(),
+            dpdk_output: Vec::new(),
+            src_mac: String::new(),
+            dst_mac: String::new(),
+            log_dir: String::new(),
+            dump_dir: String::new(),
+            dump_items: Some(vec![DumpItem::Pcap]),
+            dump_http_content_types: Some(Vec::new()),
+            giganto_ingest_srv_addr: SocketAddr::new(IpAddr::from_str("1.1.1.2").unwrap(), 3030),
+            giganto_name: String::new(),
+            pcap_max_size: 4_294_967_295,
+        };
+
+        let piglet_agent = Agent {
+            node: 0,
+            key: "piglet".to_string(),
+            kind: crate::AgentKind::Sensor,
+            status: agent_status,
+            config: None,
+            draft: Some(toml::to_string(&piglet_config).unwrap().try_into().unwrap()),
+        };
+
+        let giganto_config = GigantoConfig {
+            ingest_srv_addr: SocketAddr::new(IpAddr::from_str("0.0.0.0").unwrap(), 3030),
+            publish_srv_addr: SocketAddr::new(IpAddr::from_str("0.0.0.0").unwrap(), 3050),
+            graphql_srv_addr: SocketAddr::new(IpAddr::from_str("0.0.0.0").unwrap(), 5050),
+            data_dir: String::new(),
+            log_dir: String::new(),
+            export_dir: String::new(),
+            retention: {
+                let days = u64::from(100_u16);
+                std::time::Duration::from_secs(days * 24 * 60 * 60)
+            },
+            max_open_files: i32::MAX,
+            max_mb_of_level_base: u64::MIN,
+            num_of_thread: i32::MAX,
+            max_sub_compactions: u32::MAX,
+            ack_transmission: u16::MAX,
+        };
+
+        let old_node = OldNodeFromV29BeforeV37 {
+            id: 0,
+            name: "name".to_string(),
+            name_draft: None,
+            profile: None,
+            profile_draft: Some(NodeProfile {
+                customer_id: 20,
+                description: "description".to_string(),
+                hostname: "host".to_string(),
+            }),
+            agents: vec![hog_agent.clone(), piglet_agent.clone()],
+            giganto: Some(Giganto {
+                status: remote_status,
+                draft: Some(
+                    toml::to_string(&giganto_config)
+                        .unwrap()
+                        .try_into()
+                        .unwrap(),
+                ),
+            }),
+            creation_time: Utc::now(),
+        };
+
+        let settings = TestSchema::new();
+        let map = settings.store.node_map();
+        let node_db = map.raw();
+        let agent_db = map.agent_raw();
+
+        let hog_res = agent_db.insert(hog_agent.unique_key().as_ref(), hog_agent.value().as_ref());
+        assert!(hog_res.is_ok());
+        let piglet_res = agent_db.insert(
+            piglet_agent.unique_key().as_ref(),
+            piglet_agent.value().as_ref(),
+        );
+        assert!(piglet_res.is_ok());
+        let old_inner_node: OldInnerFromV29BeforeV37 = old_node.clone().into();
+        let res = node_db.insert(old_inner_node);
+        assert!(res.is_ok());
+
+        let id = res.unwrap();
+        let (db_dir, backup_dir) = settings.close();
+        let settings = TestSchema::new_with_dir(db_dir, backup_dir);
+
+        assert!(super::migrate_0_38_node(&settings.store).is_ok());
+
+        let map = settings.store.node_map();
+        let (new_node, invalid_agent, invalid_remotes) = map.get_by_id(id).unwrap().unwrap();
+
+        assert!(invalid_agent.is_empty());
+        assert!(invalid_remotes.is_empty());
+        assert_eq!(new_node.id, id);
+        assert_eq!(new_node.name, "name");
+        assert_eq!(new_node.agents.len(), 2);
+        assert_eq!(new_node.agents[0].key, "hog");
+        assert!(new_node.agents[0].config.is_none());
+        assert!(new_node.agents[0].draft.is_some());
+        assert_eq!(new_node.agents[1].key, "piglet");
+        assert!(new_node.agents[1].config.is_none());
+        let draft = new_node.agents[1].draft.clone().unwrap();
+        let piglet: PigletConfig = toml::from_str(draft.as_ref()).unwrap();
+        assert!(piglet.dump_items.is_some());
+        assert!(piglet.dump_http_content_types.is_some_and(|v| v.is_empty()));
+        assert_eq!(new_node.remotes.len(), 1);
+        assert_eq!(new_node.remotes[0].key, "giganto");
+        assert!(new_node.remotes[0].draft.is_some());
+        let draft = new_node.remotes[0].draft.clone().unwrap();
+        let giganto: GigantoConfig = toml::from_str(draft.as_ref()).unwrap();
+        assert_eq!(
+            giganto.retention,
+            std::time::Duration::from_secs(100 * 24 * 60 * 60)
+        );
     }
 }

--- a/src/migration/migration_structures.rs
+++ b/src/migration/migration_structures.rs
@@ -14,8 +14,8 @@ use crate::{
     BlocklistTlsFields, CryptocurrencyMiningPoolFields, DgaFields, DnsEventFields, EventCategory,
     ExternalDdosFields, ExtraThreat, FtpBruteForceFields, FtpEventFields, HttpEventFields,
     HttpThreatFields, Indexable, LdapBruteForceFields, LdapEventFields, MultiHostPortScanFields,
-    NetworkThreat, NodeProfile, PortScanFields, RdpBruteForceFields, RemoteConfig, RemoteStatus,
-    RepeatedHttpSessionsFields, Role, TriageScore, WindowsThreat,
+    NetworkThreat, NodeProfile, PortScanFields, RdpBruteForceFields, RepeatedHttpSessionsFields,
+    Role, TriageScore, UnlinkedServerConfig, UnlinkedServerStatus, WindowsThreat,
     account::{PasswordHashAlgorithm, SaltedPassword},
     tables::InnerNode,
     types::Account,
@@ -2240,8 +2240,8 @@ impl From<Account> for AccountBeforeV36 {
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Giganto {
-    pub status: RemoteStatus,
-    pub draft: Option<RemoteConfig>,
+    pub status: UnlinkedServerStatus,
+    pub draft: Option<UnlinkedServerConfig>,
 }
 
 #[derive(Clone, Deserialize, Serialize, PartialEq, Debug)]
@@ -2292,7 +2292,7 @@ impl From<OldInnerFromV29BeforeV37> for InnerNode {
             profile: input.profile,
             profile_draft: input.profile_draft,
             agents: input.agents,
-            remotes: input
+            unlinked_servers: input
                 .giganto
                 .map_or_else(Vec::new, |_| vec!["giganto".to_string()]),
             creation_time: input.creation_time,

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -15,7 +15,6 @@ mod network;
 mod node;
 mod outlier_info;
 mod qualifier;
-mod remote;
 mod sampling_policy;
 mod scores;
 mod status;
@@ -27,6 +26,7 @@ mod triage_policy;
 mod triage_response;
 mod trusted_domain;
 mod trusted_user_agent;
+mod unlinked_server;
 
 use std::path::{Path, PathBuf};
 
@@ -46,12 +46,11 @@ pub use self::model_indicator::ModelIndicator;
 pub use self::network::{Network, Update as NetworkUpdate};
 pub(crate) use self::node::Inner as InnerNode;
 pub use self::node::{
-    Config as AgentConfig, Config as RemoteConfig, Kind as AgentKind, Kind as RemoteKind, Node,
-    Profile as NodeProfile, Status as AgentStatus, Status as RemoteStatus, Table as NodeTable,
-    Update as NodeUpdate,
+    Config as AgentConfig, Config as UnlinkedServerConfig, Kind as AgentKind,
+    Kind as UnlinkedServerKind, Node, Profile as NodeProfile, Status as AgentStatus,
+    Status as UnlinkedServerStatus, Table as NodeTable, Update as NodeUpdate,
 };
 pub use self::outlier_info::{Key as OutlierInfoKey, OutlierInfo, Value as OutlierInfoValue};
-pub use self::remote::Remote;
 pub use self::sampling_policy::{
     Interval as SamplingInterval, Kind as SamplingKind, Period as SamplingPeriod, SamplingPolicy,
     Update as SamplingPolicyUpdate,
@@ -70,6 +69,7 @@ pub use self::triage_policy::{
 pub use self::triage_response::{TriageResponse, Update as TriageResponseUpdate};
 pub use self::trusted_domain::TrustedDomain;
 pub use self::trusted_user_agent::TrustedUserAgent;
+pub use self::unlinked_server::UnlinkedServer;
 use super::{Indexed, IndexedMap, Map, event};
 use crate::{
     Direction, Indexable,
@@ -99,7 +99,6 @@ pub(super) const NETWORKS: &str = "networks";
 pub(super) const NODES: &str = "nodes";
 pub(super) const OUTLIERS: &str = "outliers";
 pub(super) const QUALIFIERS: &str = "qualifiers";
-pub(super) const REMOTES: &str = "remotes";
 pub(super) const SAMPLING_POLICY: &str = "sampling policy";
 pub(super) const SCORES: &str = "scores";
 pub(super) const STATUSES: &str = "statuses";
@@ -111,6 +110,7 @@ pub(super) const TRIAGE_POLICY: &str = "triage policy";
 pub(super) const TRIAGE_RESPONSE: &str = "triage response";
 pub(super) const TRUSTED_DNS_SERVERS: &str = "trusted DNS servers";
 pub(super) const TRUSTED_USER_AGENTS: &str = "trusted user agents";
+pub(super) const UNLINKED_SERVERS: &str = "unlinked servers";
 
 const MAP_NAMES: [&str; 30] = [
     ACCESS_TOKENS,
@@ -131,7 +131,6 @@ const MAP_NAMES: [&str; 30] = [
     NODES,
     OUTLIERS,
     QUALIFIERS,
-    REMOTES,
     SAMPLING_POLICY,
     SCORES,
     STATUSES,
@@ -143,6 +142,7 @@ const MAP_NAMES: [&str; 30] = [
     TRIAGE_RESPONSE,
     TRUSTED_DNS_SERVERS,
     TRUSTED_USER_AGENTS,
+    UNLINKED_SERVERS,
 ];
 
 // Keys for the meta map.
@@ -191,9 +191,9 @@ impl StateDb {
     }
 
     #[must_use]
-    pub(crate) fn remotes(&self) -> Table<Remote> {
+    pub(crate) fn unlinked_servers(&self) -> Table<UnlinkedServer> {
         let inner = self.inner.as_ref().expect("database must be open");
-        Table::<Remote>::open(inner).expect("{REMOTES} table must be present")
+        Table::<UnlinkedServer>::open(inner).expect("{UNLINKED_SERVERS} table must be present")
     }
 
     #[must_use]

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -15,6 +15,7 @@ mod network;
 mod node;
 mod outlier_info;
 mod qualifier;
+mod remote;
 mod sampling_policy;
 mod scores;
 mod status;
@@ -34,7 +35,7 @@ use serde::{Deserialize, Serialize};
 
 pub use self::access_token::AccessToken;
 pub use self::account_policy::AccountPolicy;
-pub use self::agent::{Agent, Config as AgentConfig, Kind as AgentKind, Status as AgentStatus};
+pub use self::agent::Agent;
 pub use self::allow_network::{AllowNetwork, Update as AllowNetworkUpdate};
 pub use self::block_network::{BlockNetwork, Update as BlockNetworkUpdate};
 pub use self::csv_column_extra::CsvColumnExtra;
@@ -45,9 +46,12 @@ pub use self::model_indicator::ModelIndicator;
 pub use self::network::{Network, Update as NetworkUpdate};
 pub(crate) use self::node::Inner as InnerNode;
 pub use self::node::{
-    Giganto, Node, Profile as NodeProfile, Table as NodeTable, Update as NodeUpdate,
+    Config as AgentConfig, Config as RemoteConfig, Kind as AgentKind, Kind as RemoteKind, Node,
+    Profile as NodeProfile, Status as AgentStatus, Status as RemoteStatus, Table as NodeTable,
+    Update as NodeUpdate,
 };
 pub use self::outlier_info::{Key as OutlierInfoKey, OutlierInfo, Value as OutlierInfoValue};
+pub use self::remote::Remote;
 pub use self::sampling_policy::{
     Interval as SamplingInterval, Kind as SamplingKind, Period as SamplingPeriod, SamplingPolicy,
     Update as SamplingPolicyUpdate,
@@ -95,6 +99,7 @@ pub(super) const NETWORKS: &str = "networks";
 pub(super) const NODES: &str = "nodes";
 pub(super) const OUTLIERS: &str = "outliers";
 pub(super) const QUALIFIERS: &str = "qualifiers";
+pub(super) const REMOTES: &str = "remotes";
 pub(super) const SAMPLING_POLICY: &str = "sampling policy";
 pub(super) const SCORES: &str = "scores";
 pub(super) const STATUSES: &str = "statuses";
@@ -107,7 +112,7 @@ pub(super) const TRIAGE_RESPONSE: &str = "triage response";
 pub(super) const TRUSTED_DNS_SERVERS: &str = "trusted DNS servers";
 pub(super) const TRUSTED_USER_AGENTS: &str = "trusted user agents";
 
-const MAP_NAMES: [&str; 29] = [
+const MAP_NAMES: [&str; 30] = [
     ACCESS_TOKENS,
     ACCOUNTS,
     ACCOUNT_POLICY,
@@ -126,6 +131,7 @@ const MAP_NAMES: [&str; 29] = [
     NODES,
     OUTLIERS,
     QUALIFIERS,
+    REMOTES,
     SAMPLING_POLICY,
     SCORES,
     STATUSES,
@@ -182,6 +188,12 @@ impl StateDb {
     pub(crate) fn agents(&self) -> Table<Agent> {
         let inner = self.inner.as_ref().expect("database must be open");
         Table::<Agent>::open(inner).expect("{AGENTS} table must be present")
+    }
+
+    #[must_use]
+    pub(crate) fn remotes(&self) -> Table<Remote> {
+        let inner = self.inner.as_ref().expect("database must be open");
+        Table::<Remote>::open(inner).expect("{REMOTES} table must be present")
     }
 
     #[must_use]

--- a/src/types.rs
+++ b/src/types.rs
@@ -41,6 +41,7 @@ mod private {
     impl Sealed for tables::Network {}
     impl Sealed for tables::OutlierInfo {}
     impl Sealed for types::Qualifier {}
+    impl Sealed for tables::Remote {}
     impl Sealed for tables::SamplingPolicy {}
     impl Sealed for types::Status {}
     impl Sealed for tables::Template {}

--- a/src/types.rs
+++ b/src/types.rs
@@ -41,7 +41,6 @@ mod private {
     impl Sealed for tables::Network {}
     impl Sealed for tables::OutlierInfo {}
     impl Sealed for types::Qualifier {}
-    impl Sealed for tables::Remote {}
     impl Sealed for tables::SamplingPolicy {}
     impl Sealed for types::Status {}
     impl Sealed for tables::Template {}
@@ -52,6 +51,7 @@ mod private {
     impl Sealed for tables::TriageResponse {}
     impl Sealed for tables::TrustedDomain {}
     impl Sealed for tables::TrustedUserAgent {}
+    impl Sealed for tables::UnlinkedServer {}
 }
 
 pub(crate) type Timestamp = i64;


### PR DESCRIPTION
This PR originates from #401 and consists solely of renaming `Remote`-related items to `UnlinkedServer`-related ones—no other changes were made.

@msk, I made this adjustment based on your feedback regarding the term `Remote`. Although `UnlinkedServer` is a bit longer, it seems to better reflect the intended meaning.

If you’re okay with this naming, could you consider this PR as the replacement for #401?

Close #399