### PR TITLE
Skip migration if no column descriptions in postgres

### DIFF
--- a/src/migration/migrate_column_stats.rs
+++ b/src/migration/migrate_column_stats.rs
@@ -8,6 +8,17 @@ use diesel_async::RunQueryDsl;
 use crate::{Database, column_statistics::Statistics};
 
 pub(crate) async fn run(database: &Database, store: &crate::Store) -> Result<()> {
+    use crate::schema::column_description::dsl as cd;
+    let mut conn = database.pool.get().await?;
+
+    // First check if there are any column descriptions to migrate
+    let record_count: i64 = cd::column_description.count().get_result(&mut conn).await?;
+
+    // No column descriptions found in PostgreSQL, skipping migration
+    if record_count == 0 {
+        return Ok(());
+    }
+
     let models = retrieve_model_to_migrate(database).await?;
     tracing::info!(
         "Migrating column statistics for a total of {} models from PostgreSQL to RocksDb",


### PR DESCRIPTION
The migration script `migrate_column_stats` attempts to migrate column statistics from PostgreSQL to RocksDB even when the `column_description` table has no records. This results in unnecessary processing and in my environment, I had to wait about 30 seconds every time I launched REview because it repeatedly executed the following SELECT statement:

```
SELECT "column_description"."id", "column_description"."type_id" FROM "column_description" WHERE ("column_description"."cluster_id" = $1) ORDER BY "column_description"."type_id"`
```

The following is the output from Reviews console (no column statistics records in Postgres):

```
2025-09-09T15:54:36.553730Z  INFO review_database::migration::migrate_column_stats: 27: Migrating column statistics for a total of 1 models from PostgreSQL to RocksDb
2025-09-09T15:55:07.770736Z  INFO review_database::migration::migrate_column_stats: 37: Removing column statistics in PostgresQL
2025-09-09T15:55:07.789294Z  INFO review_database::migration::migrate_column_stats: 39: Column statistics data migration done.
```

This PR modifies the `run()` function to check if any records exist in `column_description` table before proceeding and skip the migration if no records found.