### PR TITLE
Added the missed export for Tidb RuleKind enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub use self::tables::{
     PacketAttr, ProtocolPorts, Response, ResponseKind, SamplingInterval, SamplingKind,
     SamplingPeriod, SamplingPolicy, SamplingPolicyUpdate, Structured,
     StructuredClusteringAlgorithm, Table, Template, Ti, TiCmpKind, Tidb, TidbKind, TidbRule,
-    TorExitNode, TrafficFilter, TriagePolicy, TriagePolicyUpdate, TriageResponse,
+    TidbRuleKind, TorExitNode, TrafficFilter, TriagePolicy, TriagePolicyUpdate, TriageResponse,
     TriageResponseUpdate, TrustedDomain, TrustedUserAgent, UniqueKey, Unstructured,
     UnstructuredClusteringAlgorithm, ValueKind,
 };

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -62,7 +62,7 @@ pub use self::template::{
     Structured, StructuredClusteringAlgorithm, Template, Unstructured,
     UnstructuredClusteringAlgorithm,
 };
-pub use self::tidb::{Kind as TidbKind, Rule as TidbRule, Tidb};
+pub use self::tidb::{Kind as TidbKind, Rule as TidbRule, RuleKind as TidbRuleKind, Tidb};
 pub use self::tor_exit_node::TorExitNode;
 pub use self::traffic_filter::{ProtocolPorts, TrafficFilter};
 pub use self::triage_policy::{


### PR DESCRIPTION

- Fixed to export `Tidb::RuleKind` as `TidbRuleKind`.